### PR TITLE
[config/server]: Add multi-cluster configuration and lifecycle

### DIFF
--- a/dev/proxy.yaml
+++ b/dev/proxy.yaml
@@ -1,2 +1,7 @@
-listen:
-  hostPort: :8443
+clusters:
+  - local:
+      inbound:
+        hostPort: :8443
+  - local:
+      inbound:
+        hostPort: :9443

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -23,21 +23,27 @@ func TestLoad(t *testing.T) {
 		t.Parallel()
 
 		_, err := config.Load(strings.NewReader("{}"))
-		require.ErrorContains(t, err, "listen.hostPort is required")
+		require.ErrorContains(t, err, "must define at least one cluster")
 	})
 
 	t.Run("minimal config", func(t *testing.T) {
 		t.Parallel()
 
 		yaml := `
-listen:
-  hostPort: "localhost:7233"
+clusters:
+  - local:
+      inbound:
+        hostPort: :8233
 `
 		cfg, err := config.Load(strings.NewReader(yaml))
 		require.NoError(t, err)
 		require.Equal(t, &config.Config{
-			Listen: config.ListenConfig{
-				HostPort: "localhost:7233",
+			Clusters: []config.Cluster{
+				{
+					Local: config.LocalCluster{
+						Inbound: config.ListenConfig{HostPort: ":8233"},
+					},
+				},
 			},
 		}, cfg)
 	})
@@ -46,24 +52,59 @@ listen:
 		t.Parallel()
 
 		yaml := `
-listen:
-  hostPort: "localhost:7233"
-  tls:
-    cert: "/path/to/cert.pem"
-    key: "/path/to/key.pem"
-    ca: "/path/to/ca.pem"
-    serverName: "temporal.example.com"
+clusters:
+  - local:
+      inbound:
+        hostPort: :8233
+        tls:
+          cert: "/path/to/cert.pem"
+          key: "/path/to/key.pem"
+          ca: "/path/to/ca.pem"
+          serverName: "temporal.example.com"
+      outbound:
+        hostPort: :9233
+    remote:
+      name: temporal-cloud
+      type: outbound
+      poolSize: 5
+      hostPort: :10233
+      tls:
+        cert: "/path/to/cert.pem"
+        key: "/path/to/key.pem"
+        ca: "/path/to/ca.pem"
+        serverName: "temporal.example.com"
 `
 		cfg, err := config.Load(strings.NewReader(yaml))
 		require.NoError(t, err)
 		require.Equal(t, &config.Config{
-			Listen: config.ListenConfig{
-				HostPort: "localhost:7233",
-				TLS: &config.TLS{
-					Cert:       "/path/to/cert.pem",
-					Key:        "/path/to/key.pem",
-					CA:         "/path/to/ca.pem",
-					ServerName: "temporal.example.com",
+			Clusters: []config.Cluster{
+				{
+					Local: config.LocalCluster{
+						Inbound: config.ListenConfig{
+							HostPort: ":8233",
+							TLS: &config.TLS{
+								Cert:       "/path/to/cert.pem",
+								Key:        "/path/to/key.pem",
+								CA:         "/path/to/ca.pem",
+								ServerName: "temporal.example.com",
+							},
+						},
+						Outbound: config.ListenConfig{HostPort: ":9233"},
+					},
+					Remote: config.RemoteCluster{
+						Name:     "temporal-cloud",
+						Type:     config.Outbound,
+						PoolSize: 5,
+						Listener: config.ListenConfig{
+							HostPort: ":10233",
+							TLS: &config.TLS{
+								Cert:       "/path/to/cert.pem",
+								Key:        "/path/to/key.pem",
+								CA:         "/path/to/ca.pem",
+								ServerName: "temporal.example.com",
+							},
+						},
+					},
 				},
 			},
 		}, cfg)

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -4,27 +4,63 @@ import (
 	"fmt"
 )
 
+const (
+	// Inbound means the remote sends RPCs to this proxy.
+	Inbound RemoteType = "inbound"
+
+	// Outbound means the remote receives RPCs from this proxy.
+	Outbound RemoteType = "outbound"
+)
+
 type (
 	Config struct {
-		Listen ListenConfig `yaml:"listen"`
+		Clusters []Cluster `yaml:"clusters"`
 	}
 
+	// Cluster defines a cluster involved with this proxy.
+	Cluster struct {
+		Local  LocalCluster  `yaml:"local"`
+		Remote RemoteCluster `yaml:"remote"`
+	}
+
+	// LocalCluster defines connection details for ingress and proxying on this proxy instance.
+	//
+	// RPCs received on the outbound listener, are forwarded to the remote.
+	LocalCluster struct {
+		Inbound  ListenConfig `yaml:"inbound"`
+		Outbound ListenConfig `yaml:"outbound"` // NB: Temporal client/K8s service should point here.
+	}
+
+	// RemoteCluster defines a cluster that this proxy either sends RPCs to (outbound) or receives RPCs from (inbound).
+	RemoteCluster struct {
+		Name     string       `yaml:"name"`
+		Type     RemoteType   `yaml:"type"`
+		PoolSize int          `yaml:"poolSize"`
+		Listener ListenConfig `yaml:",inline"`
+	}
+
+	// RemoteType defines the type of remote (inbound or outbound).
+	RemoteType string
+
+	// ListenConfig defines properties for a listener.
 	ListenConfig struct {
 		HostPort string `yaml:"hostPort"`
 		TLS      *TLS   `yaml:"tls"`
 	}
 
+	// TLS defines details about TLS connections.
 	TLS struct {
-		Cert       string `yaml:"cert"`
-		Key        string `yaml:"key"`
-		CA         string `yaml:"ca"`
-		ServerName string `yaml:"serverName"`
+		Cert               string `yaml:"cert"`
+		Key                string `yaml:"key"`
+		CA                 string `yaml:"ca"`
+		ServerName         string `yaml:"serverName"`
+		InsecureSkipVerify bool   `yaml:"skipVerify"`
 	}
 )
 
 func (c *Config) validate() error {
-	if c.Listen.HostPort == "" {
-		return fmt.Errorf("listen.hostPort is required")
+	if len(c.Clusters) == 0 {
+		return fmt.Errorf("must define at least one cluster")
 	}
 
 	return nil

--- a/internal/server/fx.go
+++ b/internal/server/fx.go
@@ -25,34 +25,38 @@ var Module = fx.Option(fx.Invoke(func(p ServerParams) error {
 		opts = append(opts, WithHealthCheck(p.HealthCheck))
 	}
 
-	svr, err := New(opts...)
-	if err != nil {
-		return err
+	var err error
+	svrs := make([]*Server, len(p.Config.Clusters))
+	for i, cluster := range p.Config.Clusters {
+		svrs[i], err = New(opts...)
+		if err != nil {
+			return err
+		}
+
+		p.Lifecycle.Append(fx.Hook{
+			OnStart: func(context.Context) error {
+				lis, err := (&net.ListenConfig{}).Listen(
+					p.Context,
+					"tcp",
+					cluster.Local.Inbound.HostPort,
+				)
+				if err != nil {
+					return fmt.Errorf("failed to create listener: %w", err)
+				}
+
+				go func() {
+					defer func() { _ = lis.Close() }()
+
+					svrs[i].Start(p.Context, lis) // nolint:errcheck
+				}()
+
+				return nil
+			},
+			OnStop: func(ctx context.Context) error {
+				return svrs[i].Stop(ctx)
+			},
+		})
 	}
-
-	p.Lifecycle.Append(fx.Hook{
-		OnStart: func(context.Context) error {
-			lis, err := (&net.ListenConfig{}).Listen(
-				p.Context,
-				"tcp",
-				p.Config.Listen.HostPort,
-			)
-			if err != nil {
-				return fmt.Errorf("failed to create listener: %w", err)
-			}
-
-			go func() {
-				defer func() { _ = lis.Close() }()
-
-				svr.Start(p.Context, lis) // nolint:errcheck
-			}()
-
-			return nil
-		},
-		OnStop: func(ctx context.Context) error {
-			return svr.Stop(ctx)
-		},
-	})
 
 	return nil
 }))

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -58,7 +58,8 @@ func New(sopts ...Option) (*Server, error) {
 }
 
 func (s *Server) Start(ctx context.Context, lis net.Listener) error {
-	s.logger.Info("Starting the server", tag.NewStringerTag("addr", lis.Addr()))
+	s.logger = log.With(s.logger, tag.NewStringerTag("addr", lis.Addr()))
+	s.logger.Info("Starting the server")
 
 	ctx, s.cancelFunc = context.WithCancel(ctx)
 	go s.runHealthCheck(ctx)


### PR DESCRIPTION
The proxy needs to serve multiple clusters from a single process. This changes the configuration schema from a single flat `listen` block to a `clusters` list, where each entry describes a local inbound/outbound listener pair and an optional remote peer.

The server fx module is updated to iterate the cluster list and register one gRPC server lifecycle hook per cluster, so each cluster's inbound listener is started and stopped independently.