### PR TITLE
[crypto]: Add Sealer to handle envelope encryption

### DIFF
--- a/internal/crypto/doc.go
+++ b/internal/crypto/doc.go
@@ -1,12 +1,14 @@
 // Package crypto implements envelope encryption for Temporal payload data.
 //
+// Callers should use [Sealer], which manages per-namespace DEK rotation and
+// provides [Sealer.Seal] / [Sealer.Open] for encrypting and decrypting payloads.
+//
 // Envelope encryption uses two layers of keys:
 //
 //   - A [DEK] (Data Encryption Key) encrypts the actual payload using AES-256-GCM.
 //   - A [KEK] (Key Encryption Key) encrypts the DEK. KEKs are customer-managed and
 //     are typically backed by an external KMS such as AWS KMS or GCP Cloud KMS.
 //
-// A [KEKRegistry] maps Temporal namespaces to their KEKs. To encrypt a DEK, call
-// [KEKRegistry.Encrypt] with the target namespace; to recover a DEK, call
-// [KEKRegistry.Decrypt] with the [DEKMaterial] returned from a prior encrypt call.
+// A [KEKRegistry] maps namespaces to their KEKs and is used internally by
+// [Sealer] to wrap and unwrap DEKs during seal and open operations.
 package crypto

--- a/internal/crypto/fx.go
+++ b/internal/crypto/fx.go
@@ -15,16 +15,36 @@ var Module = fx.Options(fx.Provide(
 
 		return NewKEKRegistry(opts...)
 	},
+	func(p SealerParams) (*Sealer, error) {
+		opts := make([]SealerOption, 0, len(p.KeyConfigs))
+		for k, v := range p.KeyConfigs {
+			opts = append(opts, WithKeyConfig(k, v))
+		}
+
+		return NewSealer(p.Registry, opts...)
+	},
 ))
 
-// KEKRegistryParams holds the fx-injected parameters for constructing a KEKRegistry.
-type KEKRegistryParams struct {
-	fx.In
+type (
+	// KEKRegistryParams holds the fx-injected parameters for constructing a KEKRegistry.
+	KEKRegistryParams struct {
+		fx.In
 
-	// Default key to use when namespace override doesn't exist.
-	// When nil, a blank KEK is used (no encryption occurs).
-	DefaultKey KEK `optional:"true"`
+		// Default key to use when namespace override doesn't exist.
+		// When nil, a blank KEK is used (no encryption occurs).
+		DefaultKey KEK `optional:"true"`
 
-	// A map of namespace to KEK.
-	NamespaceKeys map[string]KEK
-}
+		// A map of namespace to KEK.
+		NamespaceKeys map[string]KEK
+	}
+
+	// SealerParams holds the fx-injected parameters for constructing a [Sealer].
+	SealerParams struct {
+		fx.In
+
+		// KeyConfigs maps each namespace ID to its [KeyConfig] rotation policy.
+		KeyConfigs map[string]KeyConfig
+		// Registry is the [KEKRegistry] used to encrypt and decrypt DEKs.
+		Registry *KEKRegistry
+	}
+)

