### PR TITLE
[validation]: Add cert validation

### DIFF
--- a/internal/validation/certs/certs.go
+++ b/internal/validation/certs/certs.go
@@ -1,0 +1,81 @@
+package certs
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+
+	"github.com/temporalio/temporal-proxy/internal/validation"
+)
+
+// Validator checks a single certificate and returns a validation.Error if it fails.
+type Validator func(*x509.Certificate) error
+
+// Validate parses the PEM-encoded certificate data and runs each validator against every
+// certificate found. It returns a validation.Errors containing all failures, or nil if all pass.
+func Validate(pemData []byte, validators ...Validator) error {
+	// With no validators there is nothing to check; skip PEM parsing entirely.
+	if len(validators) == 0 {
+		return nil
+	}
+
+	parsed, err := parsePEM(pemData)
+	if err != nil {
+		return err
+	}
+
+	var errs validation.Errors
+	for _, cert := range parsed {
+		for _, v := range validators {
+			if vErr := v(cert); vErr != nil {
+				if ve, ok := errors.AsType[validation.Error](vErr); ok {
+					errs = append(errs, ve)
+					continue
+				}
+
+				errs = append(errs, validation.Error{
+					Subject: cert.Subject.CommonName,
+					Field:   "unknown",
+					Message: vErr.Error(),
+				})
+			}
+		}
+	}
+
+	if len(errs) > 0 {
+		return errs
+	}
+
+	return nil
+}
+
+func parsePEM(data []byte) ([]*x509.Certificate, error) {
+	var block *pem.Block
+	var parsed []*x509.Certificate
+
+	rest := data
+	for len(rest) > 0 {
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+
+		if block.Type != "CERTIFICATE" {
+			continue
+		}
+
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse certificate: %w", err)
+		}
+
+		parsed = append(parsed, cert)
+	}
+
+	if len(parsed) == 0 {
+		return nil, errors.New("no certificates found in PEM data")
+	}
+
+	return parsed, nil
+}

