### PR TITLE
[validation]: Add rule-based validation API

### DIFF
--- a/internal/transport/creds/insecure.go
+++ b/internal/transport/creds/insecure.go
@@ -28,3 +28,9 @@ func (c *Insecure) DialOption() (grpc.DialOption, error) {
 func (c *Insecure) ServerOption() (grpc.ServerOption, error) {
 	return grpc.Creds(insecure.NewCredentials()), nil
 }
+
+// Validate reports any configuration problems with this credential. Insecure
+// has no certificates or keys to inspect, so it always succeeds.
+func (c *Insecure) Validate() error {
+	return nil
+}

--- a/internal/transport/creds/insecure_test.go
+++ b/internal/transport/creds/insecure_test.go
@@ -1,8 +1,6 @@
 package creds_test
 
 import (
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -26,12 +24,9 @@ func TestInsecure_ServerOption(t *testing.T) {
 	require.NotNil(t, opt)
 }
 
-func writeFile(t *testing.T, dir, name string, contents []byte) string {
-	t.Helper()
+func TestInsecure_Validate(t *testing.T) {
+	t.Parallel()
 
-	path := filepath.Join(dir, name)
-	err := os.WriteFile(path, contents, 0o600)
-	require.NoError(t, err)
-
-	return path
+	// Insecure has no certificate material to inspect; Validate is a no-op.
+	require.NoError(t, creds.NewInsecure().Validate())
 }

--- a/internal/transport/creds/mtls.go
+++ b/internal/transport/creds/mtls.go
@@ -8,6 +8,8 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+
+	"github.com/temporalio/temporal-proxy/pkg/validation"
 )
 
 type (
@@ -103,4 +105,35 @@ func (c *MTLS) ServerOption() (grpc.ServerOption, error) {
 		MinVersion:   minTLSVersion,
 		CipherSuites: preferredCipherSuites,
 	})), nil
+}
+
+// Validate checks both the leaf certificate and the CA certificate for
+// configuration problems. The leaf must be unexpired, signed with a strong
+// algorithm, and use a key type compatible with [preferredCipherSuites]; the CA
+// must be unexpired, have the CA basic constraint set, and be signed with a
+// strong algorithm. Both files are always checked; failures are collected
+// into a single [validation.Errors] so callers see every problem in one call.
+func (c *MTLS) Validate() error {
+	if errs := validation.Validate(
+		"",
+		validation.Field("cert", c.certFile, func(path string) error {
+			return ValidatePEMFile(
+				path,
+				CertificateNotExpired(),
+				UsesSecureCertificateAlgorithm(preferredCipherSuites...),
+			)
+		}),
+		validation.Field("ca", c.caFile, func(path string) error {
+			return ValidatePEMFile(
+				path,
+				CertificateNotExpired(),
+				IsCACertificate(),
+				UsesSecureCertificateAlgorithm(),
+			)
+		}),
+	); len(errs) > 0 {
+		return errs
+	}
+
+	return nil
 }

