### PR TITLE
[config]: Validate Config and its TLS material at startup

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,8 @@ import (
 	"os"
 
 	"github.com/goccy/go-yaml"
+
+	"github.com/temporalio/temporal-proxy/pkg/validation"
 )
 
 type (
@@ -42,4 +44,8 @@ func LoadFile(path string) (*Config, error) {
 	defer func() { _ = f.Close() }()
 
 	return Load(f)
+}
+
+func (c *Config) Validate() error {
+	return validation.Validate("", validation.Nested("", &c.Listen))
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/temporalio/temporal-proxy/internal/config"
+	"github.com/temporalio/temporal-proxy/pkg/validation"
 )
 
 type errReader struct{ err error }
@@ -127,6 +128,78 @@ func TestLoadFile_MissingFile(t *testing.T) {
 
 	_, err := config.LoadFile(filepath.Join(t.TempDir(), "does-not-exist.yaml"))
 	require.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestConfig_Validate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		cfg        *config.Config
+		wantTuples [][2]string // (Subject, Field); empty slice means no error expected
+	}{
+		{
+			name: "valid hostPort, no TLS",
+			cfg: &config.Config{
+				Listen: config.ListenConfig{HostPort: ":8080"},
+			},
+		},
+		{
+			name: "invalid hostPort surfaces from ListenConfig",
+			cfg: &config.Config{
+				Listen: config.ListenConfig{HostPort: "localhost"},
+			},
+			wantTuples: [][2]string{{"", "hostPort"}},
+		},
+		{
+			name: "broken TLS surfaces with tls subject stamped by parent",
+			cfg: &config.Config{
+				Listen: config.ListenConfig{
+					HostPort: ":8080",
+					TLS:      &config.TLSConfig{}, // empty -> creds.TLS PEM read failures
+				},
+			},
+			wantTuples: [][2]string{
+				{"tls", "cert"},
+				{"tls", "key"},
+			},
+		},
+		{
+			name: "hostPort and TLS failures aggregate",
+			cfg: &config.Config{
+				Listen: config.ListenConfig{
+					HostPort: "localhost",
+					TLS:      &config.TLSConfig{},
+				},
+			},
+			wantTuples: [][2]string{
+				{"", "hostPort"},
+				{"tls", "cert"},
+				{"tls", "key"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tt.cfg.Validate()
+			if len(tt.wantTuples) == 0 {
+				require.NoError(t, err)
+				return
+			}
+
+			var errs validation.Errors
+			require.True(t, errors.As(err, &errs), "expected validation.Errors, got %T", err)
+
+			got := make([][2]string, len(errs))
+			for i, e := range errs {
+				got[i] = [2]string{e.Subject, e.Field}
+			}
+			require.ElementsMatch(t, tt.wantTuples, got)
+		})
+	}
 }
 
 func (e *errReader) Read(_ []byte) (int, error) { return 0, e.err }

--- a/internal/config/listen.go
+++ b/internal/config/listen.go
@@ -1,5 +1,10 @@
 package config
 
+import (
+	"github.com/temporalio/temporal-proxy/internal/transport/creds"
+	"github.com/temporalio/temporal-proxy/pkg/validation"
+)
+
 type (
 	// ListenConfig defines properties for an inbound listener.
 	ListenConfig struct {
@@ -14,9 +19,38 @@ type (
 	// NB: Be sure to set ServerName when the host name you dial doesn't match the
 	// CN or SAN on the server's certificate.
 	TLSConfig struct {
-		CAFile     string `yaml:"ca"`         // PEM-encoded CA certificate (mTLS only)
-		CertFile   string `yaml:"cert"`       // PEM-encoded server certificate
-		KeyFile    string `yaml:"key"`        // PEM-encoded private key
+		CA         string `yaml:"ca"`         // PEM-encoded CA certificate (mTLS only)
+		Cert       string `yaml:"cert"`       // PEM-encoded server certificate
+		Key        string `yaml:"key"`        // PEM-encoded private key
 		ServerName string `yaml:"serverName"` // Optional SNI override
 	}
 )
+
+func (l *ListenConfig) Validate() error {
+	return validation.Validate(
+		"",
+		validation.Field("hostPort", l.HostPort, validation.IsHostPort()),
+		validation.WhenRules(
+			func() bool { return l.TLS != nil },
+			validation.Nested("tls", l.TLS),
+		),
+	)
+}
+
+func (t *TLSConfig) Validate() error {
+	return validation.Validate(
+		"",
+		validation.WhenRules(
+			func() bool { return t.CA != "" },
+			validation.Nested(
+				"", creds.NewMTLS(t.CA, t.Cert, t.Key, creds.MTLSOptions{
+					ServerName: t.ServerName,
+				}),
+			),
+		),
+		validation.WhenRules(
+			func() bool { return t.CA == "" },
+			validation.Nested("", creds.NewServerTLS(t.Cert, t.Key)),
+		),
+	)
+}

--- a/internal/config/listen_test.go
+++ b/internal/config/listen_test.go
@@ -1,0 +1,144 @@
+package config_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/temporalio/temporal-proxy/internal/config"
+	"github.com/temporalio/temporal-proxy/pkg/validation"
+)
+
+func TestListenConfig_Validate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		cfg      *config.ListenConfig
+		wantErrs []validation.Error
+	}{
+		{
+			name: "no TLS, valid hostPort",
+			cfg:  &config.ListenConfig{HostPort: ":8080"},
+		},
+		{
+			name: "invalid hostPort",
+			cfg:  &config.ListenConfig{HostPort: "localhost"},
+			wantErrs: []validation.Error{
+				{Field: "hostPort", Message: "is not a valid host:port"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tt.cfg.Validate()
+			if len(tt.wantErrs) == 0 {
+				require.NoError(t, err)
+				return
+			}
+
+			var errs validation.Errors
+			require.True(t, errors.As(err, &errs), "expected validation.Errors, got %T", err)
+			require.ElementsMatch(t, tt.wantErrs, []validation.Error(errs))
+		})
+	}
+}
+
+// TestListenConfig_Validate_TLS_RouteSelection exercises the branch in
+// TLSConfig.Validate that picks creds.TLS when CA is empty and creds.MTLS
+// when CA is set. The deep cert-content checks live in creds' own tests; we
+// fingerprint the routing decision via the (Subject, Field) tuples that
+// surface for missing files, which is stable across both routes.
+func TestListenConfig_Validate_TLS_RouteSelection(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		tls  *config.TLSConfig
+		// Each entry is the (Subject, Field) tuple expected on one Error.
+		// Messages are intentionally not pinned: creds errors include the
+		// host's filesystem-error wording which differs across OSes.
+		wantTuples [][2]string
+	}{
+		{
+			name: "empty TLS routes through creds.TLS (CA empty)",
+			tls:  &config.TLSConfig{},
+			wantTuples: [][2]string{
+				{"tls", "cert"}, // creds.TLS PEM read failure on cert
+				{"tls", "key"},  // creds.TLS PEM read failure on key
+			},
+		},
+		{
+			name: "missing-file paths route through creds.TLS (CA empty)",
+			tls: &config.TLSConfig{
+				Cert: "/missing/cert.pem",
+				Key:  "/missing/key.pem",
+			},
+			wantTuples: [][2]string{
+				{"tls", "cert"}, // creds.TLS PEM read failure on cert
+				{"tls", "key"},  // creds.TLS PEM read failure on key (no "ca")
+			},
+		},
+		{
+			name: "CA set routes through creds.MTLS",
+			tls: &config.TLSConfig{
+				Cert: "/missing/cert.pem",
+				Key:  "/missing/key.pem",
+				CA:   "/missing/ca.pem",
+			},
+			wantTuples: [][2]string{
+				{"tls", "cert"}, // creds.MTLS PEM read failure on cert
+				{"tls", "key"},  // creds.MTLS PEM read failure on key
+				{"tls", "ca"},   // creds.MTLS PEM read failure on ca
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := &config.ListenConfig{HostPort: ":8080", TLS: tt.tls}
+			err := cfg.Validate()
+			require.Error(t, err)
+
+			var errs validation.Errors
+			require.True(t, errors.As(err, &errs))
+
+			got := make([][2]string, len(errs))
+			for i, e := range errs {
+				got[i] = [2]string{e.Subject, e.Field}
+			}
+			require.ElementsMatch(t, tt.wantTuples, got)
+		})
+	}
+}
+
+func TestTLSConfig_Validate(t *testing.T) {
+	t.Parallel()
+
+	// Called standalone (not via Nested), entries keep the empty Subject
+	// that TLSConfig.Validate sets. An empty struct routes through the
+	// CA=="" branch (creds.TLS), so we expect cert + key PEM read failures.
+	tls := &config.TLSConfig{}
+	err := tls.Validate()
+	require.Error(t, err)
+
+	var errs validation.Errors
+	require.True(t, errors.As(err, &errs))
+	require.Len(t, errs, 2)
+
+	for _, e := range errs {
+		require.Empty(t, e.Subject, "standalone Validate leaves Subject empty")
+	}
+
+	fields := make([]string, len(errs))
+	for i, e := range errs {
+		fields[i] = e.Field
+	}
+	require.ElementsMatch(t, []string{"cert", "key"}, fields)
+}

