### PR TITLE
[config]: Add file-based YAML Configuration

### DIFF
--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"net"
 	"os"
 	"time"
 
@@ -11,6 +10,7 @@ import (
 	"go.temporal.io/server/common/log"
 	"go.uber.org/fx"
 
+	"github.com/temporalio/temporal-proxy/internal/config"
 	"github.com/temporalio/temporal-proxy/internal/server"
 )
 
@@ -22,14 +22,33 @@ var (
 )
 
 func main() {
+	// nolint:errcheck // TODO: disable this for fmt calls in golangci.yaml
+	cli.VersionPrinter = func(cmd *cli.Command) {
+		fmt.Fprintln(cmd.Writer, cmd.Name, "-", cmd.Usage)
+		fmt.Fprintln(cmd.Writer, "Version:", version)
+		fmt.Fprintln(cmd.Writer, "Built At:", buildTime)
+		fmt.Fprintln(cmd.Writer, "Git SHA:", sha)
+	}
+
 	app := &cli.Command{
 		Name:    "proxy",
 		Usage:   "A universal proxy for Temporal",
 		Version: version,
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:      "config",
+				Aliases:   []string{"c"},
+				Usage:     "Path to the config file",
+				TakesFile: true,
+				Sources:   cli.EnvVars("TEMPORAL_PROXY_CONFIG"),
+				Required:  true,
+			},
+		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			fxApp := fx.New(
 				fx.Supply(
 					fx.Annotate(ctx, fx.As(new(context.Context))),
+					fx.Annotate(cmd.String("config"), fx.ResultTags(`name:"configFile"`)),
 				),
 				fx.Provide(
 					func() log.Logger {
@@ -37,10 +56,8 @@ func main() {
 							// TODO: Make a real config
 						}))
 					},
-					func() (net.Listener, error) {
-						return (&net.ListenConfig{}).Listen(ctx, "tcp", ":0")
-					},
 				),
+				config.Module,
 				server.Module,
 				fx.NopLogger,
 			)
@@ -54,16 +71,9 @@ func main() {
 		},
 	}
 
-	// nolint:errcheck // TODO: disable this for fmt calls in golangci.yaml
-	cli.VersionPrinter = func(cmd *cli.Command) {
-		fmt.Fprintln(cmd.Writer, cmd.Name, "-", cmd.Usage)
-		fmt.Fprintln(cmd.Writer, "Version:", version)
-		fmt.Fprintln(cmd.Writer, "Built At:", buildTime)
-		fmt.Fprintln(cmd.Writer, "Git SHA:", sha)
-	}
-
 	ctx := context.Background()
 	if err := app.Run(ctx, os.Args); err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)
 	}
 }

--- a/dev/proxy.yaml
+++ b/dev/proxy.yaml
@@ -1,0 +1,2 @@
+listen:
+  hostPort: :8443

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,42 @@
+package config
+
+import (
+	"io"
+	"os"
+
+	"github.com/goccy/go-yaml"
+)
+
+// Load reads and parses the YAML config specified in the Reader.
+// Values of the form ${VAR} are replaced with the corresponding environment variable.
+func Load(r io.Reader) (*Config, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+
+	expanded := os.Expand(string(data), os.Getenv)
+
+	var cfg Config
+	if err := yaml.Unmarshal([]byte(expanded), &cfg); err != nil {
+		return nil, err
+	}
+
+	if err := cfg.validate(); err != nil {
+		return nil, err
+	}
+
+	return &cfg, nil
+}
+
+// LoadFile reads and parses the YAML config file at path.
+// Values of the form ${VAR} are replaced with the corresponding environment variable.
+func LoadFile(path string) (*Config, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	return Load(f)
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,71 @@
+package config_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/temporalio/temporal-proxy/internal/config"
+)
+
+func TestLoad(t *testing.T) {
+	t.Parallel()
+
+	t.Run("invalid YAML returns error", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := config.Load(strings.NewReader(":::"))
+		require.Error(t, err)
+	})
+
+	t.Run("missing required field returns error", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := config.Load(strings.NewReader("{}"))
+		require.ErrorContains(t, err, "listen.hostPort is required")
+	})
+
+	t.Run("minimal config", func(t *testing.T) {
+		t.Parallel()
+
+		yaml := `
+listen:
+  hostPort: "localhost:7233"
+`
+		cfg, err := config.Load(strings.NewReader(yaml))
+		require.NoError(t, err)
+		require.Equal(t, &config.Config{
+			Listen: config.ListenConfig{
+				HostPort: "localhost:7233",
+			},
+		}, cfg)
+	})
+
+	t.Run("fully configured", func(t *testing.T) {
+		t.Parallel()
+
+		yaml := `
+listen:
+  hostPort: "localhost:7233"
+  tls:
+    cert: "/path/to/cert.pem"
+    key: "/path/to/key.pem"
+    ca: "/path/to/ca.pem"
+    serverName: "temporal.example.com"
+`
+		cfg, err := config.Load(strings.NewReader(yaml))
+		require.NoError(t, err)
+		require.Equal(t, &config.Config{
+			Listen: config.ListenConfig{
+				HostPort: "localhost:7233",
+				TLS: &config.TLS{
+					Cert:       "/path/to/cert.pem",
+					Key:        "/path/to/key.pem",
+					CA:         "/path/to/ca.pem",
+					ServerName: "temporal.example.com",
+				},
+			},
+		}, cfg)
+	})
+}