--- a/internal/transport/creds/mtls_test.go
+++ b/internal/transport/creds/mtls_test.go
@@ -1,12 +1,8 @@
 package creds_test
 
 import (
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"encoding/pem"
 	"math/big"
 	"path/filepath"
 	"testing"
@@ -15,6 +11,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/temporalio/temporal-proxy/internal/transport/creds"
+	"github.com/temporalio/temporal-proxy/pkg/testutil"
+	"github.com/temporalio/temporal-proxy/pkg/validation"
 )
 
 func TestMTLS_DialOption(t *testing.T) {
@@ -29,14 +27,14 @@ func TestMTLS_DialOption(t *testing.T) {
 			name: "success",
 			setup: func(t *testing.T) (string, string, string) {
 				t.Helper()
-				return mustGenMTLSCerts(t)
+				return testutil.GenerateMTLSCerts(t)
 			},
 		},
 		{
 			name: "missing cert file",
 			setup: func(t *testing.T) (string, string, string) {
 				t.Helper()
-				caFile, _, keyFile := mustGenMTLSCerts(t)
+				caFile, _, keyFile := testutil.GenerateMTLSCerts(t)
 				return caFile, filepath.Join(t.TempDir(), "missing.pem"), keyFile
 			},
 			wantErr: "failed to load client key pair",
@@ -45,7 +43,7 @@ func TestMTLS_DialOption(t *testing.T) {
 			name: "missing key file",
 			setup: func(t *testing.T) (string, string, string) {
 				t.Helper()
-				caFile, certFile, _ := mustGenMTLSCerts(t)
+				caFile, certFile, _ := testutil.GenerateMTLSCerts(t)
 				return caFile, certFile, filepath.Join(t.TempDir(), "missing.pem")
 			},
 			wantErr: "failed to load client key pair",
@@ -54,7 +52,7 @@ func TestMTLS_DialOption(t *testing.T) {
 			name: "missing CA file",
 			setup: func(t *testing.T) (string, string, string) {
 				t.Helper()
-				_, certFile, keyFile := mustGenMTLSCerts(t)
+				_, certFile, keyFile := testutil.GenerateMTLSCerts(t)
 				return filepath.Join(t.TempDir(), "missing.pem"), certFile, keyFile
 			},
 			wantErr: "failed to load CA certificate",
@@ -64,8 +62,8 @@ func TestMTLS_DialOption(t *testing.T) {
 			setup: func(t *testing.T) (string, string, string) {
 				t.Helper()
 				dir := t.TempDir()
-				_, certFile, keyFile := mustGenMTLSCerts(t)
-				caFile := writeFile(t, dir, "ca.pem", []byte("not pem"))
+				_, certFile, keyFile := testutil.GenerateMTLSCerts(t)
+				caFile := testutil.WriteFile(t, dir, "ca.pem", []byte("not pem"))
 				return caFile, certFile, keyFile
 			},
 			wantErr: "failed to parse CA file",
@@ -96,7 +94,7 @@ func TestMTLS_Options(t *testing.T) {
 	t.Run("InsecureSkipVerify is propagated", func(t *testing.T) {
 		t.Parallel()
 
-		caFile, certFile, keyFile := mustGenMTLSCerts(t)
+		caFile, certFile, keyFile := testutil.GenerateMTLSCerts(t)
 		opt, err := creds.NewMTLS(caFile, certFile, keyFile, creds.MTLSOptions{
 			InsecureSkipVerify: true,
 		}).DialOption()
@@ -107,7 +105,7 @@ func TestMTLS_Options(t *testing.T) {
 	t.Run("ServerName is propagated", func(t *testing.T) {
 		t.Parallel()
 
-		caFile, certFile, keyFile := mustGenMTLSCerts(t)
+		caFile, certFile, keyFile := testutil.GenerateMTLSCerts(t)
 		opt, err := creds.NewMTLS(caFile, certFile, keyFile, creds.MTLSOptions{
 			ServerName: "example.com",
 		}).DialOption()
@@ -128,14 +126,14 @@ func TestMTLS_ServerOption(t *testing.T) {
 			name: "success",
 			setup: func(t *testing.T) (string, string, string) {
 				t.Helper()
-				return mustGenMTLSCerts(t)
+				return testutil.GenerateMTLSCerts(t)
 			},
 		},
 		{
 			name: "missing cert file",
 			setup: func(t *testing.T) (string, string, string) {
 				t.Helper()
-				caFile, _, keyFile := mustGenMTLSCerts(t)
+				caFile, _, keyFile := testutil.GenerateMTLSCerts(t)
 				return caFile, filepath.Join(t.TempDir(), "missing.pem"), keyFile
 			},
 			wantErr: "failed to load server key pair",
@@ -144,7 +142,7 @@ func TestMTLS_ServerOption(t *testing.T) {
 			name: "missing key file",
 			setup: func(t *testing.T) (string, string, string) {
 				t.Helper()
-				caFile, certFile, _ := mustGenMTLSCerts(t)
+				caFile, certFile, _ := testutil.GenerateMTLSCerts(t)
 				return caFile, certFile, filepath.Join(t.TempDir(), "missing.pem")
 			},
 			wantErr: "failed to load server key pair",
@@ -153,7 +151,7 @@ func TestMTLS_ServerOption(t *testing.T) {
 			name: "missing CA file",
 			setup: func(t *testing.T) (string, string, string) {
 				t.Helper()
-				_, certFile, keyFile := mustGenMTLSCerts(t)
+				_, certFile, keyFile := testutil.GenerateMTLSCerts(t)
 				return filepath.Join(t.TempDir(), "missing.pem"), certFile, keyFile
 			},
 			wantErr: "failed to load CA certificate",
@@ -163,8 +161,8 @@ func TestMTLS_ServerOption(t *testing.T) {
 			setup: func(t *testing.T) (string, string, string) {
 				t.Helper()
 				dir := t.TempDir()
-				_, certFile, keyFile := mustGenMTLSCerts(t)
-				caFile := writeFile(t, dir, "ca.pem", []byte("not pem"))
+				_, certFile, keyFile := testutil.GenerateMTLSCerts(t)
+				caFile := testutil.WriteFile(t, dir, "ca.pem", []byte("not pem"))
 				return caFile, certFile, keyFile
 			},
 			wantErr: "failed to parse CA file",
@@ -189,57 +187,69 @@ func TestMTLS_ServerOption(t *testing.T) {
 	}
 }
 
-func mustGenMTLSCerts(t *testing.T) (caFile, certFile, keyFile string) {
-	t.Helper()
+func TestMTLS_Validate(t *testing.T) {
+	t.Parallel()
 
-	dir := t.TempDir()
-
-	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	require.NoError(t, err)
-
-	caTmpl := &x509.Certificate{
-		SerialNumber:          big.NewInt(2),
-		Subject:               pkix.Name{CommonName: "test-ca"},
-		NotBefore:             time.Now().Add(-time.Hour),
-		NotAfter:              time.Now().Add(time.Hour),
-		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
-		BasicConstraintsValid: true,
-		IsCA:                  true,
+	validLeaf := func(t *testing.T) string {
+		t.Helper()
+		return writePEMFile(t, testutil.RSACert(t, validTemplate()))
 	}
 
-	caDER, err := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
-	require.NoError(t, err)
-
-	caCert, err := x509.ParseCertificate(caDER)
-	require.NoError(t, err)
-
-	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})
-	caFile = writeFile(t, dir, "ca.pem", caPEM)
-
-	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	require.NoError(t, err)
-
-	leafTmpl := &x509.Certificate{
-		SerialNumber: big.NewInt(3),
-		Subject:      pkix.Name{CommonName: "localhost"},
-		NotBefore:    time.Now().Add(-time.Hour),
-		NotAfter:     time.Now().Add(time.Hour),
-		KeyUsage:     x509.KeyUsageDigitalSignature,
-		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-		DNSNames:     []string{"localhost"},
+	validCA := func(t *testing.T) string {
+		t.Helper()
+		return writePEMFile(t, testutil.RSACert(t, caTemplate()))
 	}
 
-	leafDER, err := x509.CreateCertificate(rand.Reader, leafTmpl, caCert, &leafKey.PublicKey, caKey)
-	require.NoError(t, err)
+	t.Run("valid leaf and CA pass", func(t *testing.T) {
+		t.Parallel()
 
-	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: leafDER})
-	certFile = writeFile(t, dir, "cert.pem", certPEM)
+		err := creds.NewMTLS(validCA(t), validLeaf(t), "", creds.MTLSOptions{}).Validate()
+		require.NoError(t, err)
+	})
 
-	leafKeyDER, err := x509.MarshalECPrivateKey(leafKey)
-	require.NoError(t, err)
+	t.Run("missing leaf cert file", func(t *testing.T) {
+		t.Parallel()
 
-	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: leafKeyDER})
-	keyFile = writeFile(t, dir, "key.pem", keyPEM)
+		err := creds.NewMTLS(validCA(t), filepath.Join(t.TempDir(), "missing.pem"), "", creds.MTLSOptions{}).Validate()
+		require.ErrorContains(t, err, "failed to read PEM file")
+	})
 
-	return caFile, certFile, keyFile
+	t.Run("missing CA file", func(t *testing.T) {
+		t.Parallel()
+
+		err := creds.NewMTLS(filepath.Join(t.TempDir(), "missing.pem"), validLeaf(t), "", creds.MTLSOptions{}).Validate()
+		require.ErrorContains(t, err, "failed to read PEM file")
+	})
+
+	t.Run("non-CA cert in CA slot fails", func(t *testing.T) {
+		t.Parallel()
+
+		// validTemplate has IsCA=false; using it as the CA file should fail the
+		// IsCACertificate validator.
+		nonCAFile := writePEMFile(t, testutil.RSACert(t, validTemplate()))
+		err := creds.NewMTLS(nonCAFile, validLeaf(t), "", creds.MTLSOptions{}).Validate()
+		require.ErrorContains(t, err, "not a CA")
+	})
+
+	t.Run("leaf and CA failures are both reported", func(t *testing.T) {
+		t.Parallel()
+
+		// Validate runs both checks and combines failures into a single
+		// validation.Errors, so a bad leaf does not hide a bad CA.
+		expiredLeaf := writePEMFile(t, testutil.RSACert(t, &x509.Certificate{
+			SerialNumber: big.NewInt(7),
+			Subject:      pkix.Name{CommonName: "expired-leaf"},
+			NotBefore:    time.Now().Add(-2 * time.Hour),
+			NotAfter:     time.Now().Add(-time.Hour),
+		}))
+		nonCAFile := writePEMFile(t, testutil.RSACert(t, validTemplate()))
+
+		err := creds.NewMTLS(nonCAFile, expiredLeaf, "", creds.MTLSOptions{}).Validate()
+		require.ErrorContains(t, err, "expired-leaf")
+		require.ErrorContains(t, err, "not a CA")
+
+		var verrs validation.Errors
+		require.ErrorAs(t, err, &verrs)
+		require.Len(t, verrs, 2)
+	})
 }

--- a/internal/transport/creds/tls.go
+++ b/internal/transport/creds/tls.go
@@ -6,6 +6,8 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+
+	"github.com/temporalio/temporal-proxy/pkg/validation"
 )
 
 // minTLSVersion is the minimum TLS version accepted on both client and server
@@ -72,4 +74,27 @@ func (c *TLS) ServerOption() (grpc.ServerOption, error) {
 	}
 
 	return grpc.Creds(credentials.NewTLS(cfg)), nil
+}
+
+// Validate reads the configured certificate file and returns a [validation.Errors]
+// describing any problems found: an expired or not-yet-valid certificate, a weak
+// signature algorithm, or a public key type incompatible with [preferredCipherSuites].
+// Client-mode [TLS] credentials (those constructed via [NewClientTLS]) have no
+// certFile and will fail with a read error; callers should only invoke Validate
+// on server-mode credentials.
+func (c *TLS) Validate() error {
+	if errs := validation.Validate(
+		"",
+		validation.Field("cert", c.certFile, func(path string) error {
+			return ValidatePEMFile(
+				path,
+				CertificateNotExpired(),
+				UsesSecureCertificateAlgorithm(preferredCipherSuites...),
+			)
+		}),
+	); len(errs) > 0 {
+		return errs
+	}
+
+	return nil
 }

--- a/internal/transport/creds/tls_test.go
+++ b/internal/transport/creds/tls_test.go
@@ -1,12 +1,8 @@
 package creds_test
 
 import (
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"encoding/pem"
 	"math/big"
 	"path/filepath"
 	"testing"
@@ -15,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/temporalio/temporal-proxy/internal/transport/creds"
+	"github.com/temporalio/temporal-proxy/pkg/testutil"
 )
 
 func TestTLS_DialOption(t *testing.T) {
@@ -38,14 +35,14 @@ func TestTLS_ServerOption(t *testing.T) {
 			name: "success",
 			setup: func(t *testing.T) (string, string) {
 				t.Helper()
-				return mustGenSelfSignedCert(t)
+				return testutil.GenerateSelfSignedCert(t)
 			},
 		},
 		{
 			name: "missing cert file",
 			setup: func(t *testing.T) (string, string) {
 				t.Helper()
-				_, keyFile := mustGenSelfSignedCert(t)
+				_, keyFile := testutil.GenerateSelfSignedCert(t)
 				return filepath.Join(t.TempDir(), "missing.pem"), keyFile
 			},
 			wantErr: "failed to load server key pair",
@@ -54,7 +51,7 @@ func TestTLS_ServerOption(t *testing.T) {
 			name: "missing key file",
 			setup: func(t *testing.T) (string, string) {
 				t.Helper()
-				certFile, _ := mustGenSelfSignedCert(t)
+				certFile, _ := testutil.GenerateSelfSignedCert(t)
 				return certFile, filepath.Join(t.TempDir(), "missing.pem")
 			},
 			wantErr: "failed to load server key pair",
@@ -64,8 +61,8 @@ func TestTLS_ServerOption(t *testing.T) {
 			setup: func(t *testing.T) (string, string) {
 				t.Helper()
 				dir := t.TempDir()
-				certFile := writeFile(t, dir, "cert.pem", []byte("not a cert"))
-				keyFile := writeFile(t, dir, "key.pem", []byte("not a key"))
+				certFile := testutil.WriteFile(t, dir, "cert.pem", []byte("not a cert"))
+				keyFile := testutil.WriteFile(t, dir, "key.pem", []byte("not a key"))
 				return certFile, keyFile
 			},
 			wantErr: "failed to load server key pair",
@@ -90,35 +87,54 @@ func TestTLS_ServerOption(t *testing.T) {
 	}
 }
 
-func mustGenSelfSignedCert(t *testing.T) (certFile, keyFile string) {
-	t.Helper()
+func TestTLS_Validate(t *testing.T) {
+	t.Parallel()
 
-	dir := t.TempDir()
+	t.Run("valid RSA cert passes", func(t *testing.T) {
+		t.Parallel()
 
-	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	require.NoError(t, err)
+		// preferredCipherSuites are RSA-only, so the leaf must use an RSA key.
+		certFile := writePEMFile(t, testutil.RSACert(t, validTemplate()))
+		require.NoError(t, creds.NewServerTLS(certFile, "").Validate())
+	})
 
-	tmpl := &x509.Certificate{
-		SerialNumber: big.NewInt(1),
-		Subject:      pkix.Name{CommonName: "localhost"},
-		NotBefore:    time.Now().Add(-time.Hour),
-		NotAfter:     time.Now().Add(time.Hour),
-		KeyUsage:     x509.KeyUsageDigitalSignature,
-		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-		DNSNames:     []string{"localhost"},
-	}
+	t.Run("missing cert file", func(t *testing.T) {
+		t.Parallel()
 
-	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
-	require.NoError(t, err)
+		err := creds.NewServerTLS(filepath.Join(t.TempDir(), "missing.pem"), "").Validate()
+		require.ErrorContains(t, err, "failed to read PEM file")
+	})
 
-	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
-	certFile = writeFile(t, dir, "cert.pem", certPEM)
+	t.Run("expired cert fails", func(t *testing.T) {
+		t.Parallel()
 
-	keyDER, err := x509.MarshalECPrivateKey(key)
-	require.NoError(t, err)
+		expired := testutil.RSACert(t, &x509.Certificate{
+			SerialNumber: big.NewInt(1),
+			Subject:      pkix.Name{CommonName: "expired"},
+			NotBefore:    time.Now().Add(-2 * time.Hour),
+			NotAfter:     time.Now().Add(-time.Hour),
+		})
+		certFile := writePEMFile(t, expired)
 
-	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
-	keyFile = writeFile(t, dir, "key.pem", keyPEM)
+		err := creds.NewServerTLS(certFile, "").Validate()
+		require.ErrorContains(t, err, "expired")
+	})
 
-	return certFile, keyFile
+	t.Run("ECDSA cert rejected by RSA-only cipher suites", func(t *testing.T) {
+		t.Parallel()
+
+		certFile := writePEMFile(t, testutil.ECDSACert(t, validTemplate()))
+		err := creds.NewServerTLS(certFile, "").Validate()
+		require.ErrorContains(t, err, "key type")
+	})
+
+	t.Run("client TLS has no certFile and fails to read", func(t *testing.T) {
+		t.Parallel()
+
+		// NewClientTLS leaves certFile empty; Validate is documented as
+		// server-mode-only, but we still want to confirm it surfaces a clear
+		// IO error rather than panicking.
+		err := creds.NewClientTLS().Validate()
+		require.ErrorContains(t, err, "failed to read PEM file")
+	})
 }

--- a/internal/transport/creds/validation.go
+++ b/internal/transport/creds/validation.go
@@ -1,0 +1,228 @@
+package creds
+
+import (
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/temporalio/temporal-proxy/pkg/validation"
+)
+
+var (
+	// weakAlgorithms lists signature algorithms considered cryptographically broken.
+	// SHA-1 and MD5 are vulnerable to collision attacks; MD2 is obsolete; DSA is deprecated in X.509.
+	weakAlgorithms = map[x509.SignatureAlgorithm]bool{
+		x509.SHA1WithRSA:   true,
+		x509.ECDSAWithSHA1: true,
+		x509.MD2WithRSA:    true,
+		x509.MD5WithRSA:    true,
+		x509.DSAWithSHA1:   true,
+		x509.DSAWithSHA256: true,
+	}
+
+	// suiteKeyTypes maps each supported TLS cipher suite to the key type it requires ("rsa" or
+	// "ecdsa"). Used by SecureAlgorithm to verify that a certificate's public key is compatible
+	// with the caller's allowed suite set.
+	suiteKeyTypes = map[uint16]string{
+		// ECDHE_RSA suites
+		tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA:          "rsa",
+		tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA:          "rsa",
+		tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256:       "rsa",
+		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256:       "rsa",
+		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384:       "rsa",
+		tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256: "rsa",
+		// ECDHE_ECDSA suites
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA:          "ecdsa",
+		tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA:          "ecdsa",
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256:       "ecdsa",
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256:       "ecdsa",
+		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384:       "ecdsa",
+		tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256: "ecdsa",
+	}
+)
+
+// Validator inspects a single parsed certificate and returns a
+// validation.Error describing any failure, or nil if the certificate is valid.
+type Validator validation.Check[*x509.Certificate]
+
+// ValidatePEMFile reads path and forwards its contents to ValidatePEM. A read
+// failure is returned wrapped so callers can distinguish IO problems from
+// validation failures; the wrapped os.ReadFile error already includes the path.
+func ValidatePEMFile(path string, validators ...Validator) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("failed to read PEM file: %w", err)
+	}
+
+	return ValidatePEM(data, validators...)
+}
+
+// ValidatePEM parses all CERTIFICATE blocks from pemData and runs each
+// validator against every parsed certificate, collecting all failures into an
+// Errors value. Returns nil immediately when no validators are provided.
+func ValidatePEM(pemData []byte, validators ...Validator) error {
+	// With no validators there is nothing to check; skip PEM parsing entirely.
+	if len(validators) == 0 {
+		return nil
+	}
+
+	parsed, err := parsePEM(pemData)
+	if err != nil {
+		return err
+	}
+
+	var errs validation.Errors
+	for _, cert := range parsed {
+		for _, v := range validators {
+			if vErr := v(cert); vErr != nil {
+				if ve, ok := errors.AsType[validation.Error](vErr); ok {
+					errs = append(errs, ve)
+					continue
+				}
+
+				errs = append(errs, validation.Error{
+					Subject: cert.Subject.CommonName,
+					Field:   "unknown",
+					Message: vErr.Error(),
+				})
+			}
+		}
+	}
+
+	if len(errs) > 0 {
+		return errs
+	}
+
+	return nil
+}
+
+// CertificateNotExpired returns a CertificateValidator that rejects
+// certificates whose NotBefore is in the future or whose NotAfter is in the
+// past.
+func CertificateNotExpired() Validator {
+	return func(cert *x509.Certificate) error {
+		now := time.Now()
+		if now.Before(cert.NotBefore) {
+			return validation.Error{
+				Subject: cert.Subject.CommonName,
+				Field:   "expiry",
+				Message: fmt.Sprintf("certificate not yet valid until %s", cert.NotBefore.Format(time.RFC3339)),
+			}
+		}
+
+		if now.After(cert.NotAfter) {
+			return validation.Error{
+				Subject: cert.Subject.CommonName,
+				Field:   "expiry",
+				Message: fmt.Sprintf("certificate expired at %s", cert.NotAfter.Format(time.RFC3339)),
+			}
+		}
+
+		return nil
+	}
+}
+
+// IsCACertificate returns a CertificateValidator that rejects certificates
+// that do not have the CA basic constraint set.
+func IsCACertificate() Validator {
+	return func(cert *x509.Certificate) error {
+		if !cert.IsCA {
+			return validation.Error{
+				Subject: cert.Subject.CommonName,
+				Field:   "is_ca",
+				Message: "certificate is not a CA",
+			}
+		}
+
+		return nil
+	}
+}
+
+// UsesSecureCertificateAlgorithm returns a CertificateValidator that rejects
+// certificates signed with known-weak algorithms (SHA-1, MD5, MD2, DSA). When
+// allowedSuites are provided it additionally rejects certificates whose public
+// key type is incompatible with every suite in that list.
+func UsesSecureCertificateAlgorithm(allowedSuites ...uint16) Validator {
+	return func(cert *x509.Certificate) error {
+		if weakAlgorithms[cert.SignatureAlgorithm] {
+			return validation.Error{
+				Subject: cert.Subject.CommonName,
+				Field:   "signature_algorithm",
+				Message: fmt.Sprintf("weak signature algorithm: %s", cert.SignatureAlgorithm),
+			}
+		}
+
+		if len(allowedSuites) == 0 {
+			return nil
+		}
+
+		allowed := make(map[string]bool)
+		for _, suite := range allowedSuites {
+			if kt, ok := suiteKeyTypes[suite]; ok {
+				allowed[kt] = true
+			}
+		}
+
+		if len(allowed) == 0 {
+			return nil
+		}
+
+		kt := keyTypeOf(cert.PublicKey)
+		if !allowed[kt] {
+			return validation.Error{
+				Subject: cert.Subject.CommonName,
+				Field:   "key_type",
+				Message: fmt.Sprintf("key type %q incompatible with allowed cipher suites", kt),
+			}
+		}
+
+		return nil
+	}
+}
+
+func keyTypeOf(pub any) string {
+	switch pub.(type) {
+	case *rsa.PublicKey:
+		return "rsa"
+	case *ecdsa.PublicKey:
+		return "ecdsa"
+	default:
+		return "unknown"
+	}
+}
+
+func parsePEM(data []byte) ([]*x509.Certificate, error) {
+	var block *pem.Block
+	var parsed []*x509.Certificate
+
+	rest := data
+	for len(rest) > 0 {
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+
+		if block.Type != "CERTIFICATE" {
+			continue
+		}
+
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse certificate: %w", err)
+		}
+
+		parsed = append(parsed, cert)
+	}
+
+	if len(parsed) == 0 {
+		return nil, errors.New("no certificates found in PEM data")
+	}
+
+	return parsed, nil
+}

--- a/internal/transport/creds/validation_test.go
+++ b/internal/transport/creds/validation_test.go
@@ -1,0 +1,313 @@
+package creds_test
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/temporalio/temporal-proxy/internal/transport/creds"
+	"github.com/temporalio/temporal-proxy/pkg/testutil"
+	"github.com/temporalio/temporal-proxy/pkg/validation"
+)
+
+func TestValidatePEM_NoValidators(t *testing.T) {
+	t.Parallel()
+
+	// Invalid PEM: no validators means the function should return nil without
+	// even attempting to parse the data.
+	require.NoError(t, creds.ValidatePEM([]byte("not-pem-at-all")))
+}
+
+func TestValidatePEMFile(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing file", func(t *testing.T) {
+		t.Parallel()
+
+		err := creds.ValidatePEMFile(
+			"/tmp/definitely-not-a-real-cert.pem",
+			creds.CertificateNotExpired(),
+		)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "failed to read PEM file")
+	})
+
+	t.Run("missing file with no validators still errors", func(t *testing.T) {
+		t.Parallel()
+
+		// The IO read happens before the no-validators short-circuit, so a
+		// missing file should surface even without anything to validate.
+		err := creds.ValidatePEMFile("/tmp/definitely-not-a-real-cert.pem")
+		require.Error(t, err)
+		require.ErrorContains(t, err, "failed to read PEM file")
+	})
+
+	t.Run("valid cert passes", func(t *testing.T) {
+		t.Parallel()
+
+		path := writePEMFile(t, testutil.RSACert(t, validTemplate()))
+		require.NoError(t, creds.ValidatePEMFile(
+			path,
+			creds.CertificateNotExpired(),
+		))
+	})
+
+	t.Run("validator failure is propagated", func(t *testing.T) {
+		t.Parallel()
+
+		expired := testutil.RSACert(t, &x509.Certificate{
+			SerialNumber: big.NewInt(99),
+			Subject:      pkix.Name{CommonName: "expired"},
+			NotBefore:    time.Now().Add(-2 * time.Hour),
+			NotAfter:     time.Now().Add(-time.Hour),
+		})
+		path := writePEMFile(t, expired)
+
+		err := creds.ValidatePEMFile(path, creds.CertificateNotExpired())
+		require.Error(t, err)
+		require.ErrorContains(t, err, "expired")
+	})
+
+	t.Run("non-PEM contents are rejected when validators run", func(t *testing.T) {
+		t.Parallel()
+
+		path := writePEMFile(t, []byte("this is not a PEM block"))
+		err := creds.ValidatePEMFile(path, creds.CertificateNotExpired())
+		require.Error(t, err)
+		require.ErrorContains(t, err, "no certificates found")
+	})
+}
+
+func TestValidatePEM_InvalidPEM(t *testing.T) {
+	t.Parallel()
+
+	require.Error(t, creds.ValidatePEM([]byte("not-pem"), creds.CertificateNotExpired()))
+}
+
+func TestValidatePEM_MultipleCerts(t *testing.T) {
+	t.Parallel()
+
+	valid := testutil.RSACert(t, validTemplate())
+	expired := testutil.RSACert(t, &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "expired"},
+		NotBefore:    time.Now().Add(-2 * time.Hour),
+		NotAfter:     time.Now().Add(-time.Hour),
+	})
+
+	combined := append(valid, expired...)
+	err := creds.ValidatePEM(combined, creds.CertificateNotExpired())
+	require.Error(t, err)
+
+	var verr validation.Errors
+	require.ErrorAs(t, err, &verr)
+	require.Len(t, verr, 1)
+	require.Equal(t, "expired", verr[0].Subject)
+}
+
+func TestCertificateNotExpired(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		tmpl    *x509.Certificate
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid cert passes",
+			tmpl: &x509.Certificate{
+				SerialNumber: big.NewInt(1),
+				NotBefore:    time.Now().Add(-time.Hour),
+				NotAfter:     time.Now().Add(time.Hour),
+			},
+			wantErr: false,
+		},
+		{
+			name: "expired cert fails",
+			tmpl: &x509.Certificate{
+				SerialNumber: big.NewInt(1),
+				Subject:      pkix.Name{CommonName: "old"},
+				NotBefore:    time.Now().Add(-2 * time.Hour),
+				NotAfter:     time.Now().Add(-time.Hour),
+			},
+			wantErr: true,
+			errMsg:  "expired",
+		},
+		{
+			name: "not yet valid cert fails",
+			tmpl: &x509.Certificate{
+				SerialNumber: big.NewInt(1),
+				Subject:      pkix.Name{CommonName: "future"},
+				NotBefore:    time.Now().Add(time.Hour),
+				NotAfter:     time.Now().Add(2 * time.Hour),
+			},
+			wantErr: true,
+			errMsg:  "not yet valid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			certPEM := testutil.RSACert(t, tt.tmpl)
+			err := creds.ValidatePEM(certPEM, creds.CertificateNotExpired())
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestIsCACertificate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("CA cert passes", func(t *testing.T) {
+		t.Parallel()
+
+		certPEM := testutil.RSACert(t, caTemplate())
+		require.NoError(t, creds.ValidatePEM(certPEM, creds.IsCACertificate()))
+	})
+
+	t.Run("non-CA cert fails", func(t *testing.T) {
+		t.Parallel()
+
+		certPEM := testutil.RSACert(t, validTemplate())
+		err := creds.ValidatePEM(certPEM, creds.IsCACertificate())
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "not a CA")
+	})
+}
+
+func TestUsesSecureCertificateAlgorithm(t *testing.T) {
+	t.Parallel()
+
+	rsaSuites := []uint16{
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, // ECDSA suite
+		tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,   // RSA suite
+	}
+
+	t.Run("RSA cert with no suites passes", func(t *testing.T) {
+		t.Parallel()
+
+		certPEM := testutil.RSACert(t, validTemplate())
+		require.NoError(t, creds.ValidatePEM(certPEM, creds.UsesSecureCertificateAlgorithm()))
+	})
+
+	t.Run("ECDSA cert with no suites passes", func(t *testing.T) {
+		t.Parallel()
+
+		certPEM := testutil.ECDSACert(t, validTemplate())
+		require.NoError(t, creds.ValidatePEM(certPEM, creds.UsesSecureCertificateAlgorithm()))
+	})
+
+	t.Run("RSA cert with RSA suite passes", func(t *testing.T) {
+		t.Parallel()
+
+		certPEM := testutil.RSACert(t, validTemplate())
+		require.NoError(t, creds.ValidatePEM(certPEM, creds.UsesSecureCertificateAlgorithm(rsaSuites...)))
+	})
+
+	t.Run("ECDSA cert incompatible with RSA-only suites fails", func(t *testing.T) {
+		t.Parallel()
+
+		rsaOnlySuites := []uint16{
+			tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		}
+
+		certPEM := testutil.ECDSACert(t, validTemplate())
+		err := creds.ValidatePEM(certPEM, creds.UsesSecureCertificateAlgorithm(rsaOnlySuites...))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "key type")
+	})
+
+	t.Run("unknown suites skip key type check", func(t *testing.T) {
+		t.Parallel()
+
+		// 0xFFFF is intentionally not in suiteKeyTypes, so no key type constraint applies.
+		certPEM := testutil.ECDSACert(t, validTemplate())
+		require.NoError(t, creds.ValidatePEM(certPEM, creds.UsesSecureCertificateAlgorithm(0xFFFF)))
+	})
+}
+
+func TestUsesSecureCertificateAlgorithm_WeakAlgorithm(t *testing.T) {
+	t.Parallel()
+
+	// SHA1WithRSA is produced by openssl, but Go's x509.CreateCertificate does
+	// not expose SHA-1 signing for RSA directly. We construct and parse a
+	// certificate DER manually to simulate a weak-algorithm cert.
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	tmpl := &x509.Certificate{
+		SerialNumber:       big.NewInt(1),
+		Subject:            pkix.Name{CommonName: "sha1cert"},
+		NotBefore:          time.Now().Add(-time.Hour),
+		NotAfter:           time.Now().Add(time.Hour),
+		SignatureAlgorithm: x509.SHA1WithRSA,
+	}
+
+	// Go 1.21+ rejects SHA1 signing by default; we test the validator on a
+	// well-formed modern cert but swap the SignatureAlgorithm field after
+	// parsing to simulate the weak-algorithm case without relying on Go
+	// producing a SHA1 signature.
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	// CreateCertificate may error with SHA1 — if so, construct the cert object directly.
+	if err != nil {
+		// Build a parsed cert with a weak algorithm set manually.
+		goodTmpl := validTemplate()
+		der, err = x509.CreateCertificate(rand.Reader, goodTmpl, goodTmpl, &key.PublicKey, key)
+		require.NoError(t, err)
+
+		cert, parseErr := x509.ParseCertificate(der)
+		require.NoError(t, parseErr)
+
+		// Patch the signature algorithm to be weak.
+		cert.SignatureAlgorithm = x509.SHA1WithRSA
+
+		v := creds.UsesSecureCertificateAlgorithm()
+		err = v(cert)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "weak signature algorithm")
+		return
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	err = creds.ValidatePEM(certPEM, creds.UsesSecureCertificateAlgorithm())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "weak signature algorithm")
+}
+
+func writePEMFile(t *testing.T, data []byte) string {
+	t.Helper()
+	return testutil.WriteFile(t, t.TempDir(), "cert.pem", data)
+}
+
+func validTemplate() *x509.Certificate {
+	return &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+}
+
+func caTemplate() *x509.Certificate {
+	tmpl := validTemplate()
+	tmpl.IsCA = true
+	tmpl.BasicConstraintsValid = true
+	return tmpl
+}

--- a/pkg/testutil/certs.go
+++ b/pkg/testutil/certs.go
@@ -1,0 +1,144 @@
+package testutil
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// RSACert generates a self-signed RSA-2048 certificate from tmpl and returns
+// its PEM encoding. The generated key is discarded; callers that need a
+// matching key should use [GenerateSelfSignedCert] or [GenerateMTLSCerts].
+func RSACert(t *testing.T, tmpl *x509.Certificate) []byte {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}
+
+// ECDSACert generates a self-signed ECDSA P-256 certificate from tmpl and
+// returns its PEM encoding. The generated key is discarded; callers that need
+// a matching key should use [GenerateSelfSignedCert] or [GenerateMTLSCerts].
+func ECDSACert(t *testing.T, tmpl *x509.Certificate) []byte {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}
+
+// GenerateSelfSignedCert writes a self-signed ECDSA P-256 certificate and its
+// matching PKCS#1-style EC private key to a fresh [testing.T.TempDir] and
+// returns the paths. The certificate is valid for one hour, advertises CN
+// "localhost" with DNSNames=["localhost"], and is suitable for loading via
+// [crypto/tls.LoadX509KeyPair] in server-auth scenarios.
+func GenerateSelfSignedCert(t *testing.T) (certFile, keyFile string) {
+	t.Helper()
+
+	dir := t.TempDir()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:     []string{"localhost"},
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	certFile = WriteFile(t, dir, "cert.pem", certPEM)
+
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	require.NoError(t, err)
+
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	keyFile = WriteFile(t, dir, "key.pem", keyPEM)
+
+	return certFile, keyFile
+}
+
+// GenerateMTLSCerts writes a self-signed ECDSA P-256 CA certificate plus a
+// leaf certificate signed by that CA (with its matching key) to a fresh
+// [testing.T.TempDir] and returns the three paths. The leaf advertises CN
+// "localhost" with DNSNames=["localhost"]; both certificates are valid for
+// one hour. Use this when a test needs the leaf to verify against the CA.
+func GenerateMTLSCerts(t *testing.T) (caFile, certFile, keyFile string) {
+	t.Helper()
+
+	dir := t.TempDir()
+
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	caTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(2),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	caDER, err := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
+	require.NoError(t, err)
+
+	caCert, err := x509.ParseCertificate(caDER)
+	require.NoError(t, err)
+
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})
+	caFile = WriteFile(t, dir, "ca.pem", caPEM)
+
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	leafTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(3),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:     []string{"localhost"},
+	}
+
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTmpl, caCert, &leafKey.PublicKey, caKey)
+	require.NoError(t, err)
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: leafDER})
+	certFile = WriteFile(t, dir, "cert.pem", certPEM)
+
+	leafKeyDER, err := x509.MarshalECPrivateKey(leafKey)
+	require.NoError(t, err)
+
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: leafKeyDER})
+	keyFile = WriteFile(t, dir, "key.pem", keyPEM)
+
+	return caFile, certFile, keyFile
+}

