### PR TITLE
[crypto]: Cache DEKMaterial to avoid KMS calls

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,11 @@ go 1.26.1
 
 require (
 	github.com/goccy/go-yaml v1.19.2
+	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/hashicorp/yamux v0.1.2
 	github.com/stretchr/testify v1.11.1
 	github.com/urfave/cli/v3 v3.8.0
+	go.temporal.io/api v1.62.6
 	go.temporal.io/server v1.30.4
 	go.uber.org/fx v1.24.0
 	go.uber.org/mock v0.6.0
@@ -28,7 +30,6 @@ require (
 	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	go.temporal.io/api v1.62.6 // indirect
 	go.temporal.io/sdk v1.38.0 // indirect
 	go.uber.org/dig v1.19.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.2 h1:sGm2vDRFUrQJO/Veii4h4z
 github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.2/go.mod h1:wd1YpapPLivG6nQgbf7ZkG1hhSOXDhhn4MLTknx2aAc=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.3 h1:NmZ1PKzSTQbuGHw9DGPFomqkkLWMC+vZCkfs+FHv1Vg=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.3/go.mod h1:zQrxl1YP88HQlA6i9c63DSVPFklWpGX4OWAc9bFuaH4=
+github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
+github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/yamux v0.1.2 h1:XtB8kyFOyHXYVFnwT5C3+Bdo8gArse7j2AQ0DA0Uey8=
 github.com/hashicorp/yamux v0.1.2/go.mod h1:C+zze2n6e/7wshOZep2A70/aQU6QBRWJO/G6FT1wIns=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/internal/crypto/sealer.go
+++ b/internal/crypto/sealer.go
@@ -5,7 +5,12 @@ import (
 	"fmt"
 	"sync"
 	"time"
+
+	lru "github.com/hashicorp/golang-lru/v2"
+	"golang.org/x/sync/singleflight"
 )
+
+const defaultCacheSize = 100
 
 type (
 	// Sealer manages per-ID DEK rotation and envelope encryption.
@@ -17,15 +22,18 @@ type (
 	//
 	// Use [Sealer.Seal] to encrypt data and [Sealer.Open] to decrypt it.
 	Sealer struct {
-		mu       sync.RWMutex
-		keys     map[string]*sealerDEK
-		registry *KEKRegistry
-		now      func() time.Time
+		mu        sync.RWMutex
+		keys      map[string]*sealerDEK
+		registry  *KEKRegistry
+		now       func() time.Time
+		dekCache  *lru.Cache[string, *DEK] // keyed by EncryptedDEK; nil if cacheSize == 0
+		encryptor singleflight.Group       // coalesces concurrent registry.Encrypt calls per namespace
 	}
 
 	sealerOptions struct {
-		config map[string]*KeyConfig
-		now    func() time.Time
+		config    map[string]*KeyConfig
+		now       func() time.Time
+		cacheSize int // <=0 = no cache
 	}
 
 	// SealerOption configures a [Sealer] during construction.
@@ -46,11 +54,12 @@ type (
 	}
 
 	sealerDEK struct {
-		key    *DEK             // The current DEK
-		exp    time.Time        // When this key expires
-		incr   time.Duration    // How long each DEK is valid for
-		expBuf time.Duration    // How long before expiry should we regenerate
-		now    func() time.Time // Clock source, shared with the parent Sealer
+		key      *DEK             // The current DEK
+		material *DEKMaterial     // KMS-wrapped DEK; nil after rotation, protected by Sealer.mu
+		exp      time.Time        // When this key expires
+		incr     time.Duration    // How long each DEK is valid for
+		expBuf   time.Duration    // How long before expiry should we regenerate
+		now      func() time.Time // Clock source, shared with the parent Sealer
 	}
 )
 
@@ -59,8 +68,9 @@ type (
 // Returns an error if any DEK generation fails.
 func NewSealer(r *KEKRegistry, opts ...SealerOption) (*Sealer, error) {
 	sopts := &sealerOptions{
-		config: make(map[string]*KeyConfig),
-		now:    time.Now,
+		cacheSize: defaultCacheSize,
+		config:    make(map[string]*KeyConfig),
+		now:       time.Now,
 	}
 
 	for _, opt := range opts {
@@ -71,6 +81,14 @@ func NewSealer(r *KEKRegistry, opts ...SealerOption) (*Sealer, error) {
 		keys:     make(map[string]*sealerDEK),
 		registry: r,
 		now:      sopts.now,
+	}
+
+	if sopts.cacheSize > 0 {
+		c, err := lru.New[string, *DEK](sopts.cacheSize)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create DEK cache: %w", err)
+		}
+		s.dekCache = c
 	}
 
 	for k, v := range sopts.config {
@@ -112,44 +130,97 @@ func WithNowFunc(fn func() time.Time) SealerOption {
 	}
 }
 
+// WithCacheSize sets the maximum number of decrypted DEKs the Open cache may
+// hold. Values ≤ 0 disable the cache, overriding the default. Each entry is
+// keyed by the base64-encoded encrypted DEK string.
+func WithCacheSize(n int) SealerOption {
+	return func(s *sealerOptions) {
+		s.cacheSize = n
+	}
+}
+
 // Seal encrypts data using the DEK for id, returning an [Envelope] that
 // contains the ciphertext and the [DEKMaterial] needed to decrypt it later.
 func (s *Sealer) Seal(ctx context.Context, id string, data []byte) (*Envelope, error) {
-	dek, err := s.getOrRefreshKey(id)
+	sd, err := s.getOrRefreshKey(id)
 	if err != nil {
 		return nil, err
 	}
+
+	// Snapshot key and material under RLock; release immediately so the
+	// encryption work happens outside the lock.
+	s.mu.RLock()
+	dek := sd.key
+	material := sd.material
+	s.mu.RUnlock()
 
 	ct, err := dek.Encrypt(ctx, data)
 	if err != nil {
 		return nil, err
 	}
 
-	m, err := s.registry.Encrypt(ctx, id, dek)
+	if material != nil {
+		return &Envelope{CipherText: ct, KeyMaterial: material}, nil
+	}
+
+	// First Seal after a rotation: coalesce concurrent callers for the same namespace
+	// into a single KMS call so bursts don't trigger rate limiting in the Cloud provider.
+	//
+	// Key on both the namespace and the DEK pointer. If the KMS call is slow and
+	// Refresh rotates the DEK while it is in-flight, a goroutine that snapshotted
+	// the new DEK must not join the old call as it would receive material for DEK1
+	// while its ciphertext was encrypted with DEK2, causing Open to fail. Callers
+	// holding the same DEK pointer still coalesce as intended.
+	sfKey := fmt.Sprintf("%s:%p", id, dek)
+	v, err, _ := s.encryptor.Do(sfKey, func() (any, error) {
+		return s.registry.Encrypt(ctx, id, dek)
+	})
 	if err != nil {
 		return nil, err
 	}
+	m := v.(*DEKMaterial)
 
-	return &Envelope{
-		CipherText:  ct,
-		KeyMaterial: m,
-	}, nil
+	// Store under write lock.
+	// Only touch sd.material when sd.key == dek: if the key was rotated between
+	// our snapshot and now we must not read or write material that belongs to a
+	// different DEK. The envelope we built (ct + m) is still correct for this call.
+	// When sd.key == dek, prefer an already-stored value so all concurrent callers
+	// for the same DEK return identical material.
+	s.mu.Lock()
+	if sd.key == dek {
+		if sd.material == nil {
+			sd.material = m
+		} else {
+			m = sd.material
+		}
+	}
+	s.mu.Unlock()
+
+	return &Envelope{CipherText: ct, KeyMaterial: m}, nil
 }
 
 // Open decrypts e by recovering the DEK from the registry and returning the
 // original plaintext.
 func (s *Sealer) Open(ctx context.Context, e *Envelope) ([]byte, error) {
-	dek, err := s.registry.Decrypt(ctx, e.KeyMaterial)
-	if err != nil {
-		return nil, err
+	var dek *DEK
+	if s.dekCache != nil {
+		if cached, ok := s.dekCache.Get(e.KeyMaterial.EncryptedDEK); ok {
+			dek = cached
+		}
 	}
 
-	pt, err := dek.Decrypt(ctx, e.CipherText)
-	if err != nil {
-		return nil, err
+	if dek == nil {
+		var err error
+		dek, err = s.registry.Decrypt(ctx, e.KeyMaterial)
+		if err != nil {
+			return nil, err
+		}
+		if s.dekCache != nil {
+			s.dekCache.Add(e.KeyMaterial.EncryptedDEK, dek)
+		}
 	}
 
-	return pt, nil
+	return dek.Decrypt(ctx, e.CipherText)
 }
 
 // Refresh rotates every expired DEK. It is intended to be called periodically
@@ -186,34 +257,27 @@ func (s *Sealer) Refresh() error {
 	return nil
 }
 
-func (s *Sealer) getOrRefreshKey(id string) (*DEK, error) {
+func (s *Sealer) getOrRefreshKey(id string) (*sealerDEK, error) {
 	s.mu.RLock()
-	key := s.keys[id] // keys were created in the constructor.
+	key := s.keys[id]
 	if key == nil {
 		s.mu.RUnlock()
 		return nil, fmt.Errorf("key not found, id: %s", id)
 	}
 
 	if !key.isExpired() {
-		dek := key.key // snapshot under RLock — caller never touches expiringDEK directly
 		s.mu.RUnlock()
-		return dek, nil
+		return key, nil
 	}
 	s.mu.RUnlock()
 
-	// Ideally we wouldn't get here. This is the case when Refresh hasn't been called, but the key is expired. This can
-	// happen when the ExpirationBuffer < the Refresh interval (e.g. Refresh every minute, but ExpirationBuffer is 30s),
-	// or with just bad luck/timing.
-	//
-	// The goal remains to refresh keys optimistically before they expire, so we don't generate keys in the hot path
-	// (when encrypting data).
+	// Ideally we wouldn't get here. This is the case when Refresh hasn't been called, but the key is expired.
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Re-check after acquiring the write lock: Refresh (or another Seal) may
-	// have already rotated this key in the window between RUnlock and Lock.
+	// Re-check: Refresh (or another Seal) may have already rotated this key.
 	if !key.isExpired() {
-		return key.key, nil
+		return key, nil
 	}
 
 	k, err := NewDEK()
@@ -222,7 +286,7 @@ func (s *Sealer) getOrRefreshKey(id string) (*DEK, error) {
 	}
 
 	key.rotate(k)
-	return key.key, nil
+	return key, nil
 }
 
 func (d *sealerDEK) isExpired() bool {
@@ -231,5 +295,6 @@ func (d *sealerDEK) isExpired() bool {
 
 func (d *sealerDEK) rotate(newKey *DEK) {
 	d.key = newKey
+	d.material = nil
 	d.exp = d.now().Add(d.incr)
 }

--- a/internal/crypto/sealer_test.go
+++ b/internal/crypto/sealer_test.go
@@ -2,7 +2,9 @@ package crypto_test
 
 import (
 	"context"
+	"runtime"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -11,8 +13,25 @@ import (
 	"github.com/temporalio/temporal-proxy/internal/crypto"
 )
 
-// testKEK is a passthrough KEK that returns key material unchanged.
-type testKEK struct{ id string }
+type (
+	// testKEK is a passthrough KEK that returns key material unchanged.
+	testKEK struct{ id string }
+
+	// channelKEK wraps countingKEK with an optional gate channel. When gate is
+	// non-nil, Encrypt blocks until it is closed, letting tests control exactly
+	// when concurrent KMS calls are allowed to complete.
+	channelKEK struct {
+		countingKEK
+		mu   sync.Mutex
+		gate chan struct{}
+	}
+
+	countingKEK struct {
+		*testKEK
+		encrypts atomic.Int64
+		decrypts atomic.Int64
+	}
+)
 
 func TestSealer_SealOpen(t *testing.T) {
 	t.Parallel()
@@ -33,10 +52,10 @@ func TestSealer_SealOpen(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			env, err := s.Seal(context.Background(), "ns", tc.data)
+			env, err := s.Seal(t.Context(), "ns", tc.data)
 			require.NoError(t, err)
 
-			got, err := s.Open(context.Background(), env)
+			got, err := s.Open(t.Context(), env)
 			require.NoError(t, err)
 			require.Equal(t, tc.data, got)
 		})
@@ -49,7 +68,7 @@ func TestSealer_Seal_UnknownID(t *testing.T) {
 	s, err := crypto.NewSealer(crypto.NewKEKRegistry())
 	require.NoError(t, err)
 
-	_, err = s.Seal(context.Background(), "unknown", []byte("data"))
+	_, err = s.Seal(t.Context(), "unknown", []byte("data"))
 	require.Error(t, err)
 }
 
@@ -59,11 +78,11 @@ func TestSealer_Open_TamperedCipherText(t *testing.T) {
 	cfg := crypto.KeyConfig{Lifetime: time.Hour, ExpirationBuffer: time.Minute}
 	s := newTestSealer(t, "ns", cfg)
 
-	env, err := s.Seal(context.Background(), "ns", []byte("hello"))
+	env, err := s.Seal(t.Context(), "ns", []byte("hello"))
 	require.NoError(t, err)
 
 	env.CipherText[0] ^= 0xFF
-	_, err = s.Open(context.Background(), env)
+	_, err = s.Open(t.Context(), env)
 	require.Error(t, err)
 }
 
@@ -74,22 +93,22 @@ func TestSealer_Refresh_RotatesExpiredKeys(t *testing.T) {
 	cfg := crypto.KeyConfig{Lifetime: time.Hour, ExpirationBuffer: 10 * time.Minute}
 	s := newTestSealer(t, "ns", cfg, crypto.WithNowFunc(now))
 
-	env1, err := s.Seal(context.Background(), "ns", []byte("before rotation"))
+	env1, err := s.Seal(t.Context(), "ns", []byte("before rotation"))
 	require.NoError(t, err)
 
 	// Advance past the expiration buffer threshold (60m lifetime - 10m buffer = expires at 50m).
 	timeTravel(51 * time.Minute)
 	require.NoError(t, s.Refresh())
 
-	env2, err := s.Seal(context.Background(), "ns", []byte("after rotation"))
+	env2, err := s.Seal(t.Context(), "ns", []byte("after rotation"))
 	require.NoError(t, err)
 
 	// Both envelopes must still be openable after key rotation.
-	got1, err := s.Open(context.Background(), env1)
+	got1, err := s.Open(t.Context(), env1)
 	require.NoError(t, err)
 	require.Equal(t, []byte("before rotation"), got1)
 
-	got2, err := s.Open(context.Background(), env2)
+	got2, err := s.Open(t.Context(), env2)
 	require.NoError(t, err)
 	require.Equal(t, []byte("after rotation"), got2)
 }
@@ -101,12 +120,12 @@ func TestSealer_Refresh_NoOp_WhenNotExpired(t *testing.T) {
 	cfg := crypto.KeyConfig{Lifetime: time.Hour, ExpirationBuffer: 10 * time.Minute}
 	s := newTestSealer(t, "ns", cfg, crypto.WithNowFunc(now))
 
-	env, err := s.Seal(context.Background(), "ns", []byte("hello"))
+	env, err := s.Seal(t.Context(), "ns", []byte("hello"))
 	require.NoError(t, err)
 
 	require.NoError(t, s.Refresh())
 
-	got, err := s.Open(context.Background(), env)
+	got, err := s.Open(t.Context(), env)
 	require.NoError(t, err)
 	require.Equal(t, []byte("hello"), got)
 }
@@ -119,21 +138,348 @@ func TestSealer_Seal_RotatesExpiredKeyInline(t *testing.T) {
 	cfg := crypto.KeyConfig{Lifetime: time.Hour, ExpirationBuffer: 10 * time.Minute}
 	s := newTestSealer(t, "ns", cfg, crypto.WithNowFunc(now))
 
-	env1, err := s.Seal(context.Background(), "ns", []byte("before"))
+	env1, err := s.Seal(t.Context(), "ns", []byte("before"))
 	require.NoError(t, err)
 
 	timeTravel(51 * time.Minute) // expire without calling Refresh
 
-	env2, err := s.Seal(context.Background(), "ns", []byte("after"))
+	env2, err := s.Seal(t.Context(), "ns", []byte("after"))
 	require.NoError(t, err)
 
-	got1, err := s.Open(context.Background(), env1)
+	got1, err := s.Open(t.Context(), env1)
 	require.NoError(t, err)
 	require.Equal(t, []byte("before"), got1)
 
-	got2, err := s.Open(context.Background(), env2)
+	got2, err := s.Open(t.Context(), env2)
 	require.NoError(t, err)
 	require.Equal(t, []byte("after"), got2)
+}
+
+func TestSealer_Seal_CachesKeyMaterial(t *testing.T) {
+	t.Parallel()
+
+	cfg := crypto.KeyConfig{Lifetime: time.Hour, ExpirationBuffer: time.Minute}
+	kek := &countingKEK{testKEK: &testKEK{id: "kek-ns"}}
+	reg := crypto.NewKEKRegistry(crypto.WithKeyForNamespace("ns", kek))
+	s, err := crypto.NewSealer(reg, crypto.WithKeyConfig("ns", cfg))
+	require.NoError(t, err)
+
+	_, err = s.Seal(t.Context(), "ns", []byte("first"))
+	require.NoError(t, err)
+	_, err = s.Seal(t.Context(), "ns", []byte("second"))
+	require.NoError(t, err)
+
+	require.Equal(t, int64(1), kek.encrypts.Load(), "second Seal should reuse cached DEKMaterial, not call KMS again")
+}
+
+func TestSealer_Open_CachesDecryptedDEK(t *testing.T) {
+	t.Parallel()
+
+	cfg := crypto.KeyConfig{Lifetime: time.Hour, ExpirationBuffer: time.Minute}
+	kek := &countingKEK{testKEK: &testKEK{id: "kek-ns"}}
+	reg := crypto.NewKEKRegistry(crypto.WithKeyForNamespace("ns", kek))
+	s, err := crypto.NewSealer(reg,
+		crypto.WithKeyConfig("ns", cfg),
+		crypto.WithCacheSize(10),
+	)
+	require.NoError(t, err)
+
+	env, err := s.Seal(t.Context(), "ns", []byte("hello"))
+	require.NoError(t, err)
+
+	_, err = s.Open(t.Context(), env)
+	require.NoError(t, err)
+	afterFirst := kek.decrypts.Load()
+
+	_, err = s.Open(t.Context(), env)
+	require.NoError(t, err)
+	require.Equal(t, afterFirst, kek.decrypts.Load(), "second Open must hit cache, not KMS")
+}
+
+func TestSealer_Open_CacheEviction(t *testing.T) {
+	t.Parallel()
+
+	now, timeTravel := newClock(time.Now())
+	cfg := crypto.KeyConfig{Lifetime: time.Hour, ExpirationBuffer: 10 * time.Minute}
+	kek := &countingKEK{testKEK: &testKEK{id: "kek-ns"}}
+	reg := crypto.NewKEKRegistry(crypto.WithKeyForNamespace("ns", kek))
+	s, err := crypto.NewSealer(reg,
+		crypto.WithKeyConfig("ns", cfg),
+		crypto.WithCacheSize(2),
+		crypto.WithNowFunc(now),
+	)
+	require.NoError(t, err)
+
+	// Seal with DEK1.
+	env1, err := s.Seal(t.Context(), "ns", []byte("data1"))
+	require.NoError(t, err)
+
+	// Rotate to DEK2.
+	timeTravel(51 * time.Minute)
+	require.NoError(t, s.Refresh())
+
+	// Seal with DEK2.
+	env2, err := s.Seal(t.Context(), "ns", []byte("data2"))
+	require.NoError(t, err)
+
+	// Rotate to DEK3.
+	timeTravel(51 * time.Minute)
+	require.NoError(t, s.Refresh())
+
+	// Seal with DEK3.
+	env3, err := s.Seal(t.Context(), "ns", []byte("data3"))
+	require.NoError(t, err)
+
+	// Open all three in order: cache fills to capacity 2 then evicts DEK1 (LRU).
+	// Open env1 → miss → KMS → cache: [DEK1]
+	// Open env2 → miss → KMS → cache: [DEK1, DEK2]
+	// Open env3 → miss → KMS → cache: [DEK2, DEK3] (DEK1 evicted)
+	_, err = s.Open(t.Context(), env1)
+	require.NoError(t, err)
+	_, err = s.Open(t.Context(), env2)
+	require.NoError(t, err)
+	_, err = s.Open(t.Context(), env3)
+	require.NoError(t, err)
+
+	decryptsBefore := kek.decrypts.Load()
+
+	// Re-open env1 — DEK1 was evicted, must hit KMS again.
+	_, err = s.Open(t.Context(), env1)
+	require.NoError(t, err)
+	require.Equal(t, decryptsBefore+1, kek.decrypts.Load(), "evicted DEK must trigger a fresh KMS call")
+}
+
+func TestSealer_Open_NoCacheWhenSizeZero(t *testing.T) {
+	t.Parallel()
+
+	cfg := crypto.KeyConfig{Lifetime: time.Hour, ExpirationBuffer: time.Minute}
+	kek := &countingKEK{testKEK: &testKEK{id: "kek-ns"}}
+	reg := crypto.NewKEKRegistry(crypto.WithKeyForNamespace("ns", kek))
+	s, err := crypto.NewSealer(reg,
+		crypto.WithKeyConfig("ns", cfg),
+		crypto.WithCacheSize(0), // explicitly disable the default cache
+	)
+	require.NoError(t, err)
+
+	env, err := s.Seal(t.Context(), "ns", []byte("hello"))
+	require.NoError(t, err)
+
+	_, err = s.Open(t.Context(), env)
+	require.NoError(t, err)
+	_, err = s.Open(t.Context(), env)
+	require.NoError(t, err)
+
+	require.Equal(t, int64(2), kek.decrypts.Load(), "without a cache every Open must call KMS")
+}
+
+func TestSealer_Open_DefaultCacheEnabled(t *testing.T) {
+	t.Parallel()
+
+	cfg := crypto.KeyConfig{Lifetime: time.Hour, ExpirationBuffer: time.Minute}
+	kek := &countingKEK{testKEK: &testKEK{id: "kek-ns"}}
+	reg := crypto.NewKEKRegistry(crypto.WithKeyForNamespace("ns", kek))
+	s, err := crypto.NewSealer(reg, crypto.WithKeyConfig("ns", cfg))
+	require.NoError(t, err)
+
+	env, err := s.Seal(t.Context(), "ns", []byte("hello"))
+	require.NoError(t, err)
+
+	_, err = s.Open(t.Context(), env)
+	require.NoError(t, err)
+	after := kek.decrypts.Load()
+
+	_, err = s.Open(t.Context(), env)
+	require.NoError(t, err)
+	require.Equal(t, after, kek.decrypts.Load(), "default cache should serve second Open without KMS")
+}
+
+func TestSealer_Seal_CoalescesKMSCalls(t *testing.T) {
+	t.Parallel()
+
+	const n = 50
+	cfg := crypto.KeyConfig{Lifetime: time.Hour, ExpirationBuffer: time.Minute}
+	kek := &channelKEK{countingKEK: countingKEK{testKEK: &testKEK{id: "kek-ns"}}}
+	reg := crypto.NewKEKRegistry(crypto.WithKeyForNamespace("ns", kek))
+	s, err := crypto.NewSealer(reg, crypto.WithKeyConfig("ns", cfg))
+	require.NoError(t, err)
+
+	// Install the gate before releasing goroutines so the KMS call blocks
+	// until all callers have joined the singleflight group.
+	gate := kek.openGate()
+	ready := make(chan struct{})
+
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for range n {
+		go func() {
+			defer wg.Done()
+			<-ready
+			_, serr := s.Seal(t.Context(), "ns", []byte("data"))
+			require.NoError(t, serr)
+		}()
+	}
+	close(ready)
+
+	// Spin until the first goroutine has entered kek.Encrypt (gate is now held).
+	for kek.encrypts.Load() == 0 {
+		runtime.Gosched()
+	}
+
+	// Give the remaining goroutines time to reach sf.Do and join the in-flight group.
+	time.Sleep(5 * time.Millisecond)
+	close(gate)
+	wg.Wait()
+
+	require.Equal(t, int64(1), kek.encrypts.Load(), "concurrent first-seal burst must produce exactly 1 KMS call")
+}
+
+func TestSealer_Seal_CoalescesKMSCalls_AfterRotation(t *testing.T) {
+	t.Parallel()
+
+	const n = 50
+	now, timeTravel := newClock(time.Now())
+	cfg := crypto.KeyConfig{Lifetime: time.Hour, ExpirationBuffer: 10 * time.Minute}
+	kek := &channelKEK{countingKEK: countingKEK{testKEK: &testKEK{id: "kek-ns"}}}
+	reg := crypto.NewKEKRegistry(crypto.WithKeyForNamespace("ns", kek))
+	s, err := crypto.NewSealer(reg,
+		crypto.WithKeyConfig("ns", cfg),
+		crypto.WithNowFunc(now),
+	)
+	require.NoError(t, err)
+
+	// Initial seal: no gate, completes immediately.
+	_, err = s.Seal(t.Context(), "ns", []byte("before"))
+	require.NoError(t, err)
+	require.Equal(t, int64(1), kek.encrypts.Load())
+
+	timeTravel(51 * time.Minute)
+	require.NoError(t, s.Refresh())
+
+	// Install gate before the burst so the post-rotation KMS call blocks.
+	gate := kek.openGate()
+	ready := make(chan struct{})
+
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for range n {
+		go func() {
+			defer wg.Done()
+			<-ready
+
+			_, serr := s.Seal(t.Context(), "ns", []byte("after"))
+			require.NoError(t, serr)
+		}()
+	}
+	close(ready)
+
+	// Spin until the first goroutine has entered kek.Encrypt (gate is now held).
+	for kek.encrypts.Load() == 1 {
+		runtime.Gosched()
+	}
+
+	// Give the remaining goroutines time to reach sf.Do and join the in-flight group.
+	time.Sleep(5 * time.Millisecond)
+	close(gate)
+	wg.Wait()
+
+	require.Equal(t, int64(2), kek.encrypts.Load(), "post-rotation burst must produce exactly 1 new KMS call")
+}
+
+func TestSealer_Seal_CacheClearedOnRotation(t *testing.T) {
+	t.Parallel()
+
+	now, timeTravel := newClock(time.Now())
+	cfg := crypto.KeyConfig{Lifetime: time.Hour, ExpirationBuffer: 10 * time.Minute}
+	kek := &countingKEK{testKEK: &testKEK{id: "kek-ns"}}
+	reg := crypto.NewKEKRegistry(crypto.WithKeyForNamespace("ns", kek))
+	s, err := crypto.NewSealer(reg,
+		crypto.WithKeyConfig("ns", cfg),
+		crypto.WithNowFunc(now),
+	)
+	require.NoError(t, err)
+
+	// First seal populates the material cache (1 KMS call).
+	_, err = s.Seal(t.Context(), "ns", []byte("before"))
+	require.NoError(t, err)
+	require.Equal(t, int64(1), kek.encrypts.Load())
+
+	// Rotate the DEK.
+	timeTravel(51 * time.Minute)
+	require.NoError(t, s.Refresh())
+
+	// First seal after rotation must call KMS again (2 total).
+	_, err = s.Seal(t.Context(), "ns", []byte("after"))
+	require.NoError(t, err)
+	require.Equal(t, int64(2), kek.encrypts.Load())
+
+	// Second seal after rotation must reuse the new cached material.
+	_, err = s.Seal(t.Context(), "ns", []byte("still after"))
+	require.NoError(t, err)
+	require.Equal(t, int64(2), kek.encrypts.Load())
+}
+
+func TestSealer_Seal_RotationDuringSlowKMS(t *testing.T) {
+	t.Parallel()
+
+	now, timeTravel := newClock(time.Now())
+	cfg := crypto.KeyConfig{Lifetime: time.Hour, ExpirationBuffer: 10 * time.Minute}
+	kek := &channelKEK{countingKEK: countingKEK{testKEK: &testKEK{id: "kek-ns"}}}
+	reg := crypto.NewKEKRegistry(crypto.WithKeyForNamespace("ns", kek))
+	s, err := crypto.NewSealer(reg,
+		crypto.WithKeyConfig("ns", cfg),
+		crypto.WithNowFunc(now),
+	)
+	require.NoError(t, err)
+
+	// Block all KMS calls so we can rotate the DEK while one is in-flight.
+	gate := kek.openGate()
+
+	var (
+		env1 *crypto.Envelope
+		env2 *crypto.Envelope
+		wg   sync.WaitGroup
+	)
+
+	// G1: Seal with DEK1 — will block inside KMS.
+	wg.Go(func() {
+		var serr error
+		env1, serr = s.Seal(t.Context(), "ns", []byte("dek1 data"))
+		require.NoError(t, serr)
+	})
+
+	// Wait until G1 has entered the KMS call.
+	for kek.encrypts.Load() == 0 {
+		runtime.Gosched()
+	}
+
+	// Rotate the DEK while G1's KMS call is still blocked.
+	timeTravel(51 * time.Minute)
+	require.NoError(t, s.Refresh())
+
+	// G2: Seal with DEK2 — must open its own singleflight group, not join G1's.
+	wg.Go(func() {
+		var serr error
+		env2, serr = s.Seal(t.Context(), "ns", []byte("dek2 data"))
+		require.NoError(t, serr)
+	})
+
+	// Wait until G2 has also entered the KMS call (two concurrent in-flight calls).
+	for kek.encrypts.Load() < 2 {
+		runtime.Gosched()
+	}
+
+	close(gate)
+	wg.Wait()
+
+	require.Equal(t, int64(2), kek.encrypts.Load(), "each DEK must produce its own KMS call")
+
+	got1, err := s.Open(t.Context(), env1)
+	require.NoError(t, err)
+	require.Equal(t, []byte("dek1 data"), got1)
+
+	got2, err := s.Open(t.Context(), env2)
+	require.NoError(t, err)
+	require.Equal(t, []byte("dek2 data"), got2)
 }
 
 // newClock returns a controllable now function and an timeTravel function for tests.
@@ -166,3 +512,38 @@ func (k *testKEK) ID() string                                           { return
 func (k *testKEK) Encrypt(_ context.Context, pt []byte) ([]byte, error) { return pt, nil }
 func (k *testKEK) Decrypt(_ context.Context, ct []byte) ([]byte, error) { return ct, nil }
 func (k *testKEK) Close() error                                         { return nil }
+
+func (k *countingKEK) Encrypt(ctx context.Context, pt []byte) ([]byte, error) {
+	k.encrypts.Add(1)
+	return k.testKEK.Encrypt(ctx, pt)
+}
+
+func (k *countingKEK) Decrypt(ctx context.Context, ct []byte) ([]byte, error) {
+	k.decrypts.Add(1)
+	return k.testKEK.Decrypt(ctx, ct)
+}
+
+// openGate installs a new (closed-by-caller) gate and returns it.
+// Call close(gate) to unblock any in-flight Encrypt calls.
+func (k *channelKEK) openGate() chan struct{} {
+	ch := make(chan struct{})
+	k.mu.Lock()
+	k.gate = ch
+	k.mu.Unlock()
+	return ch
+}
+
+func (k *channelKEK) Encrypt(ctx context.Context, pt []byte) ([]byte, error) {
+	k.encrypts.Add(1)
+	k.mu.Lock()
+	gate := k.gate
+	k.mu.Unlock()
+	if gate != nil {
+		select {
+		case <-gate:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	return k.testKEK.Encrypt(ctx, pt)
+}


### PR DESCRIPTION
Sealer.Seal called registry.Encrypt (a KMS network call) on every invocation, even when the active DEK had not changed. Sealer.Open called registry.Decrypt on every invocation, even for envelopes whose DEK had already been decrypted. At volume, this KMS round-trip dominates latency.

This commit introduces two caches:

Seal: sealerDEK now holds the KMS-wrapped DEKMaterial after the first wrap call. All subsequent Seal calls for the same DEK reuse the cached material, making exactly one KMS call per DEK rotation per namespace. The cache is cleared on rotation so stale material is never returned. A key-identity guard (sd.key == dek) under the write lock handles the race where Refresh rotates the DEK between the snapshot and the cache store.

Open: Sealer now has a bounded LRU cache keyed by the base64-encoded EncryptedDEK string. A cache hit returns the decrypted DEK directly, skipping KMS entirely. The cache size defaults to 100 entries and is configurable via WithCacheSize; passing 0 disables the cache.

> NB: 100 keys in the LRU cache is 300KB on the high end. Typically 1.5-2KB
per DEK.