--- a/internal/config/fx.go
+++ b/internal/config/fx.go
@@ -1,0 +1,12 @@
+package config
+
+import "go.uber.org/fx"
+
+var Module = fx.Option(fx.Provide(func(p ConfigParams) (*Config, error) {
+	return LoadFile(p.File)
+}))
+
+type ConfigParams struct {
+	fx.In
+	File string `name:"configFile"`
+}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -1,0 +1,31 @@
+package config
+
+import (
+	"fmt"
+)
+
+type (
+	Config struct {
+		Listen ListenConfig `yaml:"listen"`
+	}
+
+	ListenConfig struct {
+		HostPort string `yaml:"hostPort"`
+		TLS      *TLS   `yaml:"tls"`
+	}
+
+	TLS struct {
+		Cert       string `yaml:"cert"`
+		Key        string `yaml:"key"`
+		CA         string `yaml:"ca"`
+		ServerName string `yaml:"serverName"`
+	}
+)
+
+func (c *Config) validate() error {
+	if c.Listen.HostPort == "" {
+		return fmt.Errorf("listen.hostPort is required")
+	}
+
+	return nil
+}

--- a/internal/server/credentials_test.go
+++ b/internal/server/credentials_test.go
@@ -15,13 +15,13 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	. "github.com/temporalio/temporal-proxy/internal/server"
+	"github.com/temporalio/temporal-proxy/internal/server"
 )
 
 func TestInsecureCredentialsServer(t *testing.T) {
 	t.Parallel()
 
-	opt, err := NewInsecureCredentials().Server()
+	opt, err := server.NewInsecureCredentials().Server()
 	require.NoError(t, err)
 	require.NotNil(t, opt)
 }
@@ -66,7 +66,7 @@ func TestTLSCredentialsServer(t *testing.T) {
 				t.Parallel()
 
 				certFile, keyFile := tc.setup(t)
-				opt, err := NewTLSCredentials(certFile, keyFile).Server()
+				opt, err := server.NewTLSCredentials(certFile, keyFile).Server()
 				require.Error(t, err)
 				require.Nil(t, opt)
 				require.ErrorContains(t, err, tc.errContains)
@@ -83,7 +83,7 @@ func TestTLSCredentialsServer(t *testing.T) {
 		certFile := writeFile(t, dir, "server-cert.pem", certPEM)
 		keyFile := writeFile(t, dir, "server-key.pem", keyPEM)
 
-		opt, err := NewTLSCredentials(certFile, keyFile).Server()
+		opt, err := server.NewTLSCredentials(certFile, keyFile).Server()
 		require.NoError(t, err)
 		require.NotNil(t, opt)
 	})
@@ -141,7 +141,7 @@ func TestMTLSCredentialsServer(t *testing.T) {
 
 				caFile, certFile, keyFile := tc.setup(t)
 
-				opt, err := NewMTLSCredentials(caFile, certFile, keyFile).Server()
+				opt, err := server.NewMTLSCredentials(caFile, certFile, keyFile).Server()
 				require.Error(t, err)
 				require.Nil(t, opt)
 				require.ErrorContains(t, err, tc.errContains)
@@ -158,7 +158,7 @@ func TestMTLSCredentialsServer(t *testing.T) {
 		certFile := writeFile(t, dir, "cert.pem", certPEM)
 		keyFile := writeFile(t, dir, "key.pem", keyPEM)
 
-		opt, err := NewMTLSCredentials(caFile, certFile, keyFile).Server()
+		opt, err := server.NewMTLSCredentials(caFile, certFile, keyFile).Server()
 		require.NoError(t, err)
 		require.NotNil(t, opt)
 	})

--- a/internal/server/fx.go
+++ b/internal/server/fx.go
@@ -2,10 +2,13 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"net"
 
 	"go.temporal.io/server/common/log"
 	"go.uber.org/fx"
