### PR TITLE
[crypto]: Add pkg/crypto for envelope encryption

### DIFF
--- a/pkg/crypto/dek.go
+++ b/pkg/crypto/dek.go
@@ -1,0 +1,85 @@
+package crypto
+
+import (
+	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"errors"
+	"fmt"
+)
+
+const (
+	keyBytes        = 32 // 256 bits
+	materialVersion = byte(1)
+)
+
+// ErrMalformedCipherText indicates that the ciphertext was not created by a call
+// to Encrypt, or that it was otherwise tampered with.
+var ErrMalformedCipherText = errors.New("invalid ciphertext, not encrypted with a DEK")
+
+type (
+	// DEK defines a Data Encryption Key used to encrypt/decrypt payloads.
+	DEK struct {
+		key []byte
+		gcm cipher.AEAD
+	}
+
+	// DEKMaterial defines the material needed in order to decrypt a payload.
+	DEKMaterial struct {
+		Version      byte
+		KEKID        string // The ID/URI of the KEK the encrypted the DEK.
+		EncryptedDEK string // The base64-encoded encrypted DEK.
+	}
+)
+
+// NewDEK generates a new random 256-bit Data Encryption Key.
+func NewDEK() (*DEK, error) {
+	k := make([]byte, keyBytes)
+	if _, err := rand.Read(k); err != nil {
+		return nil, fmt.Errorf("failed to create DEK: %w", err)
+	}
+
+	return dekFromKey(k)
+}
+
+// Encrypt encrypts the plaintext pt using AES-256-GCM. The returned ciphertext
+// is prefixed with the randomly generated nonce.
+func (d *DEK) Encrypt(ctx context.Context, pt []byte) ([]byte, error) {
+	nonce := make([]byte, d.gcm.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, fmt.Errorf("failed to generate nonce: %w", err)
+	}
+
+	return d.gcm.Seal(nonce, nonce, pt, nil), nil
+}
+
+// Decrypt decrypts the ciphertext ct using AES-256-GCM. The ciphertext must be
+// prefixed with the nonce, as produced by [DEK.Encrypt].
+func (d *DEK) Decrypt(ctx context.Context, ct []byte) ([]byte, error) {
+	ns := d.gcm.NonceSize()
+	if len(ct) < ns {
+		return nil, ErrMalformedCipherText
+	}
+
+	pt, err := d.gcm.Open(nil, ct[:ns], ct[ns:], nil)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrMalformedCipherText, err)
+	}
+
+	return pt, nil
+}
+
+func dekFromKey(key []byte) (*DEK, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create cipher block: %w", err)
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create cipher: %w", err)
+	}
+
+	return &DEK{key: key, gcm: gcm}, nil
+}