--- a/pkg/testutil/certs_test.go
+++ b/pkg/testutil/certs_test.go
@@ -1,0 +1,121 @@
+package testutil_test
+
+import (
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/temporalio/temporal-proxy/pkg/testutil"
+)
+
+func TestRSACert(t *testing.T) {
+	t.Parallel()
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(42),
+		Subject:      pkix.Name{CommonName: "rsa-test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+
+	cert := parseSingleCert(t, testutil.RSACert(t, tmpl))
+	require.Equal(t, "rsa-test", cert.Subject.CommonName)
+	require.IsType(t, &rsa.PublicKey{}, cert.PublicKey)
+	require.Equal(t, 2048, cert.PublicKey.(*rsa.PublicKey).Size()*8)
+}
+
+func TestECDSACert(t *testing.T) {
+	t.Parallel()
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(43),
+		Subject:      pkix.Name{CommonName: "ecdsa-test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+
+	cert := parseSingleCert(t, testutil.ECDSACert(t, tmpl))
+	require.Equal(t, "ecdsa-test", cert.Subject.CommonName)
+
+	pub, ok := cert.PublicKey.(*ecdsa.PublicKey)
+	require.True(t, ok)
+	require.Equal(t, "P-256", pub.Curve.Params().Name)
+}
+
+func TestGenerateSelfSignedCert(t *testing.T) {
+	t.Parallel()
+
+	certFile, keyFile := testutil.GenerateSelfSignedCert(t)
+
+	// Both files should be loadable as a tls.Certificate pair, which verifies
+	// the key matches the cert.
+	pair, err := tls.LoadX509KeyPair(certFile, keyFile)
+	require.NoError(t, err)
+	require.NotEmpty(t, pair.Certificate)
+
+	certPEM, err := os.ReadFile(certFile)
+	require.NoError(t, err)
+
+	cert := parseSingleCert(t, certPEM)
+	require.Equal(t, "localhost", cert.Subject.CommonName)
+	require.Equal(t, []string{"localhost"}, cert.DNSNames)
+	require.Contains(t, cert.ExtKeyUsage, x509.ExtKeyUsageServerAuth)
+
+	// Cert window: one hour total, centered roughly on now.
+	require.WithinDuration(t, time.Now(), cert.NotBefore, 2*time.Hour)
+	require.WithinDuration(t, time.Now(), cert.NotAfter, 2*time.Hour)
+}
+
+func TestGenerateMTLSCerts(t *testing.T) {
+	t.Parallel()
+
+	caFile, certFile, keyFile := testutil.GenerateMTLSCerts(t)
+
+	// Leaf + key load as a pair.
+	_, err := tls.LoadX509KeyPair(certFile, keyFile)
+	require.NoError(t, err)
+
+	caPEM, err := os.ReadFile(caFile)
+	require.NoError(t, err)
+	caCert := parseSingleCert(t, caPEM)
+	require.True(t, caCert.IsCA, "CA cert must have IsCA=true")
+	require.Equal(t, "test-ca", caCert.Subject.CommonName)
+
+	leafPEM, err := os.ReadFile(certFile)
+	require.NoError(t, err)
+	leaf := parseSingleCert(t, leafPEM)
+	require.Equal(t, "localhost", leaf.Subject.CommonName)
+
+	// The leaf must verify against the CA, otherwise the helper has produced
+	// material that can't be used for an mTLS handshake.
+	pool := x509.NewCertPool()
+	pool.AddCert(caCert)
+	_, err = leaf.Verify(x509.VerifyOptions{
+		Roots:     pool,
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSName:   "localhost",
+	})
+	require.NoError(t, err)
+}
+
+func parseSingleCert(t *testing.T, pemBytes []byte) *x509.Certificate {
+	t.Helper()
+
+	block, rest := pem.Decode(pemBytes)
+	require.NotNil(t, block, "expected a PEM block")
+	require.Equal(t, "CERTIFICATE", block.Type)
+	require.Empty(t, rest, "expected exactly one PEM block")
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	require.NoError(t, err)
+	return cert
+}

--- a/pkg/testutil/doc.go
+++ b/pkg/testutil/doc.go
@@ -1,0 +1,3 @@
+// Package testutil provides helpers and utilities to make testing easier and
+// less tedious.
+package testutil

--- a/pkg/testutil/fs.go
+++ b/pkg/testutil/fs.go
@@ -1,0 +1,22 @@
+package testutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// WriteFile writes contents to dir/name with mode 0600 and returns the full
+// path. Any IO failure fails the test immediately. Callers typically pass
+// [testing.T.TempDir] as dir so cleanup is automatic.
+func WriteFile(t *testing.T, dir, name string, contents []byte) string {
+	t.Helper()
+
+	path := filepath.Join(dir, name)
+	err := os.WriteFile(path, contents, 0o600)
+	require.NoError(t, err)
+
+	return path
+}

--- a/pkg/testutil/fs_test.go
+++ b/pkg/testutil/fs_test.go
@@ -1,0 +1,48 @@
+package testutil_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/temporalio/temporal-proxy/pkg/testutil"
+)
+
+func TestWriteFile(t *testing.T) {
+	t.Parallel()
+
+	t.Run("writes contents and returns full path", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		path := testutil.WriteFile(t, dir, "hello.txt", []byte("world"))
+
+		require.Equal(t, filepath.Join(dir, "hello.txt"), path)
+
+		got, err := os.ReadFile(path)
+		require.NoError(t, err)
+		require.Equal(t, []byte("world"), got)
+	})
+
+	t.Run("file is created with 0600 perms", func(t *testing.T) {
+		t.Parallel()
+
+		path := testutil.WriteFile(t, t.TempDir(), "secret", []byte("x"))
+
+		info, err := os.Stat(path)
+		require.NoError(t, err)
+		require.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+	})
+
+	t.Run("empty contents are allowed", func(t *testing.T) {
+		t.Parallel()
+
+		path := testutil.WriteFile(t, t.TempDir(), "empty", nil)
+
+		got, err := os.ReadFile(path)
+		require.NoError(t, err)
+		require.Empty(t, got)
+	})
+}

