### PR TITLE
[namespace]: Add proto-walking Translator

### DIFF
--- a/pkg/namespace/doc.go
+++ b/pkg/namespace/doc.go
@@ -1,0 +1,2 @@
+// Package namespace provides info and utilities for working with Temporal namespaces.
+package namespace

--- a/pkg/namespace/proto_test.go
+++ b/pkg/namespace/proto_test.go
@@ -1,0 +1,99 @@
+package namespace_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	_ "go.temporal.io/api/operatorservice/v1"
+	_ "go.temporal.io/api/workflowservice/v1"
+	_ "go.temporal.io/server/api/adminservice/v1"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+
+	"github.com/temporalio/temporal-proxy/pkg/namespace"
+)
+
+// Services to walk to ensure we're not missing any namespace field coverage.
+// Don't forget the _ import!
+//
+// NB: We should consider parameterizing this by version so we could do
+// forward/backward compatibility tests.
+var servicesToTest = []protoreflect.FullName{
+	"temporal.api.workflowservice.v1.WorkflowService",
+	"temporal.api.operatorservice.v1.OperatorService",
+	"temporal.server.api.adminservice.v1.AdminService",
+}
+
+// TestNamespaceFieldCoverage walks every request and response message reachable
+// from the mentioned services and asserts that every string field whose proto
+// name carries namespace meaning is recognized by the translator. When Temporal
+// adds a new namespace field, this test fails with the exact field name to
+// investigate.
+func TestNamespaceFieldCoverage(t *testing.T) {
+	t.Parallel()
+
+	visited := map[protoreflect.FullName]bool{}
+	var missed []string
+
+	for _, svc := range servicesToTest {
+		desc, err := protoregistry.GlobalFiles.FindDescriptorByName(svc)
+		require.NoError(t, err, "service %q not registered; ensure its package is imported", svc)
+
+		sd, ok := desc.(protoreflect.ServiceDescriptor)
+		require.True(t, ok, "descriptor %q is not a service descriptor", svc)
+
+		methods := sd.Methods()
+		for i := range methods.Len() {
+			m := methods.Get(i)
+			scanMessageDescriptor(m.Input(), visited, &missed)
+			scanMessageDescriptor(m.Output(), visited, &missed)
+		}
+	}
+
+	require.Empty(t, missed,
+		"unrecognized namespace-bearing string fields found:\n  %s\n\n"+
+			"Each of these is a string field whose proto name contains \"namespace\" and is not\n"+
+			"in the translator's allowlist. Add it to namespaceNameFields in fields.go (if the\n"+
+			"field name globally denotes a namespace name), or to messageScopedNamespaceFields\n"+
+			"(if only certain message types use this field as a namespace name).",
+		strings.Join(missed, "\n  "))
+}
+
+func scanMessageDescriptor(md protoreflect.MessageDescriptor, visited map[protoreflect.FullName]bool, missed *[]string) {
+	if visited[md.FullName()] {
+		return
+	}
+	visited[md.FullName()] = true
+
+	fields := md.Fields()
+	for i := range fields.Len() {
+		fd := fields.Get(i)
+
+		if fd.IsMap() {
+			if mv := fd.MapValue(); mv.Kind() == protoreflect.MessageKind || mv.Kind() == protoreflect.GroupKind {
+				scanMessageDescriptor(mv.Message(), visited, missed)
+			}
+			continue
+		}
+		if fd.Kind() == protoreflect.MessageKind || fd.Kind() == protoreflect.GroupKind {
+			scanMessageDescriptor(fd.Message(), visited, missed)
+			continue
+		}
+		if fd.Kind() != protoreflect.StringKind {
+			continue
+		}
+
+		field := string(fd.Name())
+		if !strings.Contains(field, "namespace") {
+			continue
+		}
+
+		msg := string(md.FullName())
+		if namespace.IsKnownProtoField(field, msg) {
+			continue
+		}
+
+		*missed = append(*missed, msg+"."+field)
+	}
+}