--- a/pkg/crypto/dek_test.go
+++ b/pkg/crypto/dek_test.go
@@ -1,0 +1,134 @@
+package crypto_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/temporalio/temporal-proxy/pkg/crypto"
+)
+
+func TestNewDEK(t *testing.T) {
+	t.Parallel()
+
+	t.Run("non-nil", func(t *testing.T) {
+		t.Parallel()
+
+		d, err := crypto.NewDEK()
+		require.NoError(t, err)
+		require.NotNil(t, d)
+	})
+
+	t.Run("distinct keys per call", func(t *testing.T) {
+		t.Parallel()
+
+		d1, err := crypto.NewDEK()
+		require.NoError(t, err)
+
+		d2, err := crypto.NewDEK()
+		require.NoError(t, err)
+
+		ct, err := d1.Encrypt(t.Context(), []byte("sshh"))
+		require.NoError(t, err)
+
+		_, err = d2.Decrypt(t.Context(), ct)
+		require.ErrorIs(t, err, crypto.ErrMalformedCipherText)
+	})
+}
+
+func TestDEKEncryptDecrypt(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		plaintext []byte
+	}{
+		{"empty", []byte{}},
+		{"ascii", []byte("hello, world")},
+		{"binary", []byte{0x00, 0xFF, 0x42, 0x13}},
+		{"large", bytes.Repeat([]byte("a"), 64*1024)},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := t.Context()
+			dek, err := crypto.NewDEK()
+			require.NoError(t, err)
+
+			ct, err := dek.Encrypt(ctx, tc.plaintext)
+			require.NoError(t, err)
+
+			pt, err := dek.Decrypt(ctx, ct)
+			require.NoError(t, err)
+			require.True(t, bytes.Equal(tc.plaintext, pt))
+		})
+	}
+}
+
+func TestDEKEncrypt(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unique ciphertext per call", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+		dek, err := crypto.NewDEK()
+		require.NoError(t, err)
+
+		pt := []byte("same plaintext")
+		ct1, err := dek.Encrypt(ctx, pt)
+		require.NoError(t, err)
+
+		ct2, err := dek.Encrypt(ctx, pt)
+		require.NoError(t, err)
+
+		require.NotEqual(t, ct1, ct2)
+	})
+}
+
+func TestDEKDecrypt(t *testing.T) {
+	t.Parallel()
+
+	t.Run("wrong key", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		dek, err := crypto.NewDEK()
+		require.NoError(t, err)
+
+		ct, err := dek.Encrypt(ctx, []byte("secret"))
+		require.NoError(t, err)
+
+		altDEK, err := crypto.NewDEK()
+		require.NoError(t, err)
+		_, err = altDEK.Decrypt(ctx, ct)
+		require.Error(t, err)
+	})
+
+	t.Run("not encrypted with DEK", func(t *testing.T) {
+		t.Parallel()
+
+		dek, err := crypto.NewDEK()
+		require.NoError(t, err)
+
+		ct, err := dek.Decrypt(t.Context(), []byte("nope"))
+		require.ErrorIs(t, err, crypto.ErrMalformedCipherText)
+		require.Nil(t, ct)
+	})
+
+	t.Run("tampered ciphertext", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		dek, err := crypto.NewDEK()
+		require.NoError(t, err)
+
+		ct, err := dek.Encrypt(ctx, []byte("secret"))
+		require.NoError(t, err)
+
+		ct[len(ct)-1] ^= 0xFF
+		_, err = dek.Decrypt(ctx, ct)
+		require.Error(t, err)
+	})
+}

--- a/pkg/crypto/doc.go
+++ b/pkg/crypto/doc.go
@@ -1,0 +1,11 @@
+// Package crypto implements envelope encryption.
+//
+// Data is encrypted with a Data Encryption Key ([DEK]) using AES-256-GCM. Each
+// DEK is in turn encrypted ("wrapped") by a Key Encryption Key ([KEK]),
+// typically customer-managed and backed by a cloud KMS. The wrapped DEK and the
+// ID of the KEK that wrapped it are carried together as [DEKMaterial], allowing
+// the DEK to be recovered and the data decrypted later.
+//
+// A [KEKRegistry] manages the set of available KEKs, selecting the appropriate
+// key by namespace for encryption and by key ID for decryption.
+package crypto