--- a/pkg/validation/checks.go
+++ b/pkg/validation/checks.go
@@ -1,0 +1,36 @@
+package validation
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Check verifies a single value of type V. A nil return means valid.
+type Check[V any] func(V) error
+
+// Required rejects the zero value of V. Note that this means Required[bool]()
+// rejects false; reach for a different check when false is a meaningful value.
+func Required[V comparable]() Check[V] {
+	return func(v V) error {
+		var zero V
+		if v == zero {
+			return errors.New("is required")
+		}
+		return nil
+	}
+}
+
+// Unique rejects a slice containing two or more equal elements. The error
+// message names the first duplicate encountered.
+func Unique[V comparable]() Check[[]V] {
+	return func(vs []V) error {
+		seen := make(map[V]struct{}, len(vs))
+		for _, v := range vs {
+			if _, dup := seen[v]; dup {
+				return fmt.Errorf("contains duplicate value: %v", v)
+			}
+			seen[v] = struct{}{}
+		}
+		return nil
+	}
+}

--- a/pkg/validation/checks_test.go
+++ b/pkg/validation/checks_test.go
@@ -1,0 +1,108 @@
+package validation_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/temporalio/temporal-proxy/pkg/validation"
+)
+
+type sampleStruct struct {
+	Name string
+	Age  int
+}
+
+func TestRequired_String(t *testing.T) {
+	t.Parallel()
+
+	check := validation.Required[string]()
+	require.NoError(t, check("foo"))
+	require.Error(t, check(""))
+}
+
+func TestRequired_Int(t *testing.T) {
+	t.Parallel()
+
+	check := validation.Required[int]()
+	require.NoError(t, check(42))
+	require.NoError(t, check(-1))
+	require.Error(t, check(0))
+}
+
+func TestRequired_Pointer(t *testing.T) {
+	t.Parallel()
+
+	check := validation.Required[*string]()
+	s := "x"
+	require.NoError(t, check(&s))
+	require.Error(t, check(nil))
+}
+
+func TestRequired_Struct(t *testing.T) {
+	t.Parallel()
+
+	check := validation.Required[sampleStruct]()
+	require.NoError(t, check(sampleStruct{Name: "bob"}))
+	require.Error(t, check(sampleStruct{}))
+}
+
+func TestRequired_TypeInferenceWithField(t *testing.T) {
+	t.Parallel()
+
+	// Sanity check that Required composes with Field. Note: Required must be
+	// explicitly instantiated (Required[string]()) because Go's type inference
+	// does not propagate Field's V through the Check[V] return type.
+	rule := validation.Field("name", "", validation.Required[string]())
+	errs := rule()
+	require.Len(t, errs, 1)
+}
+
+func TestUnique(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		input   []string
+		wantErr bool
+	}{
+		{name: "empty slice", input: nil, wantErr: false},
+		{name: "single element", input: []string{"a"}, wantErr: false},
+		{name: "all distinct", input: []string{"a", "b", "c"}, wantErr: false},
+		{name: "one duplicate", input: []string{"a", "b", "a"}, wantErr: true},
+		{name: "multiple duplicates", input: []string{"a", "a", "b", "b"}, wantErr: true},
+	}
+
+	check := validation.Unique[string]()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := check(tc.input)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestUnique_Int(t *testing.T) {
+	t.Parallel()
+
+	check := validation.Unique[int]()
+	require.NoError(t, check([]int{1, 2, 3}))
+	require.Error(t, check([]int{1, 2, 2}))
+}
+
+func TestUnique_InferredFromField(t *testing.T) {
+	t.Parallel()
+
+	// Sanity check that Unique composes with Field. Note: Unique must be
+	// explicitly instantiated (Unique[string]()) because Go's type inference
+	// does not propagate Field's V through the Check[V] return type.
+	rule := validation.Field("tags", []string{"a", "a"}, validation.Unique[string]())
+	errs := rule()
+	require.Len(t, errs, 1)
+}