--- a/pkg/namespace/translator.go
+++ b/pkg/namespace/translator.go
@@ -1,0 +1,180 @@
+package namespace
+
+import (
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+var (
+	// namespaceNameFields lists proto field names that, wherever they appear,
+	// carry a Temporal namespace name. Adding an entry expands the set of fields
+	// the translator rewrites.
+	namespaceNameFields = map[string]struct{}{
+		"namespace":                 {},
+		"workflow_namespace":        {},
+		"parent_workflow_namespace": {},
+		"deleted_namespace":         {},
+	}
+
+	// ignoredNamespaceFields contains field with the word namespace in them, but
+	// which are not to be translated.
+	//
+	// These fields quack like namespace fields, but they aren't ducks.
+	ignoredNamespaceFields = map[string]struct{}{
+		"namespace_id":                 {},
+		"namespace_ids":                {},
+		"parent_namespace_id":          {},
+		"parent_workflow_namespace_id": {},
+	}
+
+	// messageScopedNamespaceFields handles the cases where a namespace name lives
+	// in a generically named field (e.g. NamespaceInfo.name) that would be unsafe
+	// to add to the global allowlist.
+	messageScopedNamespaceFields = map[protoreflect.FullName]map[string]struct{}{
+		"temporal.api.namespace.v1.NamespaceInfo": {"name": {}},
+	}
+)
+
+type (
+	// Translator rewrites namespace-name string fields inside any
+	// [proto.Message] by delegating each value to a [Mapper]. It is safe to
+	// use concurrently as long as the underlying Mapper is.
+	Translator struct {
+		mapper Mapper
+	}
+
+	// Mapper converts namespace names between the proxy's local view and its
+	// remote (upstream) view. Implementations must be deterministic and should
+	// be cheap to call, since a single message may invoke them many times.
+	Mapper interface {
+		// Local returns the local namespace name for a remote one.
+		Local(string) string
+		// Remote returns the remote namespace name for a local one.
+		Remote(string) string
+	}
+
+	nilMapper struct{}
+)
+
+// New returns a [Translator] backed by m. A nil m is replaced with an
+// identity mapper, so the returned Translator never panics on nil and leaves
+// every namespace value unchanged.
+func New(m Mapper) *Translator {
+	t := &Translator{mapper: new(nilMapper)}
+	if m != nil {
+		t.mapper = m
+	}
+
+	return t
+}
+
+// IsKnownProtoField reports whether the translator recognizes the field named
+// fieldName on the message type identified by parentName. A field is
+// "recognized" if it is either translated (an entry in namespaceNameFields or
+// the scoped allowlist) or explicitly ignored (an entry in
+// ignoredNamespaceFields). parentName is the fully-qualified proto message
+// name (e.g. "temporal.api.namespace.v1.NamespaceInfo").
+func IsKnownProtoField(fieldName, parentName string) bool {
+	if _, ok := ignoredNamespaceFields[fieldName]; ok {
+		return true
+	}
+	return isNamespaceField(fieldName, messageScopedNamespaceFields[protoreflect.FullName(parentName)])
+}
+
+// ToLocal rewrites every namespace-name field in msg by passing the current
+// value through [Mapper.Local]. A nil msg is a no-op.
+func (t *Translator) ToLocal(msg proto.Message) {
+	t.translate(msg, t.mapper.Local)
+}
+
+// ToRemote rewrites every namespace-name field in msg by passing the current
+// value through [Mapper.Remote]. A nil msg is a no-op.
+func (t *Translator) ToRemote(msg proto.Message) {
+	t.translate(msg, t.mapper.Remote)
+}
+
+func (t *Translator) translate(msg proto.Message, fn func(string) string) {
+	if t == nil || t.mapper == nil || msg == nil {
+		return
+	}
+
+	t.walkMessage(msg.ProtoReflect(), fn)
+}
+
+func (t *Translator) walkMessage(m protoreflect.Message, fn func(string) string) {
+	if !m.IsValid() {
+		return
+	}
+
+	md := m.Descriptor()
+	scoped := messageScopedNamespaceFields[md.FullName()]
+	fields := md.Fields()
+
+	for i := range fields.Len() {
+		fd := fields.Get(i)
+		if !m.Has(fd) {
+			continue
+		}
+
+		switch {
+		case fd.IsMap():
+			t.walkMap(fd, m.Mutable(fd).Map(), fn)
+		case fd.IsList():
+			t.walkList(fd, m.Mutable(fd).List(), isNamespaceField(string(fd.Name()), scoped), fn)
+		case fd.Kind() == protoreflect.MessageKind, fd.Kind() == protoreflect.GroupKind:
+			t.walkMessage(m.Mutable(fd).Message(), fn)
+		case fd.Kind() == protoreflect.StringKind:
+			if isNamespaceField(string(fd.Name()), scoped) {
+				m.Set(fd, protoreflect.ValueOfString(fn(m.Get(fd).String())))
+			}
+		}
+	}
+}
+
+func (t *Translator) walkList(fd protoreflect.FieldDescriptor, list protoreflect.List, isNamespaceField bool, fn func(string) string) {
+	switch fd.Kind() {
+	case protoreflect.MessageKind, protoreflect.GroupKind:
+		for i := range list.Len() {
+			t.walkMessage(list.Get(i).Message(), fn)
+		}
+	case protoreflect.StringKind:
+		if !isNamespaceField {
+			return
+		}
+		for i := range list.Len() {
+			list.Set(i, protoreflect.ValueOfString(fn(list.Get(i).String())))
+		}
+	}
+}
+
+func (t *Translator) walkMap(fd protoreflect.FieldDescriptor, m protoreflect.Map, fn func(string) string) {
+	vk := fd.MapValue().Kind()
+	if vk != protoreflect.MessageKind && vk != protoreflect.GroupKind {
+		return
+	}
+
+	m.Range(func(_ protoreflect.MapKey, v protoreflect.Value) bool {
+		t.walkMessage(v.Message(), fn)
+		return true
+	})
+}
+
+func (m *nilMapper) Local(ns string) string  { return ns }
+func (m *nilMapper) Remote(ns string) string { return ns }
+
+// isNamespaceField reports whether a field's string value should be rewritten
+// by the translator. Fields in ignoredNamespaceFields return false even though
+// their names contain "namespace": they are identifiers, not names.
+func isNamespaceField(name string, scoped map[string]struct{}) bool {
+	if _, ok := namespaceNameFields[name]; ok {
+		return true
+	}
+
+	if scoped != nil {
+		if _, ok := scoped[name]; ok {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/namespace/translator_bench_test.go
+++ b/pkg/namespace/translator_bench_test.go
@@ -1,0 +1,36 @@
+package namespace_test
+
+import (
+	"testing"
+
+	failurepb "go.temporal.io/api/failure/v1"
+	namespacepb "go.temporal.io/api/namespace/v1"
+
+	"github.com/temporalio/temporal-proxy/pkg/namespace"
+)
+
+func BenchmarkTranslator_ToLocal_NamespaceInfo(b *testing.B) {
+	tr := namespace.New(nil)
+	msg := &namespacepb.NamespaceInfo{Name: "payments"}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		tr.ToLocal(msg)
+	}
+}
+
+// BenchmarkTranslator_ToLocal_DeepRecursion measures the cost of recursive
+// descent. Failure.Cause is a self-recursive proto field, so a chain of N
+// Failures forces the walker N levels deep through one message at each step.
+func BenchmarkTranslator_ToLocal_DeepRecursion(b *testing.B) {
+	tr := namespace.New(nil)
+	msg := &failurepb.Failure{Message: "leaf"}
+	for range 100 {
+		msg = &failurepb.Failure{Message: "level", Cause: msg}
+	}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		tr.ToLocal(msg)
+	}
+}

--- a/pkg/namespace/translator_test.go
+++ b/pkg/namespace/translator_test.go
@@ -1,0 +1,214 @@
+package namespace_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	historypb "go.temporal.io/api/history/v1"
+	namespacepb "go.temporal.io/api/namespace/v1"
+	operatorservicev1 "go.temporal.io/api/operatorservice/v1"
+	workflowservicev1 "go.temporal.io/api/workflowservice/v1"
+
+	"github.com/temporalio/temporal-proxy/pkg/namespace"
+)
+
+// testMapper produces distinct outputs for Local vs Remote so tests can
+// assert which direction the translator dispatched to.
+type testMapper struct{}
+
+func TestTranslator_ToRemote(t *testing.T) {
+	t.Parallel()
+
+	tr := namespace.New(testMapper{})
+
+	t.Run("top-level namespace field", func(t *testing.T) {
+		t.Parallel()
+
+		msg := &workflowservicev1.StartWorkflowExecutionRequest{Namespace: "payments"}
+		tr.ToRemote(msg)
+
+		require.Equal(t, "R(payments)", msg.Namespace)
+	})
+
+	t.Run("workflow_namespace on poll response", func(t *testing.T) {
+		t.Parallel()
+
+		msg := &workflowservicev1.PollActivityTaskQueueResponse{WorkflowNamespace: "payments"}
+		tr.ToRemote(msg)
+
+		require.Equal(t, "R(payments)", msg.WorkflowNamespace)
+	})
+
+	t.Run("deleted_namespace on operator response", func(t *testing.T) {
+		t.Parallel()
+
+		msg := &operatorservicev1.DeleteNamespaceResponse{DeletedNamespace: "payments"}
+		tr.ToRemote(msg)
+
+		require.Equal(t, "R(payments)", msg.DeletedNamespace)
+	})
+
+	t.Run("nested parent_workflow_namespace inside attributes", func(t *testing.T) {
+		t.Parallel()
+
+		msg := &historypb.WorkflowExecutionStartedEventAttributes{
+			ParentWorkflowNamespace:   "payments",
+			ParentWorkflowNamespaceId: "uuid-stays",
+		}
+		tr.ToRemote(msg)
+
+		require.Equal(t, "R(payments)", msg.ParentWorkflowNamespace)
+		require.Equal(t, "uuid-stays", msg.ParentWorkflowNamespaceId, "namespace id must be untouched")
+	})
+
+	t.Run("deeply nested via HistoryEvent oneof", func(t *testing.T) {
+		t.Parallel()
+
+		msg := &workflowservicev1.GetWorkflowExecutionHistoryResponse{
+			History: &historypb.History{
+				Events: []*historypb.HistoryEvent{
+					{Attributes: &historypb.HistoryEvent_WorkflowExecutionStartedEventAttributes{
+						WorkflowExecutionStartedEventAttributes: &historypb.WorkflowExecutionStartedEventAttributes{
+							ParentWorkflowNamespace: "payments",
+						},
+					}},
+					{Attributes: &historypb.HistoryEvent_SignalExternalWorkflowExecutionInitiatedEventAttributes{
+						SignalExternalWorkflowExecutionInitiatedEventAttributes: &historypb.SignalExternalWorkflowExecutionInitiatedEventAttributes{
+							Namespace: "billing",
+						},
+					}},
+				},
+			},
+		}
+		tr.ToRemote(msg)
+
+		require.Equal(t, "R(payments)",
+			msg.History.Events[0].GetWorkflowExecutionStartedEventAttributes().ParentWorkflowNamespace)
+		require.Equal(t, "R(billing)",
+			msg.History.Events[1].GetSignalExternalWorkflowExecutionInitiatedEventAttributes().Namespace)
+	})
+
+	t.Run("scoped NamespaceInfo.Name allowlist", func(t *testing.T) {
+		t.Parallel()
+
+		msg := &workflowservicev1.DescribeNamespaceResponse{
+			NamespaceInfo: &namespacepb.NamespaceInfo{
+				Name: "payments",
+				Id:   "uuid-stays",
+			},
+		}
+		tr.ToRemote(msg)
+
+		require.Equal(t, "R(payments)", msg.NamespaceInfo.Name)
+		require.Equal(t, "uuid-stays", msg.NamespaceInfo.Id, "scoped allowlist must not touch sibling fields")
+	})
+
+	t.Run("repeated message field walks each element", func(t *testing.T) {
+		t.Parallel()
+
+		msg := &workflowservicev1.ListNamespacesResponse{
+			Namespaces: []*workflowservicev1.DescribeNamespaceResponse{
+				{NamespaceInfo: &namespacepb.NamespaceInfo{Name: "payments"}},
+				{NamespaceInfo: &namespacepb.NamespaceInfo{Name: "billing"}},
+			},
+		}
+		tr.ToRemote(msg)
+
+		require.Equal(t, "R(payments)", msg.Namespaces[0].NamespaceInfo.Name)
+		require.Equal(t, "R(billing)", msg.Namespaces[1].NamespaceInfo.Name)
+	})
+
+	t.Run("empty namespace stays empty", func(t *testing.T) {
+		t.Parallel()
+
+		msg := &workflowservicev1.StartWorkflowExecutionRequest{Namespace: ""}
+		tr.ToRemote(msg)
+
+		require.Empty(t, msg.Namespace, "proto3 treats empty string as unset; translator must not touch it")
+	})
+
+	t.Run("nil msg is a no-op", func(t *testing.T) {
+		t.Parallel()
+
+		require.NotPanics(t, func() { tr.ToRemote(nil) })
+	})
+
+	t.Run("nil mapper falls back to identity", func(t *testing.T) {
+		t.Parallel()
+
+		idTr := namespace.New(nil)
+		msg := &workflowservicev1.StartWorkflowExecutionRequest{Namespace: "payments"}
+
+		require.NotPanics(t, func() { idTr.ToRemote(msg) })
+		require.Equal(t, "payments", msg.Namespace, "identity mapper must leave the value unchanged")
+	})
+}
+
+func TestTranslator_ToLocal(t *testing.T) {
+	t.Parallel()
+
+	tr := namespace.New(testMapper{})
+
+	t.Run("dispatches to Mapper.Local, not Remote", func(t *testing.T) {
+		t.Parallel()
+
+		msg := &workflowservicev1.StartWorkflowExecutionRequest{Namespace: "payments"}
+		tr.ToLocal(msg)
+
+		require.Equal(t, "L(payments)", msg.Namespace)
+	})
+
+	t.Run("round-trip Local then Remote uses both directions", func(t *testing.T) {
+		t.Parallel()
+
+		msg := &workflowservicev1.StartWorkflowExecutionRequest{Namespace: "payments"}
+
+		tr.ToLocal(msg)
+		require.Equal(t, "L(payments)", msg.Namespace)
+
+		tr.ToRemote(msg)
+		require.Equal(t, "R(L(payments))", msg.Namespace)
+	})
+}
+
+func TestIsKnownProtoField(t *testing.T) {
+	t.Parallel()
+
+	const (
+		nsInfo = "temporal.api.namespace.v1.NamespaceInfo"
+		swer   = "temporal.api.workflowservice.v1.StartWorkflowExecutionRequest"
+	)
+
+	tests := []struct {
+		name       string
+		field      string
+		parent     string
+		want       bool
+		wantReason string
+	}{
+		{name: "global namespace field", field: "namespace", parent: swer, want: true},
+		{name: "global workflow_namespace", field: "workflow_namespace", parent: swer, want: true},
+		{name: "global parent_workflow_namespace", field: "parent_workflow_namespace", parent: swer, want: true},
+		{name: "global deleted_namespace", field: "deleted_namespace", parent: swer, want: true},
+		{name: "scoped NamespaceInfo.name", field: "name", parent: nsInfo, want: true},
+		{name: "name on unrelated message is not scoped", field: "name", parent: swer, want: false},
+		{
+			name: "ignored namespace_id", field: "namespace_id", parent: swer, want: true,
+			wantReason: "namespace_id is in ignoredNamespaceFields, which IsKnownProtoField reports as known so the coverage test skips it",
+		},
+		{name: "ignored namespace_ids", field: "namespace_ids", parent: swer, want: true},
+		{name: "ignored parent_workflow_namespace_id", field: "parent_workflow_namespace_id", parent: swer, want: true},
+		{name: "unrelated field", field: "task_queue", parent: swer, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tt.want, namespace.IsKnownProtoField(tt.field, tt.parent), tt.wantReason)
+		})
+	}
+}
+
+func (testMapper) Local(s string) string  { return "L(" + s + ")" }
+func (testMapper) Remote(s string) string { return "R(" + s + ")" }