--- a/internal/crypto/sealer.go
+++ b/internal/crypto/sealer.go
@@ -1,0 +1,235 @@
+package crypto
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+)
+
+type (
+	// Sealer manages per-ID DEK rotation and envelope encryption.
+	//
+	// Each ID (typically a Temporal namespace) has its own [DEK] with an
+	// independent rotation schedule defined by a [KeyConfig]. DEKs are
+	// pre-rotated by a background [Sealer.Refresh] call before their
+	// expiration buffer is reached, keeping key generation off the hot path.
+	//
+	// Use [Sealer.Seal] to encrypt data and [Sealer.Open] to decrypt it.
+	Sealer struct {
+		mu       sync.RWMutex
+		keys     map[string]*sealerDEK
+		registry *KEKRegistry
+		now      func() time.Time
+	}
+
+	sealerOptions struct {
+		config map[string]*KeyConfig
+		now    func() time.Time
+	}
+
+	// SealerOption configures a [Sealer] during construction.
+	SealerOption func(*sealerOptions)
+
+	// Envelope is the output of a [Sealer.Seal] call. It carries the
+	// AES-256-GCM ciphertext together with the [DEKMaterial] required to
+	// recover the DEK for decryption via [Sealer.Open].
+	Envelope struct {
+		CipherText  []byte
+		KeyMaterial *DEKMaterial
+	}
+
+	// KeyConfig defines the config (e.g. rotation policy) for a single key slot.
+	KeyConfig struct {
+		Lifetime         time.Duration // How long a DEK remains valid
+		ExpirationBuffer time.Duration // How far before expiry [Sealer.Refresh] should pre-rotate the key.
+	}
+
+	sealerDEK struct {
+		key    *DEK             // The current DEK
+		exp    time.Time        // When this key expires
+		incr   time.Duration    // How long each DEK is valid for
+		expBuf time.Duration    // How long before expiry should we regenerate
+		now    func() time.Time // Clock source, shared with the parent Sealer
+	}
+)
+
+// NewSealer constructs a Sealer backed by r, applying opts in order.
+// It generates an initial [DEK] for every ID registered via [WithKeyConfig].
+// Returns an error if any DEK generation fails.
+func NewSealer(r *KEKRegistry, opts ...SealerOption) (*Sealer, error) {
+	sopts := &sealerOptions{
+		config: make(map[string]*KeyConfig),
+		now:    time.Now,
+	}
+
+	for _, opt := range opts {
+		opt(sopts)
+	}
+
+	s := &Sealer{
+		keys:     make(map[string]*sealerDEK),
+		registry: r,
+		now:      sopts.now,
+	}
+
+	for k, v := range sopts.config {
+		key, err := NewDEK()
+		if err != nil {
+			return nil, err
+		}
+
+		s.keys[k] = &sealerDEK{
+			incr:   v.Lifetime,
+			expBuf: v.ExpirationBuffer,
+			now:    s.now,
+		}
+
+		// NB: No locks needed in constructor
+		s.keys[k].rotate(key)
+	}
+
+	return s, nil
+}
+
+// WithKeyConfig registers a [KeyConfig] rotation policy for id.
+func WithKeyConfig(id string, cfg KeyConfig) SealerOption {
+	return func(s *sealerOptions) {
+		if _, ok := s.config[id]; ok {
+			panic(fmt.Sprintf("Duplicate key config for '%s'", id))
+		}
+
+		s.config[id] = &cfg
+	}
+}
+
+// WithNowFunc overrides the clock used for DEK expiry checks and rotation
+// timestamps. Intended for testing; production code should use the default
+// [time.Now].
+func WithNowFunc(fn func() time.Time) SealerOption {
+	return func(s *sealerOptions) {
+		s.now = fn
+	}
+}
+
+// Seal encrypts data using the DEK for id, returning an [Envelope] that
+// contains the ciphertext and the [DEKMaterial] needed to decrypt it later.
+func (s *Sealer) Seal(ctx context.Context, id string, data []byte) (*Envelope, error) {
+	dek, err := s.getOrRefreshKey(id)
+	if err != nil {
+		return nil, err
+	}
+
+	ct, err := dek.Encrypt(ctx, data)
+	if err != nil {
+		return nil, err
+	}
+
+	m, err := s.registry.Encrypt(ctx, id, dek)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Envelope{
+		CipherText:  ct,
+		KeyMaterial: m,
+	}, nil
+}
+
+// Open decrypts e by recovering the DEK from the registry and returning the
+// original plaintext.
+func (s *Sealer) Open(ctx context.Context, e *Envelope) ([]byte, error) {
+	dek, err := s.registry.Decrypt(ctx, e.KeyMaterial)
+	if err != nil {
+		return nil, err
+	}
+
+	pt, err := dek.Decrypt(ctx, e.CipherText)
+	if err != nil {
+		return nil, err
+	}
+
+	return pt, nil
+}
+
+// Refresh rotates every expired DEK. It is intended to be called periodically
+// from a background goroutine so that key rotation stays off the [Sealer.Seal]
+// hot path.
+func (s *Sealer) Refresh() error {
+	// Find expired keys without acquiring a write lock.
+	s.mu.RLock()
+	expKeys := make([]string, 0, len(s.keys))
+	for k, v := range s.keys {
+		if v.isExpired() {
+			expKeys = append(expKeys, k)
+		}
+	}
+	s.mu.RUnlock()
+
+	// Generate DEKs without the lock as well.
+	updates := make(map[string]*DEK, len(expKeys))
+	for _, k := range expKeys {
+		dek, err := NewDEK()
+		if err != nil {
+			return fmt.Errorf("failed to create DEK for %s: %w", k, err)
+		}
+
+		updates[k] = dek
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for k, d := range updates {
+		s.keys[k].rotate(d)
+	}
+
+	return nil
+}
+
+func (s *Sealer) getOrRefreshKey(id string) (*DEK, error) {
+	s.mu.RLock()
+	key := s.keys[id] // keys were created in the constructor.
+	if key == nil {
+		s.mu.RUnlock()
+		return nil, fmt.Errorf("key not found, id: %s", id)
+	}
+
+	if !key.isExpired() {
+		dek := key.key // snapshot under RLock — caller never touches expiringDEK directly
+		s.mu.RUnlock()
+		return dek, nil
+	}
+	s.mu.RUnlock()
+
+	// Ideally we wouldn't get here. This is the case when Refresh hasn't been called, but the key is expired. This can
+	// happen when the ExpirationBuffer < the Refresh interval (e.g. Refresh every minute, but ExpirationBuffer is 30s),
+	// or with just bad luck/timing.
+	//
+	// The goal remains to refresh keys optimistically before they expire, so we don't generate keys in the hot path
+	// (when encrypting data).
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Re-check after acquiring the write lock: Refresh (or another Seal) may
+	// have already rotated this key in the window between RUnlock and Lock.
+	if !key.isExpired() {
+		return key.key, nil
+	}
+
+	k, err := NewDEK()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate DEK for %s: %w", id, err)
+	}
+
+	key.rotate(k)
+	return key.key, nil
+}
+
+func (d *sealerDEK) isExpired() bool {
+	return d.exp.Add(-d.expBuf).Before(d.now())
+}
+
+func (d *sealerDEK) rotate(newKey *DEK) {
+	d.key = newKey
+	d.exp = d.now().Add(d.incr)
+}