--- a/pkg/validation/doc.go
+++ b/pkg/validation/doc.go
@@ -1,0 +1,16 @@
+// Package validation provides structured error primitives plus a small
+// rule-based API for accumulating validation failures.
+//
+// An [Error] captures a single failure as a (Subject, Field, Message) triple,
+// where Subject identifies the thing being validated (e.g. a hostname or
+// certificate CN), Field names the attribute that failed, and Message
+// describes the failure in human-readable form. [Errors] aggregates multiple
+// [Error] values into a single error while remaining compatible with
+// [errors.Is], [errors.As], and [errors.Join] via its Unwrap method.
+//
+// Higher-level validation is expressed by passing a list of [Rule] values to
+// [Validate], typically constructed via [Field] and the built-in [Check]
+// functions ([Required], [Unique]). Validate accumulates every rule's output
+// into one Errors value and stamps the supplied subject onto entries that
+// don't already carry one.
+package validation

--- a/pkg/validation/errors.go
+++ b/pkg/validation/errors.go
@@ -1,0 +1,47 @@
+package validation
+
+import (
+	"errors"
+	"fmt"
+)
+
+type (
+	// Error is a single validation failure for a named subject and field.
+	Error struct {
+		Subject string // identifier of the thing being validated (e.g. a hostname or cert CN)
+		Field   string // attribute or property that failed (e.g. "expiry", "key_type")
+		Message string // human-readable description of the failure
+	}
+
+	// Errors is a collection of Error values.
+	Errors []Error
+)
+
+// Error implements the error interface.
+func (e Error) Error() string {
+	return fmt.Sprintf("%s: %s: %s", e.Subject, e.Field, e.Message)
+}
+
+// Error implements the error interface, joining all individual errors.
+func (ve Errors) Error() string {
+	if len(ve) == 0 {
+		return ""
+	}
+
+	errs := make([]error, len(ve))
+	for i, e := range ve {
+		errs[i] = e
+	}
+
+	return errors.Join(errs...).Error()
+}
+
+// Unwrap returns each Error as an individual error, enabling errors.As and errors.Is traversal.
+func (ve Errors) Unwrap() []error {
+	errs := make([]error, len(ve))
+	for i, e := range ve {
+		errs[i] = e
+	}
+
+	return errs
+}