--- a/internal/validation/certs/validators.go
+++ b/internal/validation/certs/validators.go
@@ -1,0 +1,166 @@
+package certs
+
+import (
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"time"
+
+	"github.com/temporalio/temporal-proxy/internal/validation"
+)
+
+var (
+	// weakAlgorithms lists signature algorithms considered cryptographically broken.
+	// SHA-1 and MD5 are vulnerable to collision attacks; MD2 is obsolete; DSA is deprecated in X.509.
+	weakAlgorithms = map[x509.SignatureAlgorithm]bool{
+		x509.SHA1WithRSA:   true,
+		x509.ECDSAWithSHA1: true,
+		x509.MD2WithRSA:    true,
+		x509.MD5WithRSA:    true,
+		x509.DSAWithSHA1:   true,
+		x509.DSAWithSHA256: true,
+	}
+
+	// suiteKeyTypes maps each supported TLS cipher suite to the key type it requires ("rsa" or
+	// "ecdsa"). Used by SecureAlgorithm to verify that a certificate's public key is compatible
+	// with the caller's allowed suite set.
+	suiteKeyTypes = map[uint16]string{
+		// ECDHE_RSA suites
+		tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA:          "rsa",
+		tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA:          "rsa",
+		tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256:       "rsa",
+		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256:       "rsa",
+		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384:       "rsa",
+		tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256: "rsa",
+		// ECDHE_ECDSA suites
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA:          "ecdsa",
+		tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA:          "ecdsa",
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256:       "ecdsa",
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256:       "ecdsa",
+		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384:       "ecdsa",
+		tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256: "ecdsa",
+	}
+)
+
+// NotExpired returns a Validator that fails if a certificate is expired or not yet valid.
+func NotExpired() Validator {
+	return func(cert *x509.Certificate) error {
+		now := time.Now()
+		if now.Before(cert.NotBefore) {
+			return validation.Error{
+				Subject: cert.Subject.CommonName,
+				Field:   "expiry",
+				Message: fmt.Sprintf("certificate not yet valid until %s", cert.NotBefore.Format(time.RFC3339)),
+			}
+		}
+
+		if now.After(cert.NotAfter) {
+			return validation.Error{
+				Subject: cert.Subject.CommonName,
+				Field:   "expiry",
+				Message: fmt.Sprintf("certificate expired at %s", cert.NotAfter.Format(time.RFC3339)),
+			}
+		}
+
+		return nil
+	}
+}
+
+// IsCA returns a Validator that fails if a certificate is not a CA certificate.
+func IsCA() Validator {
+	return func(cert *x509.Certificate) error {
+		if !cert.IsCA {
+			return validation.Error{
+				Subject: cert.Subject.CommonName,
+				Field:   "is_ca",
+				Message: "certificate is not a CA",
+			}
+		}
+
+		return nil
+	}
+}
+
+// SecureAlgorithm returns a Validator that fails if a certificate uses a weak signature algorithm.
+// If allowedSuites is provided, it also fails if the certificate's key type is incompatible with
+// all of the supplied TLS cipher suites.
+func SecureAlgorithm(allowedSuites ...uint16) Validator {
+	return func(cert *x509.Certificate) error {
+		if weakAlgorithms[cert.SignatureAlgorithm] {
+			return validation.Error{
+				Subject: cert.Subject.CommonName,
+				Field:   "signature_algorithm",
+				Message: fmt.Sprintf("weak signature algorithm: %s", cert.SignatureAlgorithm),
+			}
+		}
+
+		if len(allowedSuites) == 0 {
+			return nil
+		}
+
+		allowed := make(map[string]bool)
+		for _, suite := range allowedSuites {
+			if kt, ok := suiteKeyTypes[suite]; ok {
+				allowed[kt] = true
+			}
+		}
+
+		if len(allowed) == 0 {
+			return nil
+		}
+
+		kt := keyTypeOf(cert.PublicKey)
+		if !allowed[kt] {
+			return validation.Error{
+				Subject: cert.Subject.CommonName,
+				Field:   "key_type",
+				Message: fmt.Sprintf("key type %q incompatible with allowed cipher suites", kt),
+			}
+		}
+
+		return nil
+	}
+}
+
+// CAChain returns a Validator that fails if a certificate cannot be verified against the provided
+// PEM-encoded CA certificate(s).
+func CAChain(caPEM []byte) Validator {
+	pool := x509.NewCertPool()
+	poolOK := pool.AppendCertsFromPEM(caPEM)
+
+	return func(cert *x509.Certificate) error {
+		if !poolOK {
+			return validation.Error{
+				Subject: cert.Subject.CommonName,
+				Field:   "ca_chain",
+				Message: "failed to parse CA PEM",
+			}
+		}
+
+		if _, err := cert.Verify(x509.VerifyOptions{
+			Roots:     pool,
+			KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
+		}); err != nil {
+			return validation.Error{
+				Subject: cert.Subject.CommonName,
+				Field:   "ca_chain",
+				Message: fmt.Sprintf("certificate does not chain to provided CA: %s", err),
+			}
+		}
+
+		return nil
+	}
+}
+
+func keyTypeOf(pub any) string {
+	switch pub.(type) {
+	case *rsa.PublicKey:
+		return "rsa"
+	case *ecdsa.PublicKey:
+		return "ecdsa"
+	default:
+		return "unknown"
+	}
+}