--- a/internal/server/fx.go
+++ b/internal/server/fx.go
@@ -15,6 +15,10 @@ import (
 // Module is the fx module that constructs a [Server] from [ServerParams] and
 // binds its lifecycle to the application.
 var Module = fx.Option(fx.Invoke(func(p ServerParams) error {
+	if err := p.Config.Validate(); err != nil {
+		return fmt.Errorf("invalid configuration: %w", err)
+	}
+
 	opts := make([]Option, 0, 3)
 	opts = append(opts, WithCredentials(p.creds()))
 
@@ -82,15 +86,16 @@ func (p *ServerParams) creds() Credentials {
 		return creds.NewInsecure()
 	}
 
-	if tls.CAFile != "" {
+	if tls.CA != "" {
 		return creds.NewMTLS(
-			tls.CAFile,
-			tls.CertFile,
-			tls.KeyFile,
+			tls.CA,
+			tls.Cert,
+			tls.Key,
 			creds.MTLSOptions{
 				ServerName: tls.ServerName,
-			})
+			},
+		)
 	}
 
-	return creds.NewServerTLS(tls.CertFile, tls.KeyFile)
+	return creds.NewServerTLS(tls.Cert, tls.Key)
 }

--- a/internal/server/fx_test.go
+++ b/internal/server/fx_test.go
@@ -2,7 +2,6 @@ package server_test
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -14,6 +13,7 @@ import (
 
 	"github.com/temporalio/temporal-proxy/internal/config"
 	"github.com/temporalio/temporal-proxy/internal/server"
+	"github.com/temporalio/temporal-proxy/pkg/validation"
 )
 
 func TestModule(t *testing.T) {
@@ -22,7 +22,8 @@ func TestModule(t *testing.T) {
 	t.Run("wires defaults and runs the lifecycle", func(t *testing.T) {
 		t.Parallel()
 
-		app := newTestApp(t,
+		app := newTestApp(
+			t,
 			fx.Supply(&config.Config{
 				Listen: config.ListenConfig{HostPort: "127.0.0.1:0"},
 			}),
@@ -44,7 +45,8 @@ func TestModule(t *testing.T) {
 			return grpc_health_v1.HealthCheckResponse_SERVING
 		})
 
-		app := newTestApp(t,
+		app := newTestApp(
+			t,
 			fx.Supply(
 				&config.Config{Listen: config.ListenConfig{HostPort: "127.0.0.1:0"}},
 				fx.Annotate(hc, fx.As(new(server.HealthCheck))),
@@ -61,9 +63,12 @@ func TestModule(t *testing.T) {
 		require.NoError(t, app.Stop(stopCtx))
 	})
 
-	t.Run("surfaces server construction errors", func(t *testing.T) {
+	t.Run("rejects invalid configuration before construction", func(t *testing.T) {
 		t.Parallel()
 
+		// TLS paths that don't exist trip creds.TLS.Validate at config-validation
+		// time, before any server is constructed or listener bound. The fx
+		// Invoke wraps the validation.Errors with "invalid configuration: %w".
 		missing := filepath.Join(t.TempDir(), "missing.pem")
 
 		app := fx.New(
@@ -73,8 +78,8 @@ func TestModule(t *testing.T) {
 					Listen: config.ListenConfig{
 						HostPort: "127.0.0.1:0",
 						TLS: &config.TLSConfig{
-							CertFile: missing,
-							KeyFile:  missing,
+							Cert: missing,
+							Key:  missing,
 						},
 					},
 				},
@@ -84,15 +89,24 @@ func TestModule(t *testing.T) {
 		)
 
 		require.Error(t, app.Err())
-		require.ErrorIs(t, app.Err(), os.ErrNotExist)
+		require.ErrorContains(t, app.Err(), "invalid configuration")
+
+		var errs validation.Errors
+		require.ErrorAs(t, app.Err(), &errs, "expected validation.Errors in chain")
+		require.NotEmpty(t, errs)
 	})
 
 	t.Run("surfaces listener creation errors at start", func(t *testing.T) {
 		t.Parallel()
 
-		app := newTestApp(t,
+		// 1.2.3.4:0 is a well-formed host:port (passes IsHostPort and so
+		// passes config validation) but isn't a local interface, so the
+		// runtime bind fails with EADDRNOTAVAIL. This exercises the
+		// listener-failure path that validation alone can't catch.
+		app := newTestApp(
+			t,
 			fx.Supply(&config.Config{
-				Listen: config.ListenConfig{HostPort: "not-a-valid-host:port"},
+				Listen: config.ListenConfig{HostPort: "1.2.3.4:0"},
 			}),
 		)
 

--- a/internal/transport/creds/mtls.go
+++ b/internal/transport/creds/mtls.go
@@ -114,7 +114,7 @@ func (c *MTLS) ServerOption() (grpc.ServerOption, error) {
 // strong algorithm. Both files are always checked; failures are collected
 // into a single [validation.Errors] so callers see every problem in one call.
 func (c *MTLS) Validate() error {
-	if errs := validation.Validate(
+	return validation.Validate(
 		"",
 		validation.Field("cert", c.certFile, func(path string) error {
 			return ValidatePEMFile(
@@ -123,6 +123,7 @@ func (c *MTLS) Validate() error {
 				UsesSecureCertificateAlgorithm(preferredCipherSuites...),
 			)
 		}),
+		validation.Field("key", c.keyFile, ValidatePEMKeyFile),
 		validation.Field("ca", c.caFile, func(path string) error {
 			return ValidatePEMFile(
 				path,
@@ -131,9 +132,5 @@ func (c *MTLS) Validate() error {
 				UsesSecureCertificateAlgorithm(),
 			)
 		}),
-	); len(errs) > 0 {
-		return errs
-	}
-
-	return nil
+	)
 }

--- a/internal/transport/creds/mtls_test.go
+++ b/internal/transport/creds/mtls_test.go
@@ -203,7 +203,7 @@ func TestMTLS_Validate(t *testing.T) {
 	t.Run("valid leaf and CA pass", func(t *testing.T) {
 		t.Parallel()
 
-		err := creds.NewMTLS(validCA(t), validLeaf(t), "", creds.MTLSOptions{}).Validate()
+		err := creds.NewMTLS(validCA(t), validLeaf(t), validKey(t), creds.MTLSOptions{}).Validate()
 		require.NoError(t, err)
 	})
 
@@ -244,7 +244,9 @@ func TestMTLS_Validate(t *testing.T) {
 		}))
 		nonCAFile := writePEMFile(t, testutil.RSACert(t, validTemplate()))
 
-		err := creds.NewMTLS(nonCAFile, expiredLeaf, "", creds.MTLSOptions{}).Validate()
+		// Pass a valid key file so the leaf/CA failures aren't joined by a
+		// third key-file error; this test's intent is leaf+CA aggregation.
+		err := creds.NewMTLS(nonCAFile, expiredLeaf, validKey(t), creds.MTLSOptions{}).Validate()
 		require.ErrorContains(t, err, "expired-leaf")
 		require.ErrorContains(t, err, "not a CA")
 

--- a/internal/transport/creds/tls.go
+++ b/internal/transport/creds/tls.go
@@ -83,7 +83,7 @@ func (c *TLS) ServerOption() (grpc.ServerOption, error) {
 // certFile and will fail with a read error; callers should only invoke Validate
 // on server-mode credentials.
 func (c *TLS) Validate() error {
-	if errs := validation.Validate(
+	return validation.Validate(
 		"",
 		validation.Field("cert", c.certFile, func(path string) error {
 			return ValidatePEMFile(
@@ -92,9 +92,6 @@ func (c *TLS) Validate() error {
 				UsesSecureCertificateAlgorithm(preferredCipherSuites...),
 			)
 		}),
-	); len(errs) > 0 {
-		return errs
-	}
-
-	return nil
+		validation.Field("key", c.keyFile, ValidatePEMKeyFile),
+	)
 }

--- a/internal/transport/creds/tls_test.go
+++ b/internal/transport/creds/tls_test.go
@@ -94,8 +94,10 @@ func TestTLS_Validate(t *testing.T) {
 		t.Parallel()
 
 		// preferredCipherSuites are RSA-only, so the leaf must use an RSA key.
+		// Validate only checks that the key file exists and is PEM; it does
+		// not verify cert/key matching (LoadX509KeyPair does that at runtime).
 		certFile := writePEMFile(t, testutil.RSACert(t, validTemplate()))
-		require.NoError(t, creds.NewServerTLS(certFile, "").Validate())
+		require.NoError(t, creds.NewServerTLS(certFile, validKey(t)).Validate())
 	})
 
 	t.Run("missing cert file", func(t *testing.T) {

--- a/internal/transport/creds/validation.go
+++ b/internal/transport/creds/validation.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/temporalio/temporal-proxy/pkg/validation"
@@ -61,6 +62,33 @@ func ValidatePEMFile(path string, validators ...Validator) error {
 	}
 
 	return ValidatePEM(data, validators...)
+}
+
+// ValidatePEMKeyFile reads path and verifies it contains at least one PEM
+// block whose type ends in "PRIVATE KEY" (covering "RSA PRIVATE KEY",
+// "EC PRIVATE KEY", and "PRIVATE KEY" for PKCS#8). The block contents are
+// not parsed; cryptographic validity and cert/key matching are exercised
+// at runtime by [crypto/tls.LoadX509KeyPair].
+func ValidatePEMKeyFile(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("failed to read PEM key file: %w", err)
+	}
+
+	for rest := data; len(rest) > 0; {
+		block, r := pem.Decode(rest)
+		if block == nil {
+			break
+		}
+
+		if strings.HasSuffix(block.Type, "PRIVATE KEY") {
+			return nil
+		}
+
+		rest = r
+	}
+
+	return errors.New("no PRIVATE KEY block found in PEM data")
 }
 
 // ValidatePEM parses all CERTIFICATE blocks from pemData and runs each

--- a/internal/transport/creds/validation_test.go
+++ b/internal/transport/creds/validation_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"math/big"
+	"os"
 	"testing"
 	"time"
 
@@ -291,9 +292,86 @@ func TestUsesSecureCertificateAlgorithm_WeakAlgorithm(t *testing.T) {
 	require.Contains(t, err.Error(), "weak signature algorithm")
 }
 
+func TestValidatePEMKeyFile(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid private key file", func(t *testing.T) {
+		t.Parallel()
+
+		require.NoError(t, creds.ValidatePEMKeyFile(validKey(t)))
+	})
+
+	t.Run("missing file", func(t *testing.T) {
+		t.Parallel()
+
+		err := creds.ValidatePEMKeyFile("/tmp/definitely-not-a-real-key.pem")
+		require.Error(t, err)
+		require.ErrorContains(t, err, "failed to read PEM key file")
+	})
+
+	t.Run("empty path", func(t *testing.T) {
+		t.Parallel()
+
+		err := creds.ValidatePEMKeyFile("")
+		require.Error(t, err)
+		require.ErrorContains(t, err, "failed to read PEM key file")
+	})
+
+	t.Run("non-PEM contents", func(t *testing.T) {
+		t.Parallel()
+
+		path := testutil.WriteFile(t, t.TempDir(), "key.pem", []byte("not pem at all"))
+		err := creds.ValidatePEMKeyFile(path)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "no PRIVATE KEY block")
+	})
+
+	t.Run("PEM with only certificate block", func(t *testing.T) {
+		t.Parallel()
+
+		// A CERTIFICATE block is valid PEM but not a private key.
+		path := writePEMFile(t, testutil.RSACert(t, validTemplate()))
+		err := creds.ValidatePEMKeyFile(path)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "no PRIVATE KEY block")
+	})
+
+	t.Run("PEM with mixed blocks accepts first PRIVATE KEY", func(t *testing.T) {
+		t.Parallel()
+
+		// A CERTIFICATE then a PRIVATE KEY block: the loop should keep
+		// scanning past the cert and accept the key.
+		certPEM := testutil.RSACert(t, validTemplate())
+
+		_, keyFile := testutil.GenerateSelfSignedCert(t)
+		keyPEM := readFile(t, keyFile)
+
+		mixed := append(append([]byte{}, certPEM...), keyPEM...)
+		path := testutil.WriteFile(t, t.TempDir(), "mixed.pem", mixed)
+		require.NoError(t, creds.ValidatePEMKeyFile(path))
+	})
+}
+
+func readFile(t *testing.T, path string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return data
+}
+
 func writePEMFile(t *testing.T, data []byte) string {
 	t.Helper()
 	return testutil.WriteFile(t, t.TempDir(), "cert.pem", data)
+}
+
+// validKey returns a path to a PEM-encoded private key file. The key
+// contents are not parsed by ValidatePEMKeyFile, so any PEM block typed
+// *PRIVATE KEY satisfies the check; this helper reuses the ECDSA key
+// produced by testutil to avoid duplicating key-generation code.
+func validKey(t *testing.T) string {
+	t.Helper()
+	_, keyFile := testutil.GenerateSelfSignedCert(t)
+	return keyFile
 }
 
 func validTemplate() *x509.Certificate {

--- a/pkg/validation/checks.go
+++ b/pkg/validation/checks.go
@@ -3,10 +3,23 @@ package validation
 import (
 	"errors"
 	"fmt"
+	"net"
 )
 
 // Check verifies a single value of type V. A nil return means valid.
 type Check[V any] func(V) error
+
+// IsHostPort validates that s is a host:port pair accepted by net.ResolveTCPAddr.
+// Both "host:port" and ":port" (listen-on-all-interfaces) forms are valid.
+func IsHostPort() Check[string] {
+	return func(s string) error {
+		if _, err := net.ResolveTCPAddr("tcp", s); err != nil {
+			return errors.New("is not a valid host:port")
+		}
+
+		return nil
+	}
+}
 
 // Required rejects the zero value of V. Note that this means Required[bool]()
 // rejects false; reach for a different check when false is a meaningful value.
@@ -16,6 +29,7 @@ func Required[V comparable]() Check[V] {
 		if v == zero {
 			return errors.New("is required")
 		}
+
 		return nil
 	}
 }
@@ -29,8 +43,10 @@ func Unique[V comparable]() Check[[]V] {
 			if _, dup := seen[v]; dup {
 				return fmt.Errorf("contains duplicate value: %v", v)
 			}
+
 			seen[v] = struct{}{}
 		}
+
 		return nil
 	}
 }

--- a/pkg/validation/checks_test.go
+++ b/pkg/validation/checks_test.go
@@ -106,3 +106,33 @@ func TestUnique_InferredFromField(t *testing.T) {
 	errs := rule()
 	require.Len(t, errs, 1)
 }
+
+func TestIsHostPort(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		in      string
+		wantErr bool
+	}{
+		{name: "host and port", in: "localhost:8080"},
+		{name: "ipv4 and port", in: "127.0.0.1:8080"},
+		{name: "wildcard host", in: ":8080"},
+		{name: "missing port", in: "localhost", wantErr: true},
+		{name: "url with scheme", in: "https://example.com:8080", wantErr: true},
+	}
+
+	check := validation.IsHostPort()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := check(tt.in)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/pkg/validation/combinators.go
+++ b/pkg/validation/combinators.go
@@ -1,0 +1,82 @@
+package validation
+
+// Validator is satisfied by any type whose Validate method returns an
+// error. Types that already follow the standard "Validate() error"
+// convention satisfy this interface implicitly.
+type Validator interface {
+	Validate() error
+}
+
+// When runs the supplied checks only when pred(v) returns true. When pred
+// returns false the combinator yields nil and no inner check runs. Inner
+// failures are aggregated into a single Errors return.
+func When[V any](pred func(V) bool, checks ...Check[V]) Check[V] {
+	return func(v V) error {
+		if !pred(v) {
+			return nil
+		}
+		var errs Errors
+		for _, c := range checks {
+			if err := c(v); err != nil {
+				errs = append(errs, toErrors("", err)...)
+			}
+		}
+		if len(errs) == 0 {
+			return nil
+		}
+		return errs
+	}
+}
+
+// WhenFn is When with a value-free predicate. Use it to guard checks on
+// captured outer state - for example, "if cfg.TLS != nil, require this
+// field" - where the predicate does not depend on the value under
+// validation.
+func WhenFn[V any](pred func() bool, checks ...Check[V]) Check[V] {
+	return When(func(V) bool { return pred() }, checks...)
+}
+
+// WhenRules runs the supplied rules only when pred returns true. When
+// pred returns false the combinator yields no entries. Use this to skip
+// an entire block of Field rules at once (for example, every TLS.* field
+// when TLS is not configured).
+func WhenRules(pred func() bool, rules ...Rule) Rule {
+	return func() Errors {
+		if !pred() {
+			return nil
+		}
+		var errs Errors
+		for _, r := range rules {
+			errs = append(errs, r()...)
+		}
+		return errs
+	}
+}
+
+// Nested embeds the result of v.Validate as a Rule. Entries whose
+// Subject was left empty by the child are stamped with subject; entries
+// the child already attributed (or whose Subject is non-empty for any
+// reason) are preserved unchanged. A nil error from v yields no entries,
+// and any non-validation error is wrapped as a single entry whose
+// Message is err.Error() and whose Subject is subject.
+func Nested(subject string, v Validator) Rule {
+	return func() Errors {
+		err := v.Validate()
+		if err == nil {
+			return nil
+		}
+
+		errs := toErrors("", err)
+		if subject == "" {
+			return errs
+		}
+
+		for i := range errs {
+			if errs[i].Subject == "" {
+				errs[i].Subject = subject
+			}
+		}
+
+		return errs
+	}
+}

--- a/pkg/validation/combinators_test.go
+++ b/pkg/validation/combinators_test.go
@@ -1,0 +1,308 @@
+package validation_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/temporalio/temporal-proxy/pkg/validation"
+)
+
+func TestWhen_PredicateFalse_DoesNotInvokeChecks(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	failing := func(string) error {
+		calls++
+		return errors.New("should not run")
+	}
+
+	c := validation.When(func(string) bool { return false }, failing)
+	require.NoError(t, c("anything"))
+	require.Zero(t, calls)
+}
+
+func TestWhen_PredicateTrue_AllPass_ReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	ok := func(string) error { return nil }
+	c := validation.When(func(string) bool { return true }, ok, ok)
+	require.NoError(t, c("anything"))
+}
+
+func TestWhen_PredicateTrue_AggregatesFailures(t *testing.T) {
+	t.Parallel()
+
+	failA := func(string) error { return errors.New("a") }
+	failB := func(string) error { return errors.New("b") }
+
+	c := validation.When(func(string) bool { return true }, failA, failB)
+	err := c("anything")
+	require.Error(t, err)
+
+	var errs validation.Errors
+	require.True(t, errors.As(err, &errs), "expected validation.Errors, got %T", err)
+	require.Len(t, errs, 2)
+	require.Equal(t, "a", errs[0].Message)
+	require.Equal(t, "b", errs[1].Message)
+}
+
+func TestWhen_PredicateReceivesValue(t *testing.T) {
+	t.Parallel()
+
+	var seen string
+	pred := func(s string) bool {
+		seen = s
+		return false
+	}
+
+	c := validation.When(pred, func(string) error { return nil })
+	require.NoError(t, c("hello"))
+	require.Equal(t, "hello", seen)
+}
+
+func TestWhen_PreservesExplicitField(t *testing.T) {
+	t.Parallel()
+
+	fail := func(string) error {
+		return validation.Error{Field: "explicit", Message: "boom"}
+	}
+	c := validation.When(func(string) bool { return true }, fail)
+
+	err := c("anything")
+	var errs validation.Errors
+	require.True(t, errors.As(err, &errs))
+	require.Len(t, errs, 1)
+	require.Equal(t, "explicit", errs[0].Field)
+	require.Equal(t, "boom", errs[0].Message)
+}
+
+func TestWhen_EmptyChecksList_PredicateTrue_ReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	c := validation.When[string](func(string) bool { return true })
+	require.NoError(t, c("anything"))
+}
+
+func TestWhenFn_PredicateFalse_DoesNotInvokeChecks(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	failing := func(string) error {
+		calls++
+		return errors.New("should not run")
+	}
+
+	c := validation.WhenFn[string](func() bool { return false }, failing)
+	require.NoError(t, c("anything"))
+	require.Zero(t, calls)
+}
+
+func TestWhenFn_PredicateTrue_RunsChecks(t *testing.T) {
+	t.Parallel()
+
+	fail := func(string) error { return errors.New("boom") }
+	c := validation.WhenFn[string](func() bool { return true }, fail)
+
+	err := c("anything")
+	require.Error(t, err)
+
+	var errs validation.Errors
+	require.True(t, errors.As(err, &errs))
+	require.Len(t, errs, 1)
+	require.Equal(t, "boom", errs[0].Message)
+}
+
+func TestWhenFn_CapturedState(t *testing.T) {
+	t.Parallel()
+
+	// Demonstrates the intended use: the predicate closes over outer state.
+	tlsEnabled := false
+	c := validation.WhenFn[string](
+		func() bool { return tlsEnabled },
+		func(string) error { return errors.New("required") },
+	)
+
+	require.NoError(t, c(""))
+	tlsEnabled = true
+	require.Error(t, c(""))
+}
+
+func TestWhenRules_PredicateFalse_DoesNotInvokeRules(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	rule := validation.Rule(func() validation.Errors {
+		calls++
+		return validation.Errors{{Message: "should not run"}}
+	})
+
+	out := validation.WhenRules(func() bool { return false }, rule)()
+	require.Empty(t, out)
+	require.Zero(t, calls)
+}
+
+func TestWhenRules_PredicateTrue_RunsAllRules(t *testing.T) {
+	t.Parallel()
+
+	ruleA := validation.Rule(func() validation.Errors {
+		return validation.Errors{{Field: "a", Message: "boom-a"}}
+	})
+	ruleB := validation.Rule(func() validation.Errors {
+		return validation.Errors{{Field: "b", Message: "boom-b"}}
+	})
+
+	out := validation.WhenRules(func() bool { return true }, ruleA, ruleB)()
+	require.Len(t, out, 2)
+	require.Equal(t, "a", out[0].Field)
+	require.Equal(t, "b", out[1].Field)
+}
+
+func TestWhenRules_EmptyRulesList_IsNoOp(t *testing.T) {
+	t.Parallel()
+
+	out := validation.WhenRules(func() bool { return true })()
+	require.Empty(t, out)
+}
+
+func TestWhenRules_IntegratesWithValidate(t *testing.T) {
+	t.Parallel()
+
+	// WhenRules wrapped in Validate should let Validate's subject stamping
+	// apply to the inner Field's emitted entries.
+	rule := validation.Field("inner", "", validation.Required[string]())
+
+	err := validation.Validate(
+		"subject",
+		validation.WhenRules(func() bool { return true }, rule),
+	)
+
+	var errs validation.Errors
+	require.True(t, errors.As(err, &errs))
+	require.Len(t, errs, 1)
+	require.Equal(t, "subject", errs[0].Subject)
+	require.Equal(t, "inner", errs[0].Field)
+}
+
+type recordingValidator struct {
+	calls int
+	err   error
+}
+
+func (r *recordingValidator) Validate() error {
+	r.calls++
+	return r.err
+}
+
+func TestNested_NilError_NoEntries(t *testing.T) {
+	t.Parallel()
+
+	v := &recordingValidator{err: nil}
+	out := validation.Nested("tls", v)()
+	require.Empty(t, out)
+	require.Equal(t, 1, v.calls)
+}
+
+func TestNested_StampsEmptySubjects(t *testing.T) {
+	t.Parallel()
+
+	v := &recordingValidator{
+		err: validation.Errors{
+			{Field: "certFile", Message: "is required"},
+			{Field: "keyFile", Message: "is required"},
+		},
+	}
+
+	out := validation.Nested("tls", v)()
+	require.Len(t, out, 2)
+	require.Equal(t, "tls", out[0].Subject)
+	require.Equal(t, "tls", out[1].Subject)
+	require.Equal(t, "certFile", out[0].Field)
+	require.Equal(t, "keyFile", out[1].Field)
+}
+
+func TestNested_PreservesExplicitSubjects(t *testing.T) {
+	t.Parallel()
+
+	v := &recordingValidator{
+		err: validation.Errors{
+			{Subject: "explicit", Field: "x", Message: "boom"},
+			{Field: "y", Message: "boom"},
+		},
+	}
+
+	out := validation.Nested("outer", v)()
+	require.Len(t, out, 2)
+	require.Equal(t, "explicit", out[0].Subject, "explicit subject must be preserved")
+	require.Equal(t, "outer", out[1].Subject, "empty subject must be stamped")
+}
+
+func TestNested_SingleValidationError(t *testing.T) {
+	t.Parallel()
+
+	v := &recordingValidator{
+		err: validation.Error{Field: "certFile", Message: "is required"},
+	}
+
+	out := validation.Nested("tls", v)()
+	require.Len(t, out, 1)
+	require.Equal(t, "tls", out[0].Subject)
+	require.Equal(t, "certFile", out[0].Field)
+}
+
+func TestNested_PlainError_WrappedAsSingleEntry(t *testing.T) {
+	t.Parallel()
+
+	v := &recordingValidator{err: errors.New("io: file not found")}
+
+	out := validation.Nested("tls", v)()
+	require.Len(t, out, 1)
+	require.Equal(t, "tls", out[0].Subject)
+	require.Equal(t, "", out[0].Field)
+	require.Equal(t, "io: file not found", out[0].Message)
+}
+
+func TestNested_EmptySubject_NoStamping(t *testing.T) {
+	t.Parallel()
+
+	v := &recordingValidator{
+		err: validation.Errors{{Field: "x", Message: "boom"}},
+	}
+
+	out := validation.Nested("", v)()
+	require.Len(t, out, 1)
+	require.Equal(t, "", out[0].Subject, "empty subject argument must not stamp")
+	require.Equal(t, "x", out[0].Field)
+}
+
+func TestNested_NotInvokedUnderFalseWhenRules(t *testing.T) {
+	t.Parallel()
+
+	v := &recordingValidator{err: errors.New("should not run")}
+
+	rule := validation.WhenRules(
+		func() bool { return false },
+		validation.Nested("tls", v),
+	)
+
+	out := rule()
+	require.Empty(t, out)
+	require.Zero(t, v.calls, "Validator must not be invoked when guard is false")
+}
+
+func TestNested_OuterValidate_DoesNotReStampExplicitSubject(t *testing.T) {
+	t.Parallel()
+
+	v := &recordingValidator{
+		err: validation.Errors{{Field: "x", Message: "boom"}},
+	}
+
+	// Nested stamps "tls" first; Validate's outer "outer" subject must not
+	// re-stamp because the entry's Subject is no longer empty.
+	err := validation.Validate("outer", validation.Nested("tls", v))
+	var errs validation.Errors
+	require.True(t, errors.As(err, &errs))
+	require.Len(t, errs, 1)
+	require.Equal(t, "tls", errs[0].Subject)
+}

--- a/pkg/validation/doc.go
+++ b/pkg/validation/doc.go
@@ -10,7 +10,15 @@
 //
 // Higher-level validation is expressed by passing a list of [Rule] values to
 // [Validate], typically constructed via [Field] and the built-in [Check]
-// functions ([Required], [Unique]). Validate accumulates every rule's output
-// into one Errors value and stamps the supplied subject onto entries that
-// don't already carry one.
+// functions ([Required], [Unique], [IsHostPort]). Validate accumulates every
+// rule's output into one Errors value and stamps the supplied subject onto
+// entries that don't already carry one.
+//
+// Conditional logic is expressed with the [When] family of combinators:
+// [When] guards Checks on a value-aware predicate, [WhenFn] guards Checks on
+// a value-free predicate (closing over outer state), and [WhenRules] guards
+// an entire block of Rules. Nested struct validation is expressed with
+// [Nested], which embeds a child's [Validator] (anything with
+// Validate() error) as a Rule and stamps a subject onto entries the child
+// left unattributed.
 package validation

--- a/pkg/validation/validate.go
+++ b/pkg/validation/validate.go
@@ -1,9 +1,9 @@
 package validation
 
-// Validate runs each rule, accumulating failures into a single Errors. Any
-// Error returned by a rule whose Subject is empty is stamped with subject.
-// Returns nil when no rule produced an error.
-func Validate(subject string, rules ...Rule) Errors {
+// Validate runs each rule, accumulating failures into a single error (which
+// will typically be an [Errors] instance). Any [Error] whose Subject is empty is
+// stamped with subject.
+func Validate(subject string, rules ...Rule) error {
 	var errs Errors
 	for _, r := range rules {
 		errs = append(errs, r()...)
@@ -31,13 +31,17 @@ func toErrors(field string, err error) Errors {
 				out[i].Field = field
 			}
 		}
+
 		return out
 	}
+
 	if ve, ok := err.(Error); ok {
 		if ve.Field == "" {
 			ve.Field = field
 		}
+
 		return Errors{ve}
 	}
+
 	return Errors{{Field: field, Message: err.Error()}}
 }

--- a/pkg/validation/validate_test.go
+++ b/pkg/validation/validate_test.go
@@ -12,7 +12,7 @@ import (
 func TestValidate_NoRules(t *testing.T) {
 	t.Parallel()
 
-	require.Nil(t, validation.Validate("subj"))
+	require.NoError(t, validation.Validate("subj"))
 }
 
 func TestValidate_AllRulesPass(t *testing.T) {
@@ -20,7 +20,7 @@ func TestValidate_AllRulesPass(t *testing.T) {
 
 	pass := func() validation.Errors { return nil }
 
-	require.Nil(t, validation.Validate("subj", pass, pass))
+	require.NoError(t, validation.Validate("subj", pass, pass))
 }
 
 func TestValidate_SubjectStamping(t *testing.T) {
@@ -51,7 +51,9 @@ func TestValidate_SubjectStamping(t *testing.T) {
 			t.Parallel()
 
 			rule := func() validation.Errors { return validation.Errors{tt.ruleErr} }
-			errs := validation.Validate(tt.outerSubj, rule)
+			err := validation.Validate(tt.outerSubj, rule)
+			var errs validation.Errors
+			require.True(t, errors.As(err, &errs))
 			require.Len(t, errs, 1)
 			require.Equal(t, tt.wantSubject, errs[0].Subject)
 		})
@@ -71,11 +73,11 @@ func TestValidate_ConcatenatesFromMultipleRules(t *testing.T) {
 		}
 	}
 
-	errs := validation.Validate("subj", a, b)
-	require.Len(t, errs, 3)
+	err := validation.Validate("subj", a, b)
+	require.Error(t, err)
 
-	// Errors implements error, so errors.As must still find the aggregate.
-	var verrs validation.Errors
-	require.True(t, errors.As(errs, &verrs))
-	require.Len(t, verrs, 3)
+	// Errors implements error, so errors.As finds the aggregate.
+	var errs validation.Errors
+	require.True(t, errors.As(err, &errs))
+	require.Len(t, errs, 3)
 }


### PR DESCRIPTION
`Config` now exposes a `Validate` method that walks the entire config tree (simple right now) and reports problems before the proxy attempts to use it.

`ListenConfig` verifies `hostPort` is a valid TCP address, and, when supplied, TLS configuration is validated. TLS validation is offloaded to _transport/creds_, but conditionally uses `MTLS` or `TLS` based on whether or not CA is supplied.