--- a/pkg/crypto/kek.go
+++ b/pkg/crypto/kek.go
@@ -1,0 +1,219 @@
+package crypto
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"slices"
+	"sync"
+)
+
+type (
+	// KEK defines an interface for a Key Encryption Keys.
+	// These keys are used to encrypt/decrypt DEKs and are customer-managed (e.g. via AWS/GCP KMS).
+	KEK interface {
+		io.Closer
+
+		// ID returns a unique ID for this KEK, e.g. a KMS ARN.
+		ID() string
+		// Encrypt encrypts a DEK, returning the ciphertext.
+		Encrypt(context.Context, []byte) ([]byte, error)
+		// Decrypt decrypts a DEK previously produced by Encrypt.
+		Decrypt(context.Context, []byte) ([]byte, error)
+	}
+
+	// KEKRegistry holds the set of KEKs available for encrypting and decrypting DEKs.
+	// It is keyed by namespace (for encryption) and by key ID (for decryption).
+	// Close must be called when the registry is no longer needed to release KEK resources.
+	KEKRegistry struct {
+		defaultKey      KEK            // Fallback when no namespace key exists.
+		keks            map[string]KEK // map from NS -> KEK
+		keyIDs          map[string]KEK // map from ID -> KEK
+		decryptOnlyKeys []KEK          // used for decryption only, never selected for new encryption
+
+		closeOnce sync.Once
+		closeErr  error
+	}
+
+	// KEKRegistryOption configures a KEKRegistry during construction.
+	KEKRegistryOption interface {
+		apply(*KEKRegistry) error
+	}
+
+	kekRegOpt func(*KEKRegistry) error
+)
+
+// NewKEKRegistry constructs a KEKRegistry, applying opts in order. A default key is
+// required (see [WithDefaultKey]); construction fails if one is not provided. The
+// key-ID index used by Decrypt is built after all options are applied.
+func NewKEKRegistry(opts ...KEKRegistryOption) (*KEKRegistry, error) {
+	r := &KEKRegistry{
+		keks: map[string]KEK{},
+	}
+	for _, opt := range opts {
+		if err := opt.apply(r); err != nil {
+			return nil, err
+		}
+	}
+
+	if r.defaultKey == nil {
+		return nil, errors.New("a default key is required")
+	}
+
+	// Ensure no duplicate keys between default/namespace/decrypt-only.
+	idMap := make(map[string]KEK, len(r.keks)+len(r.decryptOnlyKeys)+1)
+	add := func(k KEK) error {
+		if _, ok := idMap[k.ID()]; ok {
+			return fmt.Errorf("duplicate key id: %s", k.ID())
+		}
+
+		idMap[k.ID()] = k
+		return nil
+	}
+
+	if err := add(r.defaultKey); err != nil {
+		return nil, err
+	}
+
+	for _, v := range r.keks {
+		if err := add(v); err != nil {
+			return nil, err
+		}
+	}
+
+	for _, k := range r.decryptOnlyKeys {
+		if err := add(k); err != nil {
+			return nil, err
+		}
+	}
+
+	r.keyIDs = idMap
+	return r, nil
+}
+
+// WithDefaultKey sets the fallback KEK used when no namespace-specific key is registered.
+// A default key is required: NewKEKRegistry returns an error if one is not provided.
+func WithDefaultKey(k KEK) KEKRegistryOption {
+	return kekRegOpt(func(r *KEKRegistry) error {
+		if k == nil {
+			return errors.New("default key must not be nil")
+		}
+
+		r.defaultKey = k
+		return nil
+	})
+}
+
+// WithKeyForNamespace registers k for ns, used when encrypting or decrypting DEKs for that namespace.
+func WithKeyForNamespace(ns string, k KEK) KEKRegistryOption {
+	return kekRegOpt(func(r *KEKRegistry) error {
+		if k == nil {
+			return fmt.Errorf("key for namespace '%s' must not be nil", ns)
+		}
+		if _, ok := r.keks[ns]; ok {
+			return fmt.Errorf("key for namespace '%s' already defined", ns)
+		}
+
+		r.keks[ns] = k
+		return nil
+	})
+}
+
+// WithDecryptOnlyKey registers k for decryption only. It is added to the key-ID index so that DEKs
+// encrypted with k can still be opened, but k is never selected for new DEK encryption. This is
+// typically used for keys that have been rotated out of active use.
+func WithDecryptOnlyKey(k KEK) KEKRegistryOption {
+	return kekRegOpt(func(r *KEKRegistry) error {
+		if k == nil {
+			return errors.New("decrypt-only key must not be nil")
+		}
+
+		if slices.ContainsFunc(r.decryptOnlyKeys, func(existing KEK) bool {
+			return existing.ID() == k.ID()
+		}) {
+			return fmt.Errorf("key already defined: %s", k.ID())
+		}
+
+		r.decryptOnlyKeys = append(r.decryptOnlyKeys, k)
+		return nil
+	})
+}
+
+// Encrypt encrypts the given DEK using the KEK registered for the specified namespace.
+// It returns DEKMaterial containing the KEK ID and the base64-encoded ciphertext.
+func (r *KEKRegistry) Encrypt(ctx context.Context, ns string, dek *DEK) (*DEKMaterial, error) {
+	if dek == nil {
+		return nil, errors.New("dek must not be nil")
+	}
+
+	k, ok := r.keks[ns]
+	if !ok {
+		k = r.defaultKey
+	}
+
+	ct, err := k.Encrypt(ctx, dek.key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encrypt message in namespace: %s, %w", ns, err)
+	}
+
+	return &DEKMaterial{
+		Version:      materialVersion,
+		KEKID:        k.ID(),
+		EncryptedDEK: base64.StdEncoding.EncodeToString(ct),
+	}, nil
+}
+
+// Decrypt decrypts the DEK described by m using the KEK identified by m.KEKID.
+func (r *KEKRegistry) Decrypt(ctx context.Context, m *DEKMaterial) (*DEK, error) {
+	if m == nil {
+		return nil, errors.New("dek material must not be nil")
+	}
+
+	k, ok := r.keyIDs[m.KEKID]
+	if !ok {
+		return nil, fmt.Errorf("unknown key: %s", m.KEKID)
+	}
+
+	ct, err := base64.StdEncoding.DecodeString(m.EncryptedDEK)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode DEK: %s, %w", m.KEKID, err)
+	}
+
+	key, err := k.Decrypt(ctx, ct)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decrypt using KEK: %s, %w", m.KEKID, err)
+	}
+
+	if len(key) != keyBytes {
+		return nil, fmt.Errorf("invalid DEK for KEK: %s", m.KEKID)
+	}
+
+	return dekFromKey(key)
+}
+
+// Close closes all registered KEKs and releases their resources.
+// Subsequent calls return the same error as the first call.
+func (r *KEKRegistry) Close() error {
+	// Blocking concurrent callers here is acceptable: Close is a shutdown
+	// operation; callers should not race to close, and if they do, waiting
+	// for a single authoritative result is the right behaviour.
+	r.closeOnce.Do(func() {
+		// keyIDs holds the default, namespace, and decrypt-only keys deduped by ID,
+		// so iterating it closes every distinct KEK exactly once.
+		errs := make([]error, 0, len(r.keyIDs))
+		for id, kek := range r.keyIDs {
+			if err := kek.Close(); err != nil {
+				errs = append(errs, fmt.Errorf("failed to close KEK: %s, %w", id, err))
+			}
+		}
+		r.closeErr = errors.Join(errs...)
+	})
+
+	return r.closeErr
+}
+
+func (f kekRegOpt) apply(r *KEKRegistry) error {
+	return f(r)
+}