--- a/internal/validation/certs/validators_test.go
+++ b/internal/validation/certs/validators_test.go
@@ -1,0 +1,338 @@
+package certs_test
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/temporalio/temporal-proxy/internal/validation"
+	"github.com/temporalio/temporal-proxy/internal/validation/certs"
+)
+
+type certConfig struct {
+	cn        string
+	isCA      bool
+	notBefore time.Time
+	notAfter  time.Time
+	keyType   string // "ecdsa" (default) or "rsa"
+	parent    *x509.Certificate
+	parentKey any
+}
+
+func TestValidate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no validators returns nil for any input", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, certs.Validate([]byte("not pem")))
+	})
+
+	t.Run("no certificate blocks returns error", func(t *testing.T) {
+		t.Parallel()
+		pemData := []byte("-----BEGIN PRIVATE KEY-----\ndGVzdA==\n-----END PRIVATE KEY-----\n")
+		alwaysFail := certs.Validator(func(_ *x509.Certificate) error {
+			return validation.Error{Subject: "x", Field: "f", Message: "fail"}
+		})
+		err := certs.Validate(pemData, alwaysFail)
+		require.ErrorContains(t, err, "no certificates found")
+	})
+
+	t.Run("returns nil when all validators pass", func(t *testing.T) {
+		t.Parallel()
+		_, _, pemData := mustMakeCert(t, certConfig{cn: "ok"})
+		alwaysPass := certs.Validator(func(_ *x509.Certificate) error { return nil })
+		require.NoError(t, certs.Validate(pemData, alwaysPass))
+	})
+
+	t.Run("collects all errors across all certs", func(t *testing.T) {
+		t.Parallel()
+		_, _, pem1 := mustMakeCert(t, certConfig{cn: "cert1"})
+		_, _, pem2 := mustMakeCert(t, certConfig{cn: "cert2"})
+		combined := append(pem1, pem2...)
+
+		alwaysFail := certs.Validator(func(cert *x509.Certificate) error {
+			return validation.Error{Subject: cert.Subject.CommonName, Field: "test", Message: "fail"}
+		})
+
+		err := certs.Validate(combined, alwaysFail)
+		require.Error(t, err)
+
+		var errs validation.Errors
+		require.ErrorAs(t, err, &errs)
+		require.Len(t, errs, 2)
+		require.Equal(t, "cert1", errs[0].Subject)
+		require.Equal(t, "cert2", errs[1].Subject)
+	})
+
+	t.Run("skips non-certificate PEM blocks", func(t *testing.T) {
+		t.Parallel()
+		_, _, certPEM := mustMakeCert(t, certConfig{cn: "cert"})
+		privKeyBlock := []byte("-----BEGIN PRIVATE KEY-----\ndGVzdA==\n-----END PRIVATE KEY-----\n")
+		mixed := append(privKeyBlock, certPEM...)
+
+		alwaysPass := certs.Validator(func(_ *x509.Certificate) error { return nil })
+		require.NoError(t, certs.Validate(mixed, alwaysPass))
+	})
+}
+
+func TestNotExpired(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		notBefore time.Time
+		notAfter  time.Time
+		wantMsg   string
+	}{
+		{
+			name:      "valid cert",
+			notBefore: time.Now().Add(-time.Hour),
+			notAfter:  time.Now().Add(time.Hour),
+		},
+		{
+			name:      "expired cert",
+			notBefore: time.Now().Add(-2 * time.Hour),
+			notAfter:  time.Now().Add(-time.Minute),
+			wantMsg:   "expired",
+		},
+		{
+			name:      "not yet valid cert",
+			notBefore: time.Now().Add(time.Hour),
+			notAfter:  time.Now().Add(2 * time.Hour),
+			wantMsg:   "not yet valid",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, _, pemData := mustMakeCert(t, certConfig{
+				cn:        tc.name,
+				notBefore: tc.notBefore,
+				notAfter:  tc.notAfter,
+			})
+
+			err := certs.Validate(pemData, certs.NotExpired())
+			if tc.wantMsg == "" {
+				require.NoError(t, err)
+				return
+			}
+
+			var errs validation.Errors
+			require.ErrorAs(t, err, &errs)
+			require.Len(t, errs, 1)
+			require.Equal(t, "expiry", errs[0].Field)
+			require.Equal(t, tc.name, errs[0].Subject)
+			require.ErrorContains(t, err, tc.wantMsg)
+		})
+	}
+}
+
+func TestIsCA(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		isCA    bool
+		wantErr bool
+	}{
+		{name: "CA cert", isCA: true, wantErr: false},
+		{name: "leaf cert", isCA: false, wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, _, pemData := mustMakeCert(t, certConfig{cn: tc.name, isCA: tc.isCA})
+
+			err := certs.Validate(pemData, certs.IsCA())
+			if !tc.wantErr {
+				require.NoError(t, err)
+				return
+			}
+
+			var errs validation.Errors
+			require.ErrorAs(t, err, &errs)
+			require.Len(t, errs, 1)
+			require.Equal(t, "is_ca", errs[0].Field)
+			require.Equal(t, tc.name, errs[0].Subject)
+		})
+	}
+}
+
+func TestSecureAlgorithm(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ECDSA cert passes with no suites", func(t *testing.T) {
+		t.Parallel()
+		_, _, pemData := mustMakeCert(t, certConfig{cn: "ecdsa-cert"})
+		require.NoError(t, certs.Validate(pemData, certs.SecureAlgorithm()))
+	})
+
+	t.Run("weak SHA1 signature algorithm is rejected", func(t *testing.T) {
+		t.Parallel()
+		// Call the validator directly on a fake cert — avoids x509.CreateCertificate
+		// rejecting SHA1 in newer Go versions.
+		k, err := rsa.GenerateKey(rand.Reader, 2048)
+		require.NoError(t, err)
+		fakeCert := &x509.Certificate{
+			Subject:            pkix.Name{CommonName: "sha1-cert"},
+			SignatureAlgorithm: x509.SHA1WithRSA,
+			PublicKey:          &k.PublicKey,
+		}
+		validatorErr := certs.SecureAlgorithm()(fakeCert)
+		var ve validation.Error
+		require.ErrorAs(t, validatorErr, &ve)
+		require.Equal(t, "signature_algorithm", ve.Field)
+		require.Equal(t, "sha1-cert", ve.Subject)
+	})
+
+	t.Run("weak MD5 signature algorithm is rejected", func(t *testing.T) {
+		t.Parallel()
+		k, err := rsa.GenerateKey(rand.Reader, 2048)
+		require.NoError(t, err)
+		fakeCert := &x509.Certificate{
+			Subject:            pkix.Name{CommonName: "md5-cert"},
+			SignatureAlgorithm: x509.MD5WithRSA,
+			PublicKey:          &k.PublicKey,
+		}
+		validatorErr := certs.SecureAlgorithm()(fakeCert)
+		var ve validation.Error
+		require.ErrorAs(t, validatorErr, &ve)
+		require.Equal(t, "signature_algorithm", ve.Field)
+		require.Equal(t, "md5-cert", ve.Subject)
+	})
+
+	t.Run("RSA cert passes with ECDHE_RSA suites", func(t *testing.T) {
+		t.Parallel()
+		_, _, pemData := mustMakeCert(t, certConfig{cn: "rsa-cert", keyType: "rsa"})
+		err := certs.Validate(pemData, certs.SecureAlgorithm(
+			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		))
+		require.NoError(t, err)
+	})
+
+	t.Run("ECDSA cert rejected with RSA-only suites", func(t *testing.T) {
+		t.Parallel()
+		_, _, pemData := mustMakeCert(t, certConfig{cn: "ecdsa-cert"})
+
+		err := certs.Validate(pemData, certs.SecureAlgorithm(
+			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		))
+		var errs validation.Errors
+		require.ErrorAs(t, err, &errs)
+		require.Len(t, errs, 1)
+		require.Equal(t, "key_type", errs[0].Field)
+	})
+}
+
+func TestCAChain(t *testing.T) {
+	t.Parallel()
+
+	t.Run("cert signed by CA passes", func(t *testing.T) {
+		t.Parallel()
+		caCert, caKey, caPEM := mustMakeCert(t, certConfig{cn: "test-ca", isCA: true})
+		_, _, leafPEM := mustMakeCert(t, certConfig{cn: "leaf", parent: caCert, parentKey: caKey})
+
+		err := certs.Validate(leafPEM, certs.CAChain(caPEM))
+		require.NoError(t, err)
+	})
+
+	t.Run("self-signed cert not in CA pool fails", func(t *testing.T) {
+		t.Parallel()
+		_, _, leafPEM := mustMakeCert(t, certConfig{cn: "self-signed"})
+		_, _, differentCAPEM := mustMakeCert(t, certConfig{cn: "other-ca", isCA: true})
+
+		err := certs.Validate(leafPEM, certs.CAChain(differentCAPEM))
+		var errs validation.Errors
+		require.ErrorAs(t, err, &errs)
+		require.Len(t, errs, 1)
+		require.Equal(t, "ca_chain", errs[0].Field)
+		require.Equal(t, "self-signed", errs[0].Subject)
+	})
+
+	t.Run("invalid CA PEM fails", func(t *testing.T) {
+		t.Parallel()
+		_, _, leafPEM := mustMakeCert(t, certConfig{cn: "leaf"})
+
+		err := certs.Validate(leafPEM, certs.CAChain([]byte("not pem")))
+		var errs validation.Errors
+		require.ErrorAs(t, err, &errs)
+		require.Len(t, errs, 1)
+		require.Equal(t, "ca_chain", errs[0].Field)
+		require.ErrorContains(t, err, "failed to parse CA PEM")
+	})
+}
+
+func mustMakeCert(t *testing.T, cfg certConfig) (*x509.Certificate, any, []byte) {
+	t.Helper()
+
+	if cfg.cn == "" {
+		cfg.cn = "test-cert"
+	}
+
+	if cfg.notBefore.IsZero() {
+		cfg.notBefore = time.Now().Add(-time.Hour)
+	}
+
+	if cfg.notAfter.IsZero() {
+		cfg.notAfter = time.Now().Add(time.Hour)
+	}
+
+	var privKey any
+	var pubKey any
+
+	switch cfg.keyType {
+	case "rsa":
+		k, err := rsa.GenerateKey(rand.Reader, 2048)
+		require.NoError(t, err)
+		privKey = k
+		pubKey = &k.PublicKey
+	default:
+		k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.NoError(t, err)
+		privKey = k
+		pubKey = &k.PublicKey
+	}
+
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: cfg.cn},
+		NotBefore:             cfg.notBefore,
+		NotAfter:              cfg.notAfter,
+		BasicConstraintsValid: cfg.isCA,
+		IsCA:                  cfg.isCA,
+	}
+	if cfg.isCA {
+		tmpl.KeyUsage = x509.KeyUsageCertSign | x509.KeyUsageCRLSign
+	} else {
+		tmpl.KeyUsage = x509.KeyUsageDigitalSignature
+	}
+
+	parent := tmpl
+	signerKey := privKey
+	if cfg.parent != nil {
+		parent = cfg.parent
+		signerKey = cfg.parentKey
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, parent, pubKey, signerKey)
+	require.NoError(t, err)
+
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+
+	return cert, privKey, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}