+
+	"github.com/temporalio/temporal-proxy/internal/config"
 )
 
 var Module = fx.Option(fx.Invoke(func(p ServerParams) error {
@@ -29,7 +32,21 @@ var Module = fx.Option(fx.Invoke(func(p ServerParams) error {
 
 	p.Lifecycle.Append(fx.Hook{
 		OnStart: func(context.Context) error {
-			go svr.Start(p.Context, p.Listener) // nolint:errcheck
+			lis, err := (&net.ListenConfig{}).Listen(
+				p.Context,
+				"tcp",
+				p.Config.Listen.HostPort,
+			)
+			if err != nil {
+				return fmt.Errorf("failed to create listener: %w", err)
+			}
+
+			go func() {
+				defer func() { _ = lis.Close() }()
+
+				svr.Start(p.Context, lis) // nolint:errcheck
+			}()
+
 			return nil
 		},
 		OnStop: func(ctx context.Context) error {
@@ -45,8 +62,8 @@ type ServerParams struct {
 	Lifecycle fx.Lifecycle
 
 	// Required values
-	Context  context.Context
-	Listener net.Listener
+	Context context.Context
+	Config  *config.Config
 
 	// Optional values
 	Credentials Credentials `optional:"true"`

--- a/internal/server/health_test.go
+++ b/internal/server/health_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/health/grpc_health_v1"
 
-	. "github.com/temporalio/temporal-proxy/internal/server"
+	"github.com/temporalio/temporal-proxy/internal/server"
 )
 
 func TestHealthCheckFunc(t *testing.T) {
@@ -17,7 +17,7 @@ func TestHealthCheckFunc(t *testing.T) {
 	t.Run("returns the configured interval", func(t *testing.T) {
 		t.Parallel()
 
-		hc := HealthCheckFunc(5*time.Second, func(context.Context) grpc_health_v1.HealthCheckResponse_ServingStatus {
+		hc := server.HealthCheckFunc(5*time.Second, func(context.Context) grpc_health_v1.HealthCheckResponse_ServingStatus {
 			return grpc_health_v1.HealthCheckResponse_SERVING
 		})
 
@@ -31,7 +31,7 @@ func TestHealthCheckFunc(t *testing.T) {
 
 		var called bool
 		ctx := context.WithValue(context.Background(), contextKey("probe"), "value")
-		hc := HealthCheckFunc(250*time.Millisecond, func(got context.Context) grpc_health_v1.HealthCheckResponse_ServingStatus {
+		hc := server.HealthCheckFunc(250*time.Millisecond, func(got context.Context) grpc_health_v1.HealthCheckResponse_ServingStatus {
 			called = true
 			require.Equal(t, "value", got.Value(contextKey("probe")))
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -14,7 +14,7 @@ import (
 	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/test/bufconn"
 
-	. "github.com/temporalio/temporal-proxy/internal/server"
+	"github.com/temporalio/temporal-proxy/internal/server"
 )
 
 type failingCredentials struct {
@@ -27,7 +27,7 @@ func TestNew(t *testing.T) {
 	t.Run("returns a server with default options", func(t *testing.T) {
 		t.Parallel()
 
-		svr, err := New()
+		svr, err := server.New()
 		require.NoError(t, err)
 		require.NotNil(t, svr)
 	})
@@ -35,7 +35,7 @@ func TestNew(t *testing.T) {
 	t.Run("propagates credential errors", func(t *testing.T) {
 		t.Parallel()
 
-		svr, err := New(WithCredentials(failingCredentials{err: errors.New("boom")}))
+		svr, err := server.New(server.WithCredentials(failingCredentials{err: errors.New("boom")}))
 		require.Error(t, err)
 		require.Nil(t, svr)
 		require.ErrorContains(t, err, "boom")
@@ -46,12 +46,12 @@ func TestServerStartAndStop(t *testing.T) {
 	t.Parallel()
 
 	var statusCalls atomic.Int32
-	hc := HealthCheckFunc(10*time.Millisecond, func(context.Context) grpc_health_v1.HealthCheckResponse_ServingStatus {
+	hc := server.HealthCheckFunc(10*time.Millisecond, func(context.Context) grpc_health_v1.HealthCheckResponse_ServingStatus {
 		statusCalls.Add(1)
 		return grpc_health_v1.HealthCheckResponse_NOT_SERVING
 	})
 
-	svr, err := New(WithHealthCheck(hc))
+	svr, err := server.New(server.WithHealthCheck(hc))
 	require.NoError(t, err)
 
 	lis := bufconn.Listen(1024 * 1024)

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -23,6 +23,10 @@ tasks:
       - cmd: go mod tidy -modfile={{.TOOLS_FILE}}
         ignore_error: true
 
+  server:
+    desc: Run the server locally
+    cmd: go run ./cmd/proxy -c dev/proxy.yaml
+
   build:
     desc: Build binary
     cmd: go build ./cmd/proxy


### PR DESCRIPTION
Introduces an internal/config package that loads and validates YAML config files with environment variable expansion. The CLI now requires a --config/-c flag (or TEMPORAL_PROXY_CONFIG env var) pointing to the config file. The server reads its listen address from config rather than accepting a pre-built net.Listener.