--- a/pkg/validation/errors_test.go
+++ b/pkg/validation/errors_test.go
@@ -1,0 +1,162 @@
+package validation_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/temporalio/temporal-proxy/pkg/validation"
+)
+
+func TestErrorError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		subject  string
+		field    string
+		message  string
+		expected string
+	}{
+		{
+			name:     "basic format",
+			subject:  "example.com",
+			field:    "expiry",
+			message:  "certificate has expired",
+			expected: `example.com: expiry: certificate has expired`,
+		},
+		{
+			name:     "with special characters",
+			subject:  "*.temporal.io",
+			field:    "key_type",
+			message:  "expected RSA but got ECDSA",
+			expected: `*.temporal.io: key_type: expected RSA but got ECDSA`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ve := validation.Error{
+				Subject: tt.subject,
+				Field:   tt.field,
+				Message: tt.message,
+			}
+			require.Equal(t, tt.expected, ve.Error())
+		})
+	}
+}
+
+func TestErrorsError(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty slice returns empty string", func(t *testing.T) {
+		t.Parallel()
+		ve := validation.Errors{}
+		require.Equal(t, "", ve.Error())
+	})
+
+	t.Run("single error", func(t *testing.T) {
+		t.Parallel()
+		ve := validation.Errors{
+			{
+				Subject: "cert1.com",
+				Field:   "expiry",
+				Message: "expired",
+			},
+		}
+		errStr := ve.Error()
+		require.Contains(t, errStr, `cert1.com: expiry: expired`)
+	})
+
+	t.Run("multiple errors", func(t *testing.T) {
+		t.Parallel()
+		ve := validation.Errors{
+			{
+				Subject: "cert1.com",
+				Field:   "expiry",
+				Message: "expired",
+			},
+			{
+				Subject: "cert2.com",
+				Field:   "is_ca",
+				Message: "not a CA certificate",
+			},
+			{
+				Subject: "cert3.com",
+				Field:   "signature_algorithm",
+				Message: "unsupported algorithm",
+			},
+		}
+		errStr := ve.Error()
+		require.Contains(t, errStr, `cert1.com: expiry: expired`)
+		require.Contains(t, errStr, `cert2.com: is_ca: not a CA certificate`)
+		require.Contains(t, errStr, `cert3.com: signature_algorithm: unsupported algorithm`)
+	})
+}
+
+func TestErrorsUnwrap(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty slice", func(t *testing.T) {
+		t.Parallel()
+		ve := validation.Errors{}
+		unwrapped := ve.Unwrap()
+		require.Len(t, unwrapped, 0)
+	})
+
+	t.Run("single error", func(t *testing.T) {
+		t.Parallel()
+		ve := validation.Errors{
+			{
+				Subject: "cert1.com",
+				Field:   "expiry",
+				Message: "expired",
+			},
+		}
+		unwrapped := ve.Unwrap()
+		require.Len(t, unwrapped, 1)
+	})
+
+	t.Run("multiple errors", func(t *testing.T) {
+		t.Parallel()
+		ve := validation.Errors{
+			{
+				Subject: "cert1.com",
+				Field:   "expiry",
+				Message: "expired",
+			},
+			{
+				Subject: "cert2.com",
+				Field:   "is_ca",
+				Message: "not a CA certificate",
+			},
+		}
+		unwrapped := ve.Unwrap()
+		require.Len(t, unwrapped, 2)
+	})
+}
+
+func TestErrorsAsError(t *testing.T) {
+	t.Parallel()
+
+	ve := validation.Errors{
+		{
+			Subject: "cert1.com",
+			Field:   "expiry",
+			Message: "expired",
+		},
+		{
+			Subject: "cert2.com",
+			Field:   "is_ca",
+			Message: "not a CA certificate",
+		},
+	}
+
+	var validationErr validation.Error
+	require.True(t, errors.As(ve, &validationErr))
+	require.Equal(t, "cert1.com", validationErr.Subject)
+	require.Equal(t, "expiry", validationErr.Field)
+	require.Equal(t, "expired", validationErr.Message)
+}

