### PR TITLE
[build]: Add goreleaser for binaries and images

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,5 +42,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
       - uses: ./.github/actions/setup
       - run: mise run build

--- a/.gitignore
+++ b/.gitignore
@@ -7,15 +7,8 @@
 *.dll
 *.so
 *.dylib
-
-# Test binary, built with `go test -c`
 *.test
-
-# Output of the go coverage tool, specifically when used with LiteIDE
 *.out
-
-#Workspace directory from GoLand
-.idea/
 
 # Go workspace file
 go.work
@@ -31,5 +24,6 @@ CLAUDE.local.md
 # dev things
 dev/certs/
 
-# Binary from task build
+# build things
 ./proxy
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,99 @@
+version: 2
+
+project_name: temporal-proxy
+
+builds:
+  - id: proxy
+    main: ./cmd/proxy
+    binary: proxy
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.sha={{.Commit}}
+      - -X main.buildTime={{.Date}}
+
+archives:
+  - id: default
+    ids:
+      - proxy
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
+dockers_v2:
+  - images:
+      - temporalio/{{ .ProjectName }}
+
+    tags:
+      - "v{{.Version }}"
+      - "{{ if .IsNightly }}nightly{{ end }}"
+      - "{{ if not .IsNightly }}latest{{ end }}"
+
+    labels:
+      "org.opencontainers.image.title": "{{ .ProjectName }}"
+      "org.opencontainers.image.description": "A proxy for applications, workers, and the Temporal UI"
+      "org.opencontainers.image.url": "https://github.com/temporalio/{{ .ProjectName }}"
+      "org.opencontainers.image.source": "https://github.com/temporalio/{{ .ProjectName }}"
+      "org.opencontainers.image.version": "{{ .Version }}"
+      "org.opencontainers.image.created": "{{ .Date }}"
+      "org.opencontainers.image.revision": "{{ .FullCommit }}"
+      "org.opencontainers.image.licenses": "MIT"
+
+checksum:
+  name_template: "checksums.txt"
+
+snapshot:
+  version_template: "{{ incpatch .Version }}-next"
+
+changelog:
+  sort: asc
+  use: github
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^ci:"
+      - "^build:"
+      - "^chore:"
+  groups:
+    - title: Features
+      regexp: "^.*feat[(\\w)]*:+.*$"
+      order: 0
+    - title: Bug Fixes
+      regexp: "^.*fix[(\\w)]*:+.*$"
+      order: 1
+    - title: Others
+      order: 999
+
+release:
+  github:
+    owner: temporalio
+    name: temporal-proxy
+  draft: false
+  prerelease: auto
+  name_template: "Release {{ .Version }}"
+  header: |
+    ## Temporal Proxy
+
+    Version {{ .Version }} release!
+
+    ### Container Image
+
+    Container image is available on GitHub Container Registry:
+
+    ```bash
+    docker pull temporalio/{{ .ProjectName }}:{{ .Version }}
+    ```
+
+    ### Installation
+
+    Download the appropriate binary for your platform from the assets below, or use the container image.
+
+  footer: |
+    **Full Changelog**: https://github.com/temporalio/{{ .ProjectName }}/compare/{{ .PreviousTag }}...{{ .Tag }}

--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -7,6 +7,7 @@ experimental = true
 "github:temporalio/cli" = "latest"
 go = "1.26"
 mkcert = "1.4.4"
+goreleaser = "2.16.0"
 
 ################################################################################
 # Dependencies
@@ -15,7 +16,7 @@ mkcert = "1.4.4"
 [deps.go]
 
 [deps.tools]
-sources = ["mise.toml"]
+sources = [".mise/config.toml"]
 outputs = ["dev/tools.sum"]
 description = "Sync dev tools"
 run = """
@@ -38,10 +39,6 @@ run = "goreman -exit-on-error -set-ports=false -f dev/Procfile start"
 # Development Tasks
 ################################################################################
 
-[tasks.build]
-description = "Build binaries"
-run = ["go build -o dist/proxy ./cmd/proxy"]
-
 [tasks.lint]
 description = "Lint Go files"
 run = ["go tool -modfile=dev/tools.mod golangci-lint run"]
@@ -54,7 +51,7 @@ run = ["go fix ./...", "go tool -modfile=dev/tools.mod golangci-lint fmt"]
 description = "Run unit tests"
 run = "go test -cover ./..."
 
-[tasks.test-bench]
+[tasks."test:bench"]
 description = "Run bench tests"
 usage = '''
 flag "-c --count <count>" default="3"
@@ -82,3 +79,11 @@ run = [
   "mv rootCA.pem ca.crt",
   "rm -f rootCA-key.pem",
 ]
+
+################################################################################
+# Build Tasks
+################################################################################
+
+[tasks.build]
+description = "Build binaries"
+run = "goreleaser release --snapshot --clean --skip=publish"

--- a/.mise/tasks/tag
+++ b/.mise/tasks/tag
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+#MISE description="Create and push new tag"
+
+#USAGE arg "type" help="Release type" {
+#USAGE   choices "patch" "minor" "major"
+#USAGE }
+#USAGE flag "-s --suffix <suffix>" default="" help="Optional suffix to add to the tag"
+
+main() {
+  if ! git diff --quiet; then
+    echo "Working directory must be clean" >&2
+    exit 1
+  fi
+
+  if ! git diff --cached --quiet; then
+    echo "No staged changes allowed" >&2
+    exit 1
+  fi
+
+  local tag="$(generate_tag_name ${usage_type:?})"
+  if [ -n "${usage_suffix:-}" ]; then tag="${tag}${usage_suffix:-}"; fi
+
+  create_tag "${tag}"
+}
+
+generate_tag_name() {
+  local type="${1}"
+
+  case "${type}" in
+  patch)
+    git describe --tags --abbrev=0 2>/dev/null | awk -F. '{print $1"."$2"."$3+1}' || echo "v0.0.1"
+    ;;
+  minor)
+    git describe --tags --abbrev=0 2>/dev/null | awk -F. '{print $1"."$2+1".0"}' || echo "v0.1.0"
+    ;;
+  major)
+    git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' | awk -F. '{print "v"$1+1".0.0"}' || echo "v1.0.0"
+    ;;
+  esac
+}
+
+create_tag() {
+  local tag="${1}"
+  echo git tag -s "${tag}" -m "Release ${tag}"
+  echo git push origin "${tag}"
+  echo "Tag ${tag} created and pushed. GitHub Actions will handle build and release."
+}
+
+main "$@"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM alpine:3.23.4 AS base
+RUN adduser -D -u 1000 proxy
+
+FROM scratch
+COPY --from=base /etc/passwd /etc/passwd
+COPY --from=base /etc/group /etc/group
+
+# Copy the pre-built binary (goreleaser will provide this).
+ARG TARGETPLATFORM
+COPY $TARGETPLATFORM/proxy /usr/local/bin/
+
+USER proxy
+VOLUME ["/etc/proxy"]
+
+ENTRYPOINT ["proxy"]
+CMD ["--help"]


### PR DESCRIPTION
Releases were previously a manual `go build` to a single `./proxy` binary, with no story for distributing cross-platform builds or container images.

This wires up goreleaser to handle:

- Generating amd64 and arm64 binaries for Linux and Darwin
- Building `temporalio/temporal-proxy:<latest|tag>` Docker images
- Creating a GitHub Release with changelog and build artifacts

`mise run tag` task is a small helper for cutting patch/minor/major releases (not fully functional just yet). I'll need to get Docker credentials in place to move forward.

CI runs ensure the build works, but do not publish anything. In the future pushing a signed tag will trigger a proper release.