### PR DESCRIPTION
The proxy needs to swap Temporal namespace names between the caller's local view and the upstream's remote view across every RPC

This adds pkg/namespace, whose Translator uses protoreflect to walk an arbitrary proto.Message and rewrite every string field whose proto name carries a namespace through a caller-supplied Mapper.

Three allow lists drive what is rewritten:

- `namespaceNameFields` for globally unambiguous names (namespace, workflow_namespace, parent_workflow_namespace, deleted_namespace)
- `messageScopedNamespaceFields` for fields like NamespaceInfo.name that only mean "namespace" on specific messages
- `ignoredNamespaceFields` for `*_id` siblings that share the word but are identifiers.

I added a bench test for the translation. The first one tests a NamespaceInfo object which is flat and has the field right at the root. The other uses a 100-level deep recursive message. On my laptop (pretty beefy M5) these were the results.

```bash 
$ go test -run='^$' -bench=. -benchmem -count=3 -benchtime=1s ./pkg/namespace

goos: darwin 
goarch: arm64
pkg: github.com/temporalio/temporal-proxy/pkg/namespace 
cpu: Apple M5 Max

BenchmarkTranslator_ToLocal_NamespaceInfo-18  6056732 ops/s  178.2 ns/op  56 B/op  3 allocs/op
BenchmarkTranslator_ToLocal_NamespaceInfo-18  6906356 ops/s  176.6 ns/op  56 B/op  3 allocs/op
BenchmarkTranslator_ToLocal_NamespaceInfo-18  6769731 ops/s  176.4 ns/op  56 B/op  3 allocs/op

BenchmarkTranslator_ToLocal_DeepRecursion-18  64540 ops/s    18490 ns/op  25 B/op  1 allocs/op
BenchmarkTranslator_ToLocal_DeepRecursion-18  64626 ops/s    18434 ns/op  24 B/op  1 allocs/op
BenchmarkTranslator_ToLocal_DeepRecursion-18  65556 ops/s    18450 ns/op  24 B/op  1 allocs/op

PASS
ok      github.com/temporalio/temporal-proxy/pkg/namespace      7.514s
```

> [!NOTE]
> _proto_test.go_ is a coverage guard: it walks every request and response reachable from the workflow, operator, and 
> admin service descriptors and fails with the exact field path whenever Temporal ships a new namespace-bearing string field the translator doesn't yet recognize.