--- a/internal/validation/errors.go
+++ b/internal/validation/errors.go
@@ -1,0 +1,47 @@
+package validation
+
+import (
+	"errors"
+	"fmt"
+)
+
+type (
+	// Error is a single validation failure for a named subject and field.
+	Error struct {
+		Subject string // identifier of the thing being validated (e.g. a hostname or cert CN)
+		Field   string // attribute or property that failed (e.g. "expiry", "key_type")
+		Message string // human-readable description of the failure
+	}
+
+	// Errors is a collection of Error values.
+	Errors []Error
+)
+
+// Error implements the error interface.
+func (e Error) Error() string {
+	return fmt.Sprintf("%s: %s: %s", e.Subject, e.Field, e.Message)
+}
+
+// Error implements the error interface, joining all individual errors.
+func (ve Errors) Error() string {
+	if len(ve) == 0 {
+		return ""
+	}
+
+	errs := make([]error, len(ve))
+	for i, e := range ve {
+		errs[i] = e
+	}
+
+	return errors.Join(errs...).Error()
+}
+
+// Unwrap returns each Error as an individual error, enabling errors.As and errors.Is traversal.
+func (ve Errors) Unwrap() []error {
+	errs := make([]error, len(ve))
+	for i, e := range ve {
+		errs[i] = e
+	}
+
+	return errs
+}