--- a/internal/crypto/sealer_test.go
+++ b/internal/crypto/sealer_test.go
@@ -1,0 +1,168 @@
+package crypto_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/temporalio/temporal-proxy/internal/crypto"
+)
+
+// testKEK is a passthrough KEK that returns key material unchanged.
+type testKEK struct{ id string }
+
+func TestSealer_SealOpen(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		data []byte
+	}{
+		{"empty", nil},
+		{"small", []byte("hello world")},
+		{"large", make([]byte, 64*1024)},
+	}
+
+	cfg := crypto.KeyConfig{Lifetime: time.Hour, ExpirationBuffer: time.Minute}
+	s := newTestSealer(t, "ns", cfg)
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			env, err := s.Seal(context.Background(), "ns", tc.data)
+			require.NoError(t, err)
+
+			got, err := s.Open(context.Background(), env)
+			require.NoError(t, err)
+			require.Equal(t, tc.data, got)
+		})
+	}
+}
+
+func TestSealer_Seal_UnknownID(t *testing.T) {
+	t.Parallel()
+
+	s, err := crypto.NewSealer(crypto.NewKEKRegistry())
+	require.NoError(t, err)
+
+	_, err = s.Seal(context.Background(), "unknown", []byte("data"))
+	require.Error(t, err)
+}
+
+func TestSealer_Open_TamperedCipherText(t *testing.T) {
+	t.Parallel()
+
+	cfg := crypto.KeyConfig{Lifetime: time.Hour, ExpirationBuffer: time.Minute}
+	s := newTestSealer(t, "ns", cfg)
+
+	env, err := s.Seal(context.Background(), "ns", []byte("hello"))
+	require.NoError(t, err)
+
+	env.CipherText[0] ^= 0xFF
+	_, err = s.Open(context.Background(), env)
+	require.Error(t, err)
+}
+
+func TestSealer_Refresh_RotatesExpiredKeys(t *testing.T) {
+	t.Parallel()
+
+	now, timeTravel := newClock(time.Now())
+	cfg := crypto.KeyConfig{Lifetime: time.Hour, ExpirationBuffer: 10 * time.Minute}
+	s := newTestSealer(t, "ns", cfg, crypto.WithNowFunc(now))
+
+	env1, err := s.Seal(context.Background(), "ns", []byte("before rotation"))
+	require.NoError(t, err)
+
+	// Advance past the expiration buffer threshold (60m lifetime - 10m buffer = expires at 50m).
+	timeTravel(51 * time.Minute)
+	require.NoError(t, s.Refresh())
+
+	env2, err := s.Seal(context.Background(), "ns", []byte("after rotation"))
+	require.NoError(t, err)
+
+	// Both envelopes must still be openable after key rotation.
+	got1, err := s.Open(context.Background(), env1)
+	require.NoError(t, err)
+	require.Equal(t, []byte("before rotation"), got1)
+
+	got2, err := s.Open(context.Background(), env2)
+	require.NoError(t, err)
+	require.Equal(t, []byte("after rotation"), got2)
+}
+
+func TestSealer_Refresh_NoOp_WhenNotExpired(t *testing.T) {
+	t.Parallel()
+
+	now, _ := newClock(time.Now())
+	cfg := crypto.KeyConfig{Lifetime: time.Hour, ExpirationBuffer: 10 * time.Minute}
+	s := newTestSealer(t, "ns", cfg, crypto.WithNowFunc(now))
+
+	env, err := s.Seal(context.Background(), "ns", []byte("hello"))
+	require.NoError(t, err)
+
+	require.NoError(t, s.Refresh())
+
+	got, err := s.Open(context.Background(), env)
+	require.NoError(t, err)
+	require.Equal(t, []byte("hello"), got)
+}
+
+func TestSealer_Seal_RotatesExpiredKeyInline(t *testing.T) {
+	t.Parallel()
+
+	// Verify that Seal handles an expired key even when Refresh hasn't been called.
+	now, timeTravel := newClock(time.Now())
+	cfg := crypto.KeyConfig{Lifetime: time.Hour, ExpirationBuffer: 10 * time.Minute}
+	s := newTestSealer(t, "ns", cfg, crypto.WithNowFunc(now))
+
+	env1, err := s.Seal(context.Background(), "ns", []byte("before"))
+	require.NoError(t, err)
+
+	timeTravel(51 * time.Minute) // expire without calling Refresh
+
+	env2, err := s.Seal(context.Background(), "ns", []byte("after"))
+	require.NoError(t, err)
+
+	got1, err := s.Open(context.Background(), env1)
+	require.NoError(t, err)
+	require.Equal(t, []byte("before"), got1)
+
+	got2, err := s.Open(context.Background(), env2)
+	require.NoError(t, err)
+	require.Equal(t, []byte("after"), got2)
+}
+
+// newClock returns a controllable now function and an timeTravel function for tests.
+func newClock(start time.Time) (func() time.Time, func(time.Duration)) {
+	var mu sync.Mutex
+	cur := start
+	return func() time.Time {
+			mu.Lock()
+			defer mu.Unlock()
+			return cur
+		}, func(d time.Duration) {
+			mu.Lock()
+			defer mu.Unlock()
+			cur = cur.Add(d)
+		}
+}
+
+func newTestSealer(t *testing.T, ns string, cfg crypto.KeyConfig, opts ...crypto.SealerOption) *crypto.Sealer {
+	t.Helper()
+
+	reg := crypto.NewKEKRegistry(crypto.WithKeyForNamespace(ns, &testKEK{id: "kek-" + ns}))
+	s, err := crypto.NewSealer(reg, append([]crypto.SealerOption{
+		crypto.WithKeyConfig(ns, cfg),
+	}, opts...)...)
+	require.NoError(t, err)
+	return s
+}
+
+func (k *testKEK) ID() string                                           { return k.id }
+func (k *testKEK) Encrypt(_ context.Context, pt []byte) ([]byte, error) { return pt, nil }
+func (k *testKEK) Decrypt(_ context.Context, ct []byte) ([]byte, error) { return ct, nil }
+func (k *testKEK) Close() error                                         { return nil }


### PR DESCRIPTION
Adding Sealer as the primary entry point for envelope encryption. It manages per-namespace DEK rotation and exposes two operations:

- Seal(ctx, id, plaintext) encrypts data under the current DEK for the given ID (typically a Temporal namespace) and returns an Envelope containing the AES-256-GCM ciphertext and the DEKMaterial needed to recover the DEK later.

- Open(ctx, envelope) recovers the DEK from the KEKRegistry using the embedded DEKMaterial, then decrypts and returns the original plaintext.

DEKs will be pre-rotated before expiry via a periodic `Refresh` call, keeping key generation off the Seal hot path. The rotation window is controlled per-ID through KeyConfig (Lifetime and ExpirationBuffer). If Refresh hasn't run by the time a key expires, Seal rotates inline as a fallback.