### PR TITLE
[config]: Add Temporal cluster type and restructure config types

### DIFF
--- a/dev/proxy.yaml
+++ b/dev/proxy.yaml
@@ -1,7 +1,7 @@
 clusters:
-  - local:
-      inbound:
-        hostPort: :8443
-  - local:
-      inbound:
-        hostPort: :9443
+  - name: temporal-cloud
+    type: temporal
+    listener:
+      hostPort: :8443
+    upstream:
+      hostPort: your-tc-endpoint

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -9,6 +9,120 @@ import (
 	"github.com/temporalio/temporal-proxy/internal/config"
 )
 
+func TestLoad_ClusterTypeValidation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing cluster type returns error", func(t *testing.T) {
+		t.Parallel()
+
+		yaml := `
+clusters:
+  - listener:
+      hostPort: :8233
+`
+		_, err := config.Load(strings.NewReader(yaml))
+		require.ErrorContains(t, err, "type is required")
+	})
+
+	t.Run("unknown cluster type returns error", func(t *testing.T) {
+		t.Parallel()
+
+		yaml := `
+clusters:
+  - type: bogus
+    listener:
+      hostPort: :8233
+    upstream:
+      hostPort: :9233
+`
+		_, err := config.Load(strings.NewReader(yaml))
+		require.ErrorContains(t, err, "unknown cluster type")
+	})
+
+	t.Run("outbound requires upstream hostPort", func(t *testing.T) {
+		t.Parallel()
+
+		yaml := `
+clusters:
+  - type: outbound
+    listener:
+      hostPort: :7233
+`
+		_, err := config.Load(strings.NewReader(yaml))
+		require.ErrorContains(t, err, "upstream.hostPort required")
+	})
+
+	t.Run("outbound requires listener hostPort", func(t *testing.T) {
+		t.Parallel()
+
+		yaml := `
+clusters:
+  - type: outbound
+    listener: {}
+    upstream:
+      hostPort: :9233
+`
+		_, err := config.Load(strings.NewReader(yaml))
+		require.ErrorContains(t, err, "listener.hostPort required")
+	})
+
+	t.Run("inbound requires listener hostPort", func(t *testing.T) {
+		t.Parallel()
+
+		yaml := `
+clusters:
+  - type: inbound
+    listener: {}
+`
+		_, err := config.Load(strings.NewReader(yaml))
+		require.ErrorContains(t, err, "listener.hostPort required")
+	})
+
+	t.Run("temporal requires listener hostPort", func(t *testing.T) {
+		t.Parallel()
+
+		yaml := `
+clusters:
+  - type: temporal
+    listener: {}
+    upstream:
+      hostPort: my-ns.tmprl.cloud:7233
+`
+		_, err := config.Load(strings.NewReader(yaml))
+		require.ErrorContains(t, err, "listener.hostPort required")
+	})
+
+	t.Run("temporal requires listener and upstream hostPort", func(t *testing.T) {
+		t.Parallel()
+
+		yaml := `
+clusters:
+  - type: temporal
+    listener:
+      hostPort: :8233
+`
+		_, err := config.Load(strings.NewReader(yaml))
+		require.ErrorContains(t, err, "upstream.hostPort required")
+	})
+
+	t.Run("valid temporal config", func(t *testing.T) {
+		t.Parallel()
+
+		yaml := `
+clusters:
+  - name: temporal-cloud
+    type: temporal
+    listener:
+      hostPort: :8233
+    upstream:
+      hostPort: my-ns.tmprl.cloud:7233
+`
+		cfg, err := config.Load(strings.NewReader(yaml))
+		require.NoError(t, err)
+		require.Equal(t, config.Temporal, cfg.Clusters[0].Type)
+	})
+}
+
 func TestLoad(t *testing.T) {
 	t.Parallel()
 
@@ -31,18 +145,17 @@ func TestLoad(t *testing.T) {
 
 		yaml := `
 clusters:
-  - local:
-      inbound:
-        hostPort: :8233
+  - type: inbound
+    listener:
+      hostPort: :8233
 `
 		cfg, err := config.Load(strings.NewReader(yaml))
 		require.NoError(t, err)
 		require.Equal(t, &config.Config{
 			Clusters: []config.Cluster{
 				{
-					Local: config.LocalCluster{
-						Inbound: config.ListenConfig{HostPort: ":8233"},
-					},
+					Type:     config.Inbound,
+					Listener: config.ListenConfig{HostPort: ":8233"},
 				},
 			},
 		}, cfg)
@@ -53,19 +166,16 @@ clusters:
 
 		yaml := `
 clusters:
-  - local:
-      inbound:
-        hostPort: :8233
-        tls:
-          cert: "/path/to/cert.pem"
-          key: "/path/to/key.pem"
-          ca: "/path/to/ca.pem"
-          serverName: "temporal.example.com"
-      outbound:
-        hostPort: :9233
-    remote:
-      name: temporal-cloud
-      type: outbound
+  - name: temporal-cloud
+    type: temporal
+    listener:
+      hostPort: :8233
+      tls:
+        cert: "/path/to/cert.pem"
+        key: "/path/to/key.pem"
+        ca: "/path/to/ca.pem"
+        serverName: "temporal.example.com"
+    upstream:
       poolSize: 5
       hostPort: :10233
       tls:
@@ -79,21 +189,18 @@ clusters:
 		require.Equal(t, &config.Config{
 			Clusters: []config.Cluster{
 				{
-					Local: config.LocalCluster{
-						Inbound: config.ListenConfig{
-							HostPort: ":8233",
-							TLS: &config.TLS{
-								Cert:       "/path/to/cert.pem",
-								Key:        "/path/to/key.pem",
-								CA:         "/path/to/ca.pem",
-								ServerName: "temporal.example.com",
-							},
+					Name: "temporal-cloud",
+					Type: config.Temporal,
+					Listener: config.ListenConfig{
+						HostPort: ":8233",
+						TLS: &config.TLS{
+							Cert:       "/path/to/cert.pem",
+							Key:        "/path/to/key.pem",
+							CA:         "/path/to/ca.pem",
+							ServerName: "temporal.example.com",
 						},
-						Outbound: config.ListenConfig{HostPort: ":9233"},
 					},
-					Remote: config.RemoteCluster{
-						Name:     "temporal-cloud",
-						Type:     config.Outbound,
+					Upstream: config.Upstream{
 						PoolSize: 5,
 						Listener: config.ListenConfig{
 							HostPort: ":10233",

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -6,10 +6,13 @@ import (
 
 const (
 	// Inbound means the remote sends RPCs to this proxy.
-	Inbound RemoteType = "inbound"
+	Inbound ClusterType = "inbound"
 
 	// Outbound means the remote receives RPCs from this proxy.
-	Outbound RemoteType = "outbound"
+	Outbound ClusterType = "outbound"
+
+	// Temporal means the remote is a real Temporal server reached via plain gRPC.
+	Temporal ClusterType = "temporal"
 )
 
 type (
@@ -19,28 +22,14 @@ type (
 
 	// Cluster defines a cluster involved with this proxy.
 	Cluster struct {
-		Local  LocalCluster  `yaml:"local"`
-		Remote RemoteCluster `yaml:"remote"`
-	}
-
-	// LocalCluster defines connection details for ingress and proxying on this proxy instance.
-	//
-	// RPCs received on the outbound listener, are forwarded to the remote.
-	LocalCluster struct {
-		Inbound  ListenConfig `yaml:"inbound"`
-		Outbound ListenConfig `yaml:"outbound"` // NB: Temporal client/K8s service should point here.
-	}
-
-	// RemoteCluster defines a cluster that this proxy either sends RPCs to (outbound) or receives RPCs from (inbound).
-	RemoteCluster struct {
 		Name     string       `yaml:"name"`
-		Type     RemoteType   `yaml:"type"`
-		PoolSize int          `yaml:"poolSize"`
-		Listener ListenConfig `yaml:",inline"`
+		Type     ClusterType  `yaml:"type"`
+		Listener ListenConfig `yaml:"listener"`
+		Upstream Upstream     `yaml:"upstream"`
 	}
 
-	// RemoteType defines the type of remote (inbound or outbound).
-	RemoteType string
+	// ClusterType defines the relationship between the local and remote sides of a cluster.
+	ClusterType string
 
 	// ListenConfig defines properties for a listener.
 	ListenConfig struct {
@@ -56,11 +45,52 @@ type (
 		ServerName         string `yaml:"serverName"`
 		InsecureSkipVerify bool   `yaml:"skipVerify"`
 	}
+
+	// Upstream defines connection details for the cluster this proxy communicates with.
+	Upstream struct {
+		PoolSize int          `yaml:"poolSize"`
+		Listener ListenConfig `yaml:",inline"`
+	}
 )
 
 func (c *Config) validate() error {
 	if len(c.Clusters) == 0 {
 		return fmt.Errorf("must define at least one cluster")
+	}
+
+	for i, cluster := range c.Clusters {
+		if err := cluster.validate(i); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *Cluster) validate(idx int) error {
+	switch c.Type {
+	case Inbound:
+		if c.Listener.HostPort == "" {
+			return fmt.Errorf("cluster[%d]: listener.hostPort required for cluster type %q", idx, c.Type)
+		}
+	case Outbound:
+		if c.Listener.HostPort == "" {
+			return fmt.Errorf("cluster[%d]: listener.hostPort required for cluster type %q", idx, c.Type)
+		}
+		if c.Upstream.Listener.HostPort == "" {
+			return fmt.Errorf("cluster[%d]: upstream.hostPort required for cluster type %q", idx, c.Type)
+		}
+	case Temporal:
+		if c.Listener.HostPort == "" {
+			return fmt.Errorf("cluster[%d]: listener.hostPort required for cluster type %q", idx, c.Type)
+		}
+		if c.Upstream.Listener.HostPort == "" {
+			return fmt.Errorf("cluster[%d]: upstream.hostPort required for cluster type %q", idx, c.Type)
+		}
+	case "":
+		return fmt.Errorf("cluster[%d]: type is required", idx)
+	default:
+		return fmt.Errorf("cluster[%d]: unknown cluster type %q", idx, c.Type)
 	}
 
 	return nil

--- a/internal/server/fx.go
+++ b/internal/server/fx.go
@@ -38,7 +38,7 @@ var Module = fx.Option(fx.Invoke(func(p ServerParams) error {
 				lis, err := (&net.ListenConfig{}).Listen(
 					p.Context,
 					"tcp",
-					cluster.Local.Inbound.HostPort,
+					cluster.Listener.HostPort,
 				)
 				if err != nil {
 					return fmt.Errorf("failed to create listener: %w", err)


### PR DESCRIPTION
- Add Temporal cluster type for proxying to a real Temporal server via plain gRPC
- Replace LocalCluster (Inbound/Outbound) with a flat Listener field — ClusterType
  already determines the connection role, so a single listen address suffices
- Replace RemoteCluster with Upstream (address + pool size); promote Name and Type
  to top-level Cluster fields
- Rename RemoteType → ClusterType
- Require cluster Type in validation; omitting it is now an error