--- a/internal/validation/errors_test.go
+++ b/internal/validation/errors_test.go
@@ -1,0 +1,162 @@
+package validation_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/temporalio/temporal-proxy/internal/validation"
+)
+
+func TestErrorError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		subject  string
+		field    string
+		message  string
+		expected string
+	}{
+		{
+			name:     "basic format",
+			subject:  "example.com",
+			field:    "expiry",
+			message:  "certificate has expired",
+			expected: `example.com: expiry: certificate has expired`,
+		},
+		{
+			name:     "with special characters",
+			subject:  "*.temporal.io",
+			field:    "key_type",
+			message:  "expected RSA but got ECDSA",
+			expected: `*.temporal.io: key_type: expected RSA but got ECDSA`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ve := validation.Error{
+				Subject: tt.subject,
+				Field:   tt.field,
+				Message: tt.message,
+			}
+			require.Equal(t, tt.expected, ve.Error())
+		})
+	}
+}
+
+func TestErrorsError(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty slice returns empty string", func(t *testing.T) {
+		t.Parallel()
+		ve := validation.Errors{}
+		require.Equal(t, "", ve.Error())
+	})
+
+	t.Run("single error", func(t *testing.T) {
+		t.Parallel()
+		ve := validation.Errors{
+			{
+				Subject: "cert1.com",
+				Field:   "expiry",
+				Message: "expired",
+			},
+		}
+		errStr := ve.Error()
+		require.Contains(t, errStr, `cert1.com: expiry: expired`)
+	})
+
+	t.Run("multiple errors", func(t *testing.T) {
+		t.Parallel()
+		ve := validation.Errors{
+			{
+				Subject: "cert1.com",
+				Field:   "expiry",
+				Message: "expired",
+			},
+			{
+				Subject: "cert2.com",
+				Field:   "is_ca",
+				Message: "not a CA certificate",
+			},
+			{
+				Subject: "cert3.com",
+				Field:   "signature_algorithm",
+				Message: "unsupported algorithm",
+			},
+		}
+		errStr := ve.Error()
+		require.Contains(t, errStr, `cert1.com: expiry: expired`)
+		require.Contains(t, errStr, `cert2.com: is_ca: not a CA certificate`)
+		require.Contains(t, errStr, `cert3.com: signature_algorithm: unsupported algorithm`)
+	})
+}
+
+func TestErrorsUnwrap(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty slice", func(t *testing.T) {
+		t.Parallel()
+		ve := validation.Errors{}
+		unwrapped := ve.Unwrap()
+		require.Len(t, unwrapped, 0)
+	})
+
+	t.Run("single error", func(t *testing.T) {
+		t.Parallel()
+		ve := validation.Errors{
+			{
+				Subject: "cert1.com",
+				Field:   "expiry",
+				Message: "expired",
+			},
+		}
+		unwrapped := ve.Unwrap()
+		require.Len(t, unwrapped, 1)
+	})
+
+	t.Run("multiple errors", func(t *testing.T) {
+		t.Parallel()
+		ve := validation.Errors{
+			{
+				Subject: "cert1.com",
+				Field:   "expiry",
+				Message: "expired",
+			},
+			{
+				Subject: "cert2.com",
+				Field:   "is_ca",
+				Message: "not a CA certificate",
+			},
+		}
+		unwrapped := ve.Unwrap()
+		require.Len(t, unwrapped, 2)
+	})
+}
+
+func TestErrorsAsError(t *testing.T) {
+	t.Parallel()
+
+	ve := validation.Errors{
+		{
+			Subject: "cert1.com",
+			Field:   "expiry",
+			Message: "expired",
+		},
+		{
+			Subject: "cert2.com",
+			Field:   "is_ca",
+			Message: "not a CA certificate",
+		},
+	}
+
+	var validationErr validation.Error
+	require.True(t, errors.As(ve, &validationErr))
+	require.Equal(t, "cert1.com", validationErr.Subject)
+	require.Equal(t, "expiry", validationErr.Field)
+	require.Equal(t, "expired", validationErr.Message)
+}


### PR DESCRIPTION
Adds a new internal/validation package providing generic error types (validation.Error and validation.Errors) for representing structured validation failures. Each error carries a Subject (the thing being validated), a Field (the attribute that failed), and a Message (human-readable explanation), and the collection type supports full errors.As/errors.Is traversal via Unwrap.

Building on that I've added internal/validation/certs, which implements PEM certificate validation through a composable Validator function type and a certs.Validate entry point. Bundled validators cover the common cases: NotExpired (rejects expired and not-yet-valid certificates), IsCA, SecureAlgorithm (weak signature algorithms and cipher-suite key-type compatibility), and CAChain (chain-of-trust verification against a provided CA PEM).