--- a/pkg/crypto/kek_test.go
+++ b/pkg/crypto/kek_test.go
@@ -1,0 +1,457 @@
+package crypto_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/temporalio/temporal-proxy/pkg/crypto"
+)
+
+type fakeKEK struct {
+	id         string
+	closeCount int
+	closeErr   error
+	encErr     error
+	decErr     error
+	plaintext  []byte // when non-nil, returned from Decrypt instead of ct
+}
+
+func TestNewKEKRegistry(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		opts    []crypto.KEKRegistryOption
+		wantErr bool
+	}{
+		{
+			name:    "requires a default key",
+			opts:    []crypto.KEKRegistryOption{crypto.WithKeyForNamespace("ns1", &fakeKEK{id: "k1"})},
+			wantErr: true,
+		},
+		{
+			name:    "nil default key",
+			opts:    []crypto.KEKRegistryOption{crypto.WithDefaultKey(nil)},
+			wantErr: true,
+		},
+		{
+			name: "nil namespace key",
+			opts: []crypto.KEKRegistryOption{
+				crypto.WithDefaultKey(&fakeKEK{id: "default"}),
+				crypto.WithKeyForNamespace("ns1", nil),
+			},
+			wantErr: true,
+		},
+		{
+			name: "duplicate namespace key",
+			opts: []crypto.KEKRegistryOption{
+				crypto.WithDefaultKey(&fakeKEK{id: "default"}),
+				crypto.WithKeyForNamespace("ns1", &fakeKEK{id: "k1"}),
+				crypto.WithKeyForNamespace("ns1", &fakeKEK{id: "k2"}),
+			},
+			wantErr: true,
+		},
+		{
+			name: "nil decrypt-only key",
+			opts: []crypto.KEKRegistryOption{
+				crypto.WithDefaultKey(&fakeKEK{id: "default"}),
+				crypto.WithDecryptOnlyKey(nil),
+			},
+			wantErr: true,
+		},
+		{
+			name: "duplicate decrypt-only key",
+			opts: func() []crypto.KEKRegistryOption {
+				decryptOnly := &fakeKEK{id: "decrypt-only"}
+				return []crypto.KEKRegistryOption{
+					crypto.WithDefaultKey(&fakeKEK{id: "default"}),
+					crypto.WithDecryptOnlyKey(decryptOnly),
+					crypto.WithDecryptOnlyKey(decryptOnly),
+				}
+			}(),
+			wantErr: true,
+		},
+		{
+			name: "namespace key shares id with default key",
+			opts: []crypto.KEKRegistryOption{
+				crypto.WithDefaultKey(&fakeKEK{id: "dup"}),
+				crypto.WithKeyForNamespace("ns1", &fakeKEK{id: "dup"}),
+			},
+			wantErr: true,
+		},
+		{
+			name: "decrypt-only key shares id with default key",
+			opts: []crypto.KEKRegistryOption{
+				crypto.WithDefaultKey(&fakeKEK{id: "dup"}),
+				crypto.WithDecryptOnlyKey(&fakeKEK{id: "dup"}),
+			},
+			wantErr: true,
+		},
+		{
+			name: "decrypt-only key shares id with namespace key",
+			opts: []crypto.KEKRegistryOption{
+				crypto.WithDefaultKey(&fakeKEK{id: "default"}),
+				crypto.WithKeyForNamespace("ns1", &fakeKEK{id: "dup"}),
+				crypto.WithDecryptOnlyKey(&fakeKEK{id: "dup"}),
+			},
+			wantErr: true,
+		},
+		{
+			name: "distinct namespace keys share id",
+			opts: []crypto.KEKRegistryOption{
+				crypto.WithDefaultKey(&fakeKEK{id: "default"}),
+				crypto.WithKeyForNamespace("ns1", &fakeKEK{id: "dup"}),
+				crypto.WithKeyForNamespace("ns2", &fakeKEK{id: "dup"}),
+			},
+			wantErr: true,
+		},
+		{
+			name: "success",
+			opts: []crypto.KEKRegistryOption{
+				crypto.WithDefaultKey(&fakeKEK{id: "default"}),
+				crypto.WithKeyForNamespace("ns1", &fakeKEK{id: "k1"}),
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			r, err := crypto.NewKEKRegistry(tc.opts...)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Nil(t, r)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, r)
+		})
+	}
+}
+
+func TestKEKRegistryEncrypt(t *testing.T) {
+	t.Parallel()
+
+	dek, err := crypto.NewDEK()
+	require.NoError(t, err)
+
+	t.Run("nil dek", func(t *testing.T) {
+		t.Parallel()
+		r, err := crypto.NewKEKRegistry(crypto.WithDefaultKey(&fakeKEK{id: "default"}))
+		require.NoError(t, err)
+
+		_, err = r.Encrypt(t.Context(), "ns1", nil)
+		require.Error(t, err)
+	})
+
+	tests := []struct {
+		name      string
+		ns        string
+		opts      []crypto.KEKRegistryOption
+		wantErr   bool
+		wantKEKID string
+	}{
+		{
+			name:      "unknown namespace falls back to default key",
+			ns:        "missing",
+			opts:      []crypto.KEKRegistryOption{crypto.WithDefaultKey(&fakeKEK{id: "default"})},
+			wantKEKID: "default",
+		},
+		{
+			name: "kek encrypt error",
+			ns:   "ns1",
+			opts: []crypto.KEKRegistryOption{
+				crypto.WithDefaultKey(&fakeKEK{id: "default"}),
+				crypto.WithKeyForNamespace("ns1", &fakeKEK{id: "k1", encErr: errors.New("kms unavailable")}),
+			},
+			wantErr: true,
+		},
+		{
+			name: "success",
+			ns:   "ns1",
+			opts: []crypto.KEKRegistryOption{
+				crypto.WithDefaultKey(&fakeKEK{id: "default"}),
+				crypto.WithKeyForNamespace("ns1", &fakeKEK{id: "k1"}),
+			},
+			wantKEKID: "k1",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			r, err := crypto.NewKEKRegistry(tc.opts...)
+			require.NoError(t, err)
+
+			m, err := r.Encrypt(t.Context(), tc.ns, dek)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.wantKEKID, m.KEKID)
+			require.NotEmpty(t, m.EncryptedDEK)
+		})
+	}
+}
+
+func TestKEKRegistryDecrypt(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		material *crypto.DEKMaterial
+		opts     []crypto.KEKRegistryOption
+		wantErr  bool
+	}{
+		{
+			name:     "nil material",
+			material: nil,
+			opts:     []crypto.KEKRegistryOption{crypto.WithDefaultKey(&fakeKEK{id: "default"})},
+			wantErr:  true,
+		},
+		{
+			name:     "unknown key id",
+			material: &crypto.DEKMaterial{KEKID: "missing"},
+			opts:     []crypto.KEKRegistryOption{crypto.WithDefaultKey(&fakeKEK{id: "default"})},
+			wantErr:  true,
+		},
+		{
+			name:     "invalid base64",
+			material: &crypto.DEKMaterial{KEKID: "k1", EncryptedDEK: "not-valid-base64!!!"},
+			opts: []crypto.KEKRegistryOption{
+				crypto.WithDefaultKey(&fakeKEK{id: "default"}),
+				crypto.WithKeyForNamespace("ns1", &fakeKEK{id: "k1"}),
+			},
+			wantErr: true,
+		},
+		{
+			name:     "kek decrypt error",
+			material: &crypto.DEKMaterial{KEKID: "k1", EncryptedDEK: "AAAA"},
+			opts: []crypto.KEKRegistryOption{
+				crypto.WithDefaultKey(&fakeKEK{id: "default"}),
+				crypto.WithKeyForNamespace("ns1", &fakeKEK{id: "k1", decErr: errors.New("kms unavailable")}),
+			},
+			wantErr: true,
+		},
+		{
+			name:     "wrong-length dek",
+			material: &crypto.DEKMaterial{KEKID: "k1", EncryptedDEK: "AAAA"},
+			opts: []crypto.KEKRegistryOption{
+				crypto.WithDefaultKey(&fakeKEK{id: "default"}),
+				crypto.WithKeyForNamespace("ns1", &fakeKEK{id: "k1", plaintext: []byte("too short")}),
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			r, err := crypto.NewKEKRegistry(tc.opts...)
+			require.NoError(t, err)
+
+			_, err = r.Decrypt(t.Context(), tc.material)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestKEKRegistryRoundtrip(t *testing.T) {
+	t.Parallel()
+
+	original, err := crypto.NewDEK()
+	require.NoError(t, err)
+
+	r, err := crypto.NewKEKRegistry(
+		crypto.WithDefaultKey(&fakeKEK{id: "default"}),
+		crypto.WithKeyForNamespace("ns1", &fakeKEK{id: "k1"}),
+	)
+	require.NoError(t, err)
+
+	m, err := r.Encrypt(t.Context(), "ns1", original)
+	require.NoError(t, err)
+
+	recovered, err := r.Decrypt(t.Context(), m)
+	require.NoError(t, err)
+	require.Equal(t, original, recovered)
+}
+
+func TestKEKRegistryDefaultKeyRoundtrip(t *testing.T) {
+	t.Parallel()
+
+	// A DEK encrypted via the default key must be decryptable by the same registry.
+	original, err := crypto.NewDEK()
+	require.NoError(t, err)
+
+	defaultKEK := &fakeKEK{id: "default"}
+	r, err := crypto.NewKEKRegistry(crypto.WithDefaultKey(defaultKEK))
+	require.NoError(t, err)
+
+	m, err := r.Encrypt(t.Context(), "unknown-ns", original)
+	require.NoError(t, err)
+	require.Equal(t, "default", m.KEKID)
+
+	recovered, err := r.Decrypt(t.Context(), m)
+	require.NoError(t, err)
+	require.Equal(t, original, recovered)
+}
+
+func TestKEKRegistryDecryptOnlyKeyDecrypt(t *testing.T) {
+	t.Parallel()
+
+	original, err := crypto.NewDEK()
+	require.NoError(t, err)
+
+	active := &fakeKEK{id: "active"}
+	decryptOnly := &fakeKEK{id: "decrypt-only"}
+
+	// Encrypt with the decrypt-only key directly (simulating a DEK from before key rotation).
+	r, err := crypto.NewKEKRegistry(
+		crypto.WithDefaultKey(&fakeKEK{id: "default"}),
+		crypto.WithKeyForNamespace("ns1", decryptOnly),
+	)
+	require.NoError(t, err)
+
+	m, err := r.Encrypt(t.Context(), "ns1", original)
+	require.NoError(t, err)
+	require.Equal(t, "decrypt-only", m.KEKID)
+
+	// New registry: active key for encryption, the rotated-out key for decryption only.
+	r2, err := crypto.NewKEKRegistry(
+		crypto.WithDefaultKey(&fakeKEK{id: "default"}),
+		crypto.WithKeyForNamespace("ns1", active),
+		crypto.WithDecryptOnlyKey(decryptOnly),
+	)
+	require.NoError(t, err)
+
+	t.Run("new DEKs use active key", func(t *testing.T) {
+		t.Parallel()
+		m2, err := r2.Encrypt(t.Context(), "ns1", original)
+		require.NoError(t, err)
+		require.Equal(t, "active", m2.KEKID)
+	})
+
+	t.Run("old DEKs decrypt via decrypt-only key", func(t *testing.T) {
+		t.Parallel()
+		recovered, err := r2.Decrypt(t.Context(), m)
+		require.NoError(t, err)
+		require.Equal(t, original, recovered)
+	})
+}
+
+func TestKEKRegistryClose(t *testing.T) {
+	t.Parallel()
+
+	t.Run("closes all keks", func(t *testing.T) {
+		t.Parallel()
+		k1 := &fakeKEK{id: "k1"}
+		k2 := &fakeKEK{id: "k2"}
+		r, err := crypto.NewKEKRegistry(
+			crypto.WithDefaultKey(&fakeKEK{id: "default"}),
+			crypto.WithKeyForNamespace("ns1", k1),
+			crypto.WithKeyForNamespace("ns2", k2),
+		)
+		require.NoError(t, err)
+
+		require.NoError(t, r.Close())
+		require.Equal(t, 1, k1.closeCount)
+		require.Equal(t, 1, k2.closeCount)
+	})
+
+	t.Run("returns error on close failure", func(t *testing.T) {
+		t.Parallel()
+		kek := &fakeKEK{id: "k1", closeErr: errors.New("close failed")}
+		r, err := crypto.NewKEKRegistry(
+			crypto.WithDefaultKey(&fakeKEK{id: "default"}),
+			crypto.WithKeyForNamespace("ns1", kek),
+		)
+		require.NoError(t, err)
+
+		require.Error(t, r.Close())
+	})
+
+	t.Run("idempotent - same result on repeated close", func(t *testing.T) {
+		t.Parallel()
+		kek := &fakeKEK{id: "k1", closeErr: errors.New("close failed")}
+		r, err := crypto.NewKEKRegistry(
+			crypto.WithDefaultKey(&fakeKEK{id: "default"}),
+			crypto.WithKeyForNamespace("ns1", kek),
+		)
+		require.NoError(t, err)
+
+		err1 := r.Close()
+		err2 := r.Close()
+		require.Equal(t, err1, err2)
+		require.Equal(t, 1, kek.closeCount)
+	})
+
+	t.Run("closes decrypt-only keys", func(t *testing.T) {
+		t.Parallel()
+		active := &fakeKEK{id: "active"}
+		decryptOnly := &fakeKEK{id: "decrypt-only"}
+		r, err := crypto.NewKEKRegistry(
+			crypto.WithDefaultKey(&fakeKEK{id: "default"}),
+			crypto.WithKeyForNamespace("ns1", active),
+			crypto.WithDecryptOnlyKey(decryptOnly),
+		)
+		require.NoError(t, err)
+
+		require.NoError(t, r.Close())
+		require.Equal(t, 1, active.closeCount)
+		require.Equal(t, 1, decryptOnly.closeCount)
+	})
+
+	t.Run("concurrent close calls kek once", func(t *testing.T) {
+		t.Parallel()
+		kek := &fakeKEK{id: "k1"}
+		r, err := crypto.NewKEKRegistry(
+			crypto.WithDefaultKey(&fakeKEK{id: "default"}),
+			crypto.WithKeyForNamespace("ns1", kek),
+		)
+		require.NoError(t, err)
+
+		errs := make([]error, 20)
+		var wg sync.WaitGroup
+		for i := range len(errs) {
+			wg.Go(func() {
+				errs[i] = r.Close()
+			})
+		}
+		wg.Wait()
+
+		require.Equal(t, 1, kek.closeCount)
+		for _, err := range errs {
+			require.NoError(t, err)
+		}
+	})
+}
+
+func (f *fakeKEK) ID() string { return f.id }
+
+func (f *fakeKEK) Encrypt(_ context.Context, pt []byte) ([]byte, error) {
+	if f.encErr != nil {
+		return nil, f.encErr
+	}
+
+	return pt, nil
+}
+
+func (f *fakeKEK) Decrypt(_ context.Context, ct []byte) ([]byte, error) {
+	if f.plaintext != nil || f.decErr != nil {
+		return f.plaintext, f.decErr
+	}
+
+	return ct, nil
+}
+
+func (f *fakeKEK) Close() error {
+	f.closeCount++
+	return f.closeErr
+}


### PR DESCRIPTION
Introduces pkg/crypto, which implements [envelope encryption] for protecting data at rest and in transit. Data is encrypted with a per-payload Data Encryption Key (DEK) using [AES-256-GCM], and each DEK is, in turn, wrapped with a customer-managed Key Encryption Key (KEK), typically backed by a cloud KMS. The wrapped DEK and the ID of the KEK that produced it travel together as `DEKMaterial`, so the DEK can be recovered, and the data decrypted later.

A KEKRegistry manages the available KEKs, selecting the appropriate key by namespace for encryption and by key ID for decryption. Retired keys can be registered for decryption only, so previously encrypted DEKs remain available for decryption.

[AES-256-GCM]: https://en.wikipedia.org/wiki/Galois/Counter_Mode
[envelope encryption]: https://en.wikipedia.org/wiki/Hybrid_cryptosystem#Envelope_encryption