### PR TITLE
[config]: Add upstream cluster configuration

### DIFF
--- a/dev/Procfile
+++ b/dev/Procfile
@@ -1,0 +1,2 @@
+temporal: temporal server start-dev -n ns1.remote -n ns2.remote
+proxy: go run ./cmd/proxy serve -c dev/config.yaml

--- a/dev/config-mtls.yaml
+++ b/dev/config-mtls.yaml
@@ -1,5 +1,0 @@
-hostPort: :8444
-tls:
-  ca: dev/certs/ca.crt
-  cert: dev/certs/server.crt
-  key: dev/certs/server.key

--- a/dev/config.yaml
+++ b/dev/config.yaml
@@ -1,1 +1,16 @@
-hostPort: :8443
+hostPort: :8444
+tls:
+  ca: dev/certs/ca.crt
+  cert: dev/certs/server.crt
+  key: dev/certs/server.key
+
+upstream:
+  hostPort: localhost:7233
+  namespaces:
+    rules:
+      # Always add .remote on the way out, and remove it on the way in.
+      suffix: .remote
+      overrides:
+        # Makes ns2 and ns3 both use ns2.remote on the remote cluster.
+        - local: ns3
+          remote: ns2.remote

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,7 +12,8 @@ import (
 type (
 	// Config is the top-level codec-server configuration.
 	Config struct {
-		Listen ListenConfig `yaml:",inline"`
+		Listen   ListenConfig `yaml:",inline"`
+		Upstream Upstream     `yaml:"upstream"`
 	}
 )
 
@@ -47,5 +48,9 @@ func LoadFile(path string) (*Config, error) {
 }
 
 func (c *Config) Validate() error {
-	return validation.Validate("", validation.Nested("", &c.Listen))
+	return validation.Validate(
+		"",
+		validation.Nested("", &c.Listen),
+		validation.Nested("upstream", &c.Upstream),
+	)
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -133,6 +133,10 @@ func TestLoadFile_MissingFile(t *testing.T) {
 func TestConfig_Validate(t *testing.T) {
 	t.Parallel()
 
+	validUpstream := config.Upstream{
+		Listen: config.ListenConfig{HostPort: "127.0.0.1:7233"},
+	}
+
 	tests := []struct {
 		name       string
 		cfg        *config.Config
@@ -141,13 +145,15 @@ func TestConfig_Validate(t *testing.T) {
 		{
 			name: "valid hostPort, no TLS",
 			cfg: &config.Config{
-				Listen: config.ListenConfig{HostPort: ":8080"},
+				Listen:   config.ListenConfig{HostPort: ":8080"},
+				Upstream: validUpstream,
 			},
 		},
 		{
 			name: "invalid hostPort surfaces from ListenConfig",
 			cfg: &config.Config{
-				Listen: config.ListenConfig{HostPort: "localhost"},
+				Listen:   config.ListenConfig{HostPort: "localhost"},
+				Upstream: validUpstream,
 			},
 			wantTuples: [][2]string{{"", "hostPort"}},
 		},
@@ -158,6 +164,7 @@ func TestConfig_Validate(t *testing.T) {
 					HostPort: ":8080",
 					TLS:      &config.TLSConfig{}, // empty -> creds.TLS PEM read failures
 				},
+				Upstream: validUpstream,
 			},
 			wantTuples: [][2]string{
 				{"tls", "cert"},
@@ -171,12 +178,20 @@ func TestConfig_Validate(t *testing.T) {
 					HostPort: "localhost",
 					TLS:      &config.TLSConfig{},
 				},
+				Upstream: validUpstream,
 			},
 			wantTuples: [][2]string{
 				{"", "hostPort"},
 				{"tls", "cert"},
 				{"tls", "key"},
 			},
+		},
+		{
+			name: "missing upstream hostPort surfaces with upstream subject",
+			cfg: &config.Config{
+				Listen: config.ListenConfig{HostPort: ":8080"},
+			},
+			wantTuples: [][2]string{{"upstream", "hostPort"}},
 		},
 	}
 

--- a/internal/config/upstream.go
+++ b/internal/config/upstream.go
@@ -1,0 +1,130 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/temporalio/temporal-proxy/pkg/validation"
+)
+
+type (
+	// Upstream describes a single upstream Temporal cluster the proxy connects
+	// workers to along with configuration for that remote cluster.
+	Upstream struct {
+		Listen     ListenConfig    `yaml:",inline"`
+		Namespaces NamespaceConfig `yaml:"namespaces"`
+	}
+
+	// NamespaceConfig groups the namespace translation rules for an upstream.
+	NamespaceConfig struct {
+		Rules NamespaceRules `yaml:"rules"`
+	}
+
+	// NamespaceRules translates namespace names between the local view that
+	// workers use and the remote names registered on the upstream cluster.
+	//
+	// The default translation is to wrap or unwrap a Prefix and Suffix:
+	// Remote("payments") returns Prefix+"payments"+Suffix, and Local of that
+	// returns "payments". When an explicit Overrides entry matches, the
+	// override takes precedence over the prefix/suffix rule.
+	NamespaceRules struct {
+		Prefix    string             `yaml:"prefix"`
+		Suffix    string             `yaml:"suffix"`
+		Overrides []NamespaceMapping `yaml:"overrides"`
+
+		localToRemote map[string]string
+		remoteToLocal map[string]string
+	}
+
+	// NamespaceMapping is one explicit local/remote namespace pair, used to
+	// short-circuit the prefix/suffix rule for namespaces whose names do not
+	// follow the convention.
+	NamespaceMapping struct {
+		Local  string `yaml:"local"`
+		Remote string `yaml:"remote"`
+	}
+)
+
+func (u *Upstream) Validate() error {
+	return validation.Validate(
+		"",
+		validation.Nested("", &u.Listen),
+		validation.Nested("namespaces", &u.Namespaces),
+	)
+}
+
+func (c *NamespaceConfig) Validate() error {
+	return validation.Validate(
+		"",
+		validation.Nested("rules", &c.Rules),
+	)
+}
+
+// Local returns the local namespace name that corresponds to remoteNS. If an
+// override matches it wins; otherwise the configured Prefix and Suffix are
+// stripped from remoteNS.
+func (r *NamespaceRules) Local(remoteNS string) string {
+	if v, ok := r.remoteToLocal[remoteNS]; ok {
+		return v
+	}
+
+	return strings.TrimPrefix(strings.TrimSuffix(remoteNS, r.Suffix), r.Prefix)
+}
+
+// Remote returns the remote namespace name that corresponds to localNS. If an
+// override matches it wins; otherwise localNS is wrapped with the configured
+// Prefix and Suffix.
+func (r *NamespaceRules) Remote(localNS string) string {
+	if v, ok := r.localToRemote[localNS]; ok {
+		return v
+	}
+
+	return fmt.Sprintf("%s%s%s", r.Prefix, localNS, r.Suffix)
+}
+
+func (r *NamespaceRules) UnmarshalYAML(unmarshal func(any) error) error {
+	type raw NamespaceRules
+
+	var decoded raw
+	if err := unmarshal(&decoded); err != nil {
+		return err
+	}
+
+	*r = NamespaceRules(decoded)
+	r.localToRemote = make(map[string]string)
+	r.remoteToLocal = make(map[string]string)
+	for _, mapping := range r.Overrides {
+		r.localToRemote[mapping.Local] = mapping.Remote
+		r.remoteToLocal[mapping.Remote] = mapping.Local
+	}
+
+	return nil
+}
+
+func (r *NamespaceRules) Validate() error {
+	if len(r.Overrides) == 0 {
+		return nil
+	}
+
+	locals := make([]string, len(r.Overrides))
+	remotes := make([]string, len(r.Overrides))
+	rules := make([]validation.Rule, len(r.Overrides)+2)
+
+	for i := range r.Overrides {
+		locals[i] = r.Overrides[i].Local
+		remotes[i] = r.Overrides[i].Remote
+		rules[i+2] = validation.Nested(fmt.Sprintf("overrides[%d]", i), &r.Overrides[i])
+	}
+
+	rules[0] = validation.Field("overrides[local]", locals, validation.Unique[string]())
+	rules[1] = validation.Field("overrides[remote]", remotes, validation.Unique[string]())
+	return validation.Validate("", rules...)
+}
+
+func (m *NamespaceMapping) Validate() error {
+	return validation.Validate(
+		"",
+		validation.Field("local", m.Local, validation.Required[string]()),
+		validation.Field("remote", m.Remote, validation.Required[string]()),
+	)
+}

--- a/internal/config/upstream_test.go
+++ b/internal/config/upstream_test.go
@@ -1,0 +1,461 @@
+package config_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/temporalio/temporal-proxy/internal/config"
+	"github.com/temporalio/temporal-proxy/pkg/validation"
+)
+
+func TestNamespaceRules_Local(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		yaml     string
+		remoteNS string
+		want     string
+	}{
+		{
+			name:     "no prefix, suffix, or override returns input unchanged",
+			yaml:     "upstream:\n  namespaces:\n    rules: {}\n",
+			remoteNS: "payments",
+			want:     "payments",
+		},
+		{
+			name:     "strips configured prefix",
+			yaml:     "upstream:\n  namespaces:\n    rules:\n      prefix: \"acme-\"\n",
+			remoteNS: "acme-payments",
+			want:     "payments",
+		},
+		{
+			name:     "strips configured suffix",
+			yaml:     "upstream:\n  namespaces:\n    rules:\n      suffix: \".cloud\"\n",
+			remoteNS: "payments.cloud",
+			want:     "payments",
+		},
+		{
+			name:     "strips both prefix and suffix",
+			yaml:     "upstream:\n  namespaces:\n    rules:\n      prefix: \"acme-\"\n      suffix: \".cloud\"\n",
+			remoteNS: "acme-payments.cloud",
+			want:     "payments",
+		},
+		{
+			name: "override wins over prefix/suffix",
+			yaml: "upstream:\n  namespaces:\n    rules:\n" +
+				"      prefix: \"acme-\"\n" +
+				"      suffix: \".cloud\"\n" +
+				"      overrides:\n" +
+				"        - local: billing\n" +
+				"          remote: legacy-billing-prod\n",
+			remoteNS: "legacy-billing-prod",
+			want:     "billing",
+		},
+		{
+			name: "no override match falls back to prefix/suffix stripping",
+			yaml: "upstream:\n  namespaces:\n    rules:\n" +
+				"      prefix: \"acme-\"\n" +
+				"      overrides:\n" +
+				"        - local: billing\n" +
+				"          remote: legacy-billing\n",
+			remoteNS: "acme-payments",
+			want:     "payments",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg, err := config.Load(strings.NewReader(tc.yaml))
+			require.NoError(t, err)
+			require.Equal(t, tc.want, cfg.Upstream.Namespaces.Rules.Local(tc.remoteNS))
+		})
+	}
+}
+
+func TestNamespaceRules_Remote(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		yaml    string
+		localNS string
+		want    string
+	}{
+		{
+			name:    "no prefix, suffix, or override returns input unchanged",
+			yaml:    "upstream:\n  namespaces:\n    rules: {}\n",
+			localNS: "payments",
+			want:    "payments",
+		},
+		{
+			name:    "applies configured prefix",
+			yaml:    "upstream:\n  namespaces:\n    rules:\n      prefix: \"acme-\"\n",
+			localNS: "payments",
+			want:    "acme-payments",
+		},
+		{
+			name:    "applies configured suffix",
+			yaml:    "upstream:\n  namespaces:\n    rules:\n      suffix: \".cloud\"\n",
+			localNS: "payments",
+			want:    "payments.cloud",
+		},
+		{
+			name:    "applies both prefix and suffix",
+			yaml:    "upstream:\n  namespaces:\n    rules:\n      prefix: \"acme-\"\n      suffix: \".cloud\"\n",
+			localNS: "payments",
+			want:    "acme-payments.cloud",
+		},
+		{
+			name: "override wins over prefix/suffix",
+			yaml: "upstream:\n  namespaces:\n    rules:\n" +
+				"      prefix: \"acme-\"\n" +
+				"      suffix: \".cloud\"\n" +
+				"      overrides:\n" +
+				"        - local: billing\n" +
+				"          remote: legacy-billing-prod\n",
+			localNS: "billing",
+			want:    "legacy-billing-prod",
+		},
+		{
+			name: "no override match falls back to prefix/suffix wrapping",
+			yaml: "upstream:\n  namespaces:\n    rules:\n" +
+				"      prefix: \"acme-\"\n" +
+				"      overrides:\n" +
+				"        - local: billing\n" +
+				"          remote: legacy-billing\n",
+			localNS: "payments",
+			want:    "acme-payments",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg, err := config.Load(strings.NewReader(tc.yaml))
+			require.NoError(t, err)
+			require.Equal(t, tc.want, cfg.Upstream.Namespaces.Rules.Remote(tc.localNS))
+		})
+	}
+}
+
+func TestNamespaceMapping_Validate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		mapping  *config.NamespaceMapping
+		wantErrs []validation.Error
+	}{
+		{
+			name:    "both local and remote set",
+			mapping: &config.NamespaceMapping{Local: "billing", Remote: "legacy-billing"},
+		},
+		{
+			name:    "missing local",
+			mapping: &config.NamespaceMapping{Remote: "legacy-billing"},
+			wantErrs: []validation.Error{
+				{Field: "local", Message: "is required"},
+			},
+		},
+		{
+			name:    "missing remote",
+			mapping: &config.NamespaceMapping{Local: "billing"},
+			wantErrs: []validation.Error{
+				{Field: "remote", Message: "is required"},
+			},
+		},
+		{
+			name:    "both missing",
+			mapping: &config.NamespaceMapping{},
+			wantErrs: []validation.Error{
+				{Field: "local", Message: "is required"},
+				{Field: "remote", Message: "is required"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tt.mapping.Validate()
+			if len(tt.wantErrs) == 0 {
+				require.NoError(t, err)
+				return
+			}
+
+			var errs validation.Errors
+			require.True(t, errors.As(err, &errs), "expected validation.Errors, got %T", err)
+			require.ElementsMatch(t, tt.wantErrs, []validation.Error(errs))
+		})
+	}
+}
+
+func TestNamespaceRules_Validate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		rules      *config.NamespaceRules
+		wantTuples [][2]string // (Subject, Field); empty slice means no error expected
+	}{
+		{
+			name:  "no overrides yields no error",
+			rules: &config.NamespaceRules{Prefix: "acme-", Suffix: ".cloud"},
+		},
+		{
+			name: "valid overrides yield no error",
+			rules: &config.NamespaceRules{
+				Overrides: []config.NamespaceMapping{
+					{Local: "billing", Remote: "legacy-billing"},
+					{Local: "payments", Remote: "acme-payments"},
+				},
+			},
+		},
+		{
+			name: "single invalid override stamped with its index",
+			rules: &config.NamespaceRules{
+				Overrides: []config.NamespaceMapping{
+					{Remote: "legacy-billing"},
+				},
+			},
+			wantTuples: [][2]string{
+				{"overrides[0]", "local"},
+			},
+		},
+		{
+			name: "invalid overrides keep their own indices",
+			rules: &config.NamespaceRules{
+				Overrides: []config.NamespaceMapping{
+					{Local: "billing", Remote: "legacy-billing"},
+					{Local: "payments"},
+					{Remote: "legacy-orders"},
+				},
+			},
+			wantTuples: [][2]string{
+				{"overrides[1]", "remote"},
+				{"overrides[2]", "local"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tt.rules.Validate()
+			if len(tt.wantTuples) == 0 {
+				require.NoError(t, err)
+				return
+			}
+
+			var errs validation.Errors
+			require.True(t, errors.As(err, &errs), "expected validation.Errors, got %T", err)
+
+			got := make([][2]string, len(errs))
+			for i, e := range errs {
+				got[i] = [2]string{e.Subject, e.Field}
+			}
+
+			require.ElementsMatch(t, tt.wantTuples, got)
+		})
+	}
+}
+
+func TestNamespaceRules_Validate_Uniqueness(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		rules    *config.NamespaceRules
+		wantErrs []validation.Error
+	}{
+		{
+			name: "duplicate local names reported on overrides field",
+			rules: &config.NamespaceRules{
+				Overrides: []config.NamespaceMapping{
+					{Local: "billing", Remote: "legacy-billing"},
+					{Local: "billing", Remote: "legacy-payments"},
+				},
+			},
+			wantErrs: []validation.Error{
+				{Field: "overrides[local]", Message: "contains duplicate value: billing"},
+			},
+		},
+		{
+			name: "duplicate remote names reported on overrides field",
+			rules: &config.NamespaceRules{
+				Overrides: []config.NamespaceMapping{
+					{Local: "billing", Remote: "legacy"},
+					{Local: "payments", Remote: "legacy"},
+				},
+			},
+			wantErrs: []validation.Error{
+				{Field: "overrides[remote]", Message: "contains duplicate value: legacy"},
+			},
+		},
+		{
+			name: "duplicate locals and remotes both reported",
+			rules: &config.NamespaceRules{
+				Overrides: []config.NamespaceMapping{
+					{Local: "billing", Remote: "legacy"},
+					{Local: "billing", Remote: "legacy"},
+				},
+			},
+			wantErrs: []validation.Error{
+				{Field: "overrides[local]", Message: "contains duplicate value: billing"},
+				{Field: "overrides[remote]", Message: "contains duplicate value: legacy"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tt.rules.Validate()
+			var errs validation.Errors
+			require.True(t, errors.As(err, &errs), "expected validation.Errors, got %T", err)
+			require.ElementsMatch(t, tt.wantErrs, []validation.Error(errs))
+		})
+	}
+}
+
+func TestNamespaceConfig_Validate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		cfg        *config.NamespaceConfig
+		wantTuples [][2]string
+	}{
+		{
+			name: "empty config yields no error",
+			cfg:  &config.NamespaceConfig{},
+		},
+		{
+			name: "rules failure surfaces with override-index subject preserved",
+			cfg: &config.NamespaceConfig{
+				Rules: config.NamespaceRules{
+					Overrides: []config.NamespaceMapping{
+						{Local: "billing"},
+					},
+				},
+			},
+			wantTuples: [][2]string{
+				{"overrides[0]", "remote"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tt.cfg.Validate()
+			if len(tt.wantTuples) == 0 {
+				require.NoError(t, err)
+				return
+			}
+
+			var errs validation.Errors
+			require.True(t, errors.As(err, &errs), "expected validation.Errors, got %T", err)
+
+			got := make([][2]string, len(errs))
+			for i, e := range errs {
+				got[i] = [2]string{e.Subject, e.Field}
+			}
+
+			require.ElementsMatch(t, tt.wantTuples, got)
+		})
+	}
+}
+
+func TestUpstream_Validate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		upstream   *config.Upstream
+		wantTuples [][2]string
+	}{
+		{
+			name: "valid listen and no overrides",
+			upstream: &config.Upstream{
+				Listen: config.ListenConfig{HostPort: "127.0.0.1:7233"},
+			},
+		},
+		{
+			name: "invalid hostPort surfaces from Listen",
+			upstream: &config.Upstream{
+				Listen: config.ListenConfig{HostPort: "not-a-host-port"},
+			},
+			wantTuples: [][2]string{
+				{"", "hostPort"},
+			},
+		},
+		{
+			name: "namespace override failure surfaces with override-index subject",
+			upstream: &config.Upstream{
+				Listen: config.ListenConfig{HostPort: "127.0.0.1:7233"},
+				Namespaces: config.NamespaceConfig{
+					Rules: config.NamespaceRules{
+						Overrides: []config.NamespaceMapping{
+							{Local: "billing"},
+						},
+					},
+				},
+			},
+			wantTuples: [][2]string{
+				{"overrides[0]", "remote"},
+			},
+		},
+		{
+			name: "listen and namespace failures aggregate",
+			upstream: &config.Upstream{
+				Listen: config.ListenConfig{HostPort: "not-a-host-port"},
+				Namespaces: config.NamespaceConfig{
+					Rules: config.NamespaceRules{
+						Overrides: []config.NamespaceMapping{
+							{},
+						},
+					},
+				},
+			},
+			wantTuples: [][2]string{
+				{"", "hostPort"},
+				{"overrides[0]", "local"},
+				{"overrides[0]", "remote"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tt.upstream.Validate()
+			if len(tt.wantTuples) == 0 {
+				require.NoError(t, err)
+				return
+			}
+
+			var errs validation.Errors
+			require.True(t, errors.As(err, &errs), "expected validation.Errors, got %T", err)
+
+			got := make([][2]string, len(errs))
+			for i, e := range errs {
+				got[i] = [2]string{e.Subject, e.Field}
+			}
+
+			require.ElementsMatch(t, tt.wantTuples, got)
+		})
+	}
+}