--- a/pkg/validation/rules.go
+++ b/pkg/validation/rules.go
@@ -1,0 +1,23 @@
+package validation
+
+// Rule produces zero or more validation errors when run.
+type Rule func() Errors
+
+// Field builds a Rule that runs every Check[V] against value and turns any
+// failure into validation.Errors entries. The returned Errors have their
+// Field stamped with name, unless the check returned a validation.Error or
+// validation.Errors with Field already set, in which case the existing value
+// is preserved.
+func Field[V any](name string, value V, checks ...Check[V]) Rule {
+	return func() Errors {
+		var errs Errors
+		for _, c := range checks {
+			err := c(value)
+			if err == nil {
+				continue
+			}
+			errs = append(errs, toErrors(name, err)...)
+		}
+		return errs
+	}
+}

--- a/pkg/validation/rules_test.go
+++ b/pkg/validation/rules_test.go
@@ -1,0 +1,101 @@
+package validation_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/temporalio/temporal-proxy/pkg/validation"
+)
+
+func TestField_NoChecks(t *testing.T) {
+	t.Parallel()
+
+	rule := validation.Field("name", "foo")
+	require.Empty(t, rule())
+}
+
+func TestField_NormalizesCheckOutput(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		checkRet error
+		want     validation.Errors
+	}{
+		{
+			name:     "nil produces no entries",
+			checkRet: nil,
+			want:     nil,
+		},
+		{
+			name:     "plain error is wrapped with Field name",
+			checkRet: errors.New("boom"),
+			want:     validation.Errors{{Field: "name", Message: "boom"}},
+		},
+		{
+			name:     "validation.Error with empty Field gets stamped",
+			checkRet: validation.Error{Message: "boom"},
+			want:     validation.Errors{{Field: "name", Message: "boom"}},
+		},
+		{
+			name:     "validation.Error with explicit fields is preserved",
+			checkRet: validation.Error{Subject: "explicit", Field: "explicit-field", Message: "boom"},
+			want:     validation.Errors{{Subject: "explicit", Field: "explicit-field", Message: "boom"}},
+		},
+		{
+			name: "validation.Errors entries with empty Field are stamped",
+			checkRet: validation.Errors{
+				{Field: "explicit", Message: "boom1"},
+				{Message: "boom2"},
+			},
+			want: validation.Errors{
+				{Field: "explicit", Message: "boom1"},
+				{Field: "name", Message: "boom2"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			check := func(string) error { return tt.checkRet }
+			rule := validation.Field("name", "foo", check)
+			require.Equal(t, tt.want, rule())
+		})
+	}
+}
+
+func TestField_RunsAllChecks(t *testing.T) {
+	t.Parallel()
+
+	failA := func(string) error { return errors.New("a") }
+	failB := func(string) error { return errors.New("b") }
+	rule := validation.Field("name", "foo", failA, failB)
+
+	errs := rule()
+	require.Len(t, errs, 2)
+	require.Equal(t, "a", errs[0].Message)
+	require.Equal(t, "b", errs[1].Message)
+}
+
+func TestField_DoesNotMutateCheckOutput(t *testing.T) {
+	t.Parallel()
+
+	// A check that returns the same validation.Errors value every time. If
+	// Field mutates the returned slice in place, the second call will see
+	// the entries' Field already populated and silently skip stamping.
+	shared := validation.Errors{{Message: "boom"}}
+	check := func(string) error { return shared }
+
+	first := validation.Field("first", "x", check)()
+	second := validation.Field("second", "x", check)()
+
+	require.Len(t, first, 1)
+	require.Len(t, second, 1)
+	require.Equal(t, "first", first[0].Field)
+	require.Equal(t, "second", second[0].Field, "second Field call must stamp independently")
+	require.Empty(t, shared[0].Field, "the caller's Errors value must not be mutated")
+}

--- a/pkg/validation/validate.go
+++ b/pkg/validation/validate.go
@@ -1,0 +1,43 @@
+package validation
+
+// Validate runs each rule, accumulating failures into a single Errors. Any
+// Error returned by a rule whose Subject is empty is stamped with subject.
+// Returns nil when no rule produced an error.
+func Validate(subject string, rules ...Rule) Errors {
+	var errs Errors
+	for _, r := range rules {
+		errs = append(errs, r()...)
+	}
+
+	if len(errs) == 0 {
+		return nil
+	}
+
+	for i := range errs {
+		if errs[i].Subject == "" {
+			errs[i].Subject = subject
+		}
+	}
+
+	return errs
+}
+
+func toErrors(field string, err error) Errors {
+	if ves, ok := err.(Errors); ok {
+		out := make(Errors, len(ves))
+		copy(out, ves)
+		for i := range out {
+			if out[i].Field == "" {
+				out[i].Field = field
+			}
+		}
+		return out
+	}
+	if ve, ok := err.(Error); ok {
+		if ve.Field == "" {
+			ve.Field = field
+		}
+		return Errors{ve}
+	}
+	return Errors{{Field: field, Message: err.Error()}}
+}

--- a/pkg/validation/validate_test.go
+++ b/pkg/validation/validate_test.go
@@ -1,0 +1,81 @@
+package validation_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/temporalio/temporal-proxy/pkg/validation"
+)
+
+func TestValidate_NoRules(t *testing.T) {
+	t.Parallel()
+
+	require.Nil(t, validation.Validate("subj"))
+}
+
+func TestValidate_AllRulesPass(t *testing.T) {
+	t.Parallel()
+
+	pass := func() validation.Errors { return nil }
+
+	require.Nil(t, validation.Validate("subj", pass, pass))
+}
+
+func TestValidate_SubjectStamping(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		outerSubj   string
+		ruleErr     validation.Error
+		wantSubject string
+	}{
+		{
+			name:        "empty Subject is stamped with outer",
+			outerSubj:   "user-42",
+			ruleErr:     validation.Error{Field: "name", Message: "is required"},
+			wantSubject: "user-42",
+		},
+		{
+			name:        "explicit Subject is preserved",
+			outerSubj:   "outer",
+			ruleErr:     validation.Error{Subject: "nested", Field: "name", Message: "boom"},
+			wantSubject: "nested",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			rule := func() validation.Errors { return validation.Errors{tt.ruleErr} }
+			errs := validation.Validate(tt.outerSubj, rule)
+			require.Len(t, errs, 1)
+			require.Equal(t, tt.wantSubject, errs[0].Subject)
+		})
+	}
+}
+
+func TestValidate_ConcatenatesFromMultipleRules(t *testing.T) {
+	t.Parallel()
+
+	a := func() validation.Errors {
+		return validation.Errors{{Field: "a", Message: "bad"}}
+	}
+	b := func() validation.Errors {
+		return validation.Errors{
+			{Field: "b", Message: "bad"},
+			{Field: "c", Message: "bad"},
+		}
+	}
+
+	errs := validation.Validate("subj", a, b)
+	require.Len(t, errs, 3)
+
+	// Errors implements error, so errors.As must still find the aggregate.
+	var verrs validation.Errors
+	require.True(t, errors.As(errs, &verrs))
+	require.Len(t, verrs, 3)
+}


### PR DESCRIPTION
Adds pkg/validation, a small package for collecting validation failures into a structured Errors value while keeping the call site explicit and type-safe.

The core types are:

* Error (a Subject/Field/Message triple)
* Errors (an errors.Is/As/Join-compatible aggregate via Unwrap)
* Rule (a function that produces Errors)
* Check[V] (a function that verifies one value of type V).

For now, the built-in checks are Required and Unique. However, I've designed the API to allow for things like `When[T any](Predicate[T], Check[T]) Rule` or `Range[T comparable](min, max T) Rule` in the future.

I also wired the new API into internal/transport/creds to handle basic cert/CA validation. We needed these checks and I needed something to test drive the validation API.