--- a/internal/server/fx_test.go
+++ b/internal/server/fx_test.go
@@ -26,6 +26,9 @@ func TestModule(t *testing.T) {
 			t,
 			fx.Supply(&config.Config{
 				Listen: config.ListenConfig{HostPort: "127.0.0.1:0"},
+				Upstream: config.Upstream{
+					Listen: config.ListenConfig{HostPort: "127.0.0.1:7233"},
+				},
 			}),
 		)
 
@@ -48,7 +51,12 @@ func TestModule(t *testing.T) {
 		app := newTestApp(
 			t,
 			fx.Supply(
-				&config.Config{Listen: config.ListenConfig{HostPort: "127.0.0.1:0"}},
+				&config.Config{
+					Listen: config.ListenConfig{HostPort: "127.0.0.1:0"},
+					Upstream: config.Upstream{
+						Listen: config.ListenConfig{HostPort: "127.0.0.1:7233"},
+					},
+				},
 				fx.Annotate(hc, fx.As(new(server.HealthCheck))),
 			),
 			fx.Provide(func() log.Logger { return log.NewNoopLogger() }),
@@ -107,6 +115,9 @@ func TestModule(t *testing.T) {
 			t,
 			fx.Supply(&config.Config{
 				Listen: config.ListenConfig{HostPort: "1.2.3.4:0"},
+				Upstream: config.Upstream{
+					Listen: config.ListenConfig{HostPort: "127.0.0.1:7233"},
+				},
 			}),
 		)
 

--- a/mise.toml
+++ b/mise.toml
@@ -3,6 +3,8 @@
 experimental = true
 
 [tools]
+"github:mattn/goreman" = "latest"
+"github:temporalio/cli" = "latest"
 go = "1.26"
 mkcert = "1.4.4"
 
@@ -29,13 +31,8 @@ run = """
 [tasks.server]
 description = "Run the server locally"
 interactive = true
-run = "go run ./cmd/proxy serve -c dev/config.yaml"
-
-[tasks.server-tls]
-description = "Run the server locally with mTLS"
-interactive = true
 depends = ["gen-certs"]
-run = "go run ./cmd/proxy serve -c dev/config-mtls.yaml"
+run = "goreman -exit-on-error -set-ports=false -f dev/Procfile start"
 
 ################################################################################
 # Development Tasks
@@ -76,12 +73,7 @@ hide = true
 dir = "dev/certs"
 env.CAROOT = "."
 sources = ["mise.toml"]
-outputs = [
-  "server.crt",
-  "client.crt",
-  "extserver.crt",
-  "ca.crt",
-]
+outputs = ["server.crt", "client.crt", "extserver.crt", "ca.crt"]
 run = [
   "rm -f *.pem *.key *.crt",
   "mkcert -key-file server.key -cert-file server.crt localhost 127.0.0.1 ::1 2>/dev/null",

--- a/pkg/validation/checks.go
+++ b/pkg/validation/checks.go
@@ -4,17 +4,34 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strconv"
+	"strings"
 )
+
+var errInvalidHostPort = errors.New("is not a valid host:port")
 
 // Check verifies a single value of type V. A nil return means valid.
 type Check[V any] func(V) error
 
-// IsHostPort validates that s is a host:port pair accepted by net.ResolveTCPAddr.
-// Both "host:port" and ":port" (listen-on-all-interfaces) forms are valid.
+// IsHostPort validates that s is syntactically a host:port pair. The check is
+// purely lexical: no DNS lookup, no /etc/services port resolution. Both
+// "host:port" and ":port" (listen-on-all-interfaces) forms are valid, and the
+// port must be a decimal integer in [0, 65535]. Port 0 is accepted because it
+// is a valid listener form meaning "let the OS pick".
 func IsHostPort() Check[string] {
 	return func(s string) error {
-		if _, err := net.ResolveTCPAddr("tcp", s); err != nil {
-			return errors.New("is not a valid host:port")
+		host, port, err := net.SplitHostPort(s)
+		if err != nil {
+			return errInvalidHostPort
+		}
+
+		if strings.ContainsAny(host, "/") {
+			return errInvalidHostPort
+		}
+
+		p, err := strconv.Atoi(port)
+		if err != nil || p < 0 || p > 65535 {
+			return errInvalidHostPort
 		}
 
 		return nil

--- a/pkg/validation/checks_test.go
+++ b/pkg/validation/checks_test.go
@@ -117,8 +117,16 @@ func TestIsHostPort(t *testing.T) {
 	}{
 		{name: "host and port", in: "localhost:8080"},
 		{name: "ipv4 and port", in: "127.0.0.1:8080"},
+		{name: "ipv6 and port", in: "[::1]:8080"},
 		{name: "wildcard host", in: ":8080"},
+		{name: "wildcard port zero", in: ":0"},
+		// Reserved TLD per RFC 2606; passing this proves we no longer do DNS lookup.
+		{name: "non-resolvable hostname is syntactically valid", in: "host.invalid:8080"},
 		{name: "missing port", in: "localhost", wantErr: true},
+		{name: "empty port after colon", in: "localhost:", wantErr: true},
+		{name: "non-numeric port", in: "localhost:http", wantErr: true},
+		{name: "port out of range", in: "localhost:70000", wantErr: true},
+		{name: "negative port", in: "localhost:-1", wantErr: true},
 		{name: "url with scheme", in: "https://example.com:8080", wantErr: true},
 	}
 


### PR DESCRIPTION
The proxy needs to know which Temporal cluster to route worker traffic to and how namespace names map between the local view that workers use and the remote names registered on the upstream. Until now there was no way to express either, so the proxy could only act as a listener with no notion of a destination.

This change adds an Upstream block to the top-level config, modeled around a single upstream cluster for now. NamespaceRules translates names in both directions: by default it wraps and unwraps a configurable Prefix/Suffix, and Overrides short-circuit that for namespaces whose names do not follow the convention (e.g. legacy names, or collapsing multiple local namespaces onto one remote).