### PR TITLE
[connect]: Add thread-safe connection pool

### DIFF
--- a/cmd/proxy/serve.go
+++ b/cmd/proxy/serve.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/temporalio/temporal-proxy/internal/config"
 	"github.com/temporalio/temporal-proxy/internal/server"
+	"github.com/temporalio/temporal-proxy/internal/transport/connect"
 )
 
 func serve() *cli.Command {
@@ -49,6 +50,7 @@ func serve() *cli.Command {
 					func() log.Logger { return logger },
 				),
 				config.Module,
+				connect.Module,
 				server.Module,
 				fx.NopLogger,
 			)

--- a/internal/transport/connect/doc.go
+++ b/internal/transport/connect/doc.go
@@ -1,0 +1,4 @@
+// Package connect manages a pool of reusable gRPC client connections keyed by
+// host. Use NewPool to create a Pool, Set to register a connection for a host,
+// Conn to retrieve it, and Close to shut every connection down exactly once.
+package connect

--- a/internal/transport/connect/fx.go
+++ b/internal/transport/connect/fx.go
@@ -1,0 +1,14 @@
+package connect
+
+import "go.uber.org/fx"
+
+// Module provides a *Pool and binds its lifecycle to the application, closing
+// every pooled connection on shutdown via an fx stop hook.
+var Module = fx.Options(
+	fx.Provide(NewPool),
+	fx.Invoke(func(p *Pool, lc fx.Lifecycle) {
+		lc.Append(fx.StopHook(func() error {
+			return p.Close()
+		}))
+	}),
+)

--- a/internal/transport/connect/fx_test.go
+++ b/internal/transport/connect/fx_test.go
@@ -1,0 +1,52 @@
+package connect_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+	"google.golang.org/grpc/connectivity"
+
+	"github.com/temporalio/temporal-proxy/internal/transport/connect"
+)
+
+func TestModule(t *testing.T) {
+	t.Parallel()
+
+	t.Run("provides a usable Pool", func(t *testing.T) {
+		t.Parallel()
+
+		var p *connect.Pool
+		app := fx.New(connect.Module, fx.Populate(&p), fx.NopLogger)
+		require.NoError(t, app.Err())
+		require.NotNil(t, p)
+
+		require.NoError(t, p.Set("host", newConn(t)))
+	})
+
+	t.Run("closes the pool on stop", func(t *testing.T) {
+		t.Parallel()
+
+		var p *connect.Pool
+		app := fx.New(connect.Module, fx.Populate(&p), fx.NopLogger)
+		require.NoError(t, app.Err())
+
+		conn := newConn(t)
+		require.NoError(t, p.Set("host", conn))
+
+		startCtx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+		defer cancel()
+		require.NoError(t, app.Start(startCtx))
+
+		stopCtx, stopCancel := context.WithTimeout(t.Context(), 5*time.Second)
+		defer stopCancel()
+		require.NoError(t, app.Stop(stopCtx))
+
+		// The stop hook calls Pool.Close, which closes every connection. A
+		// closed gRPC client connection transitions to Shutdown, so this
+		// proves the hook actually ran rather than just returning nil.
+		require.Equal(t, connectivity.Shutdown, conn.GetState())
+	})
+}

--- a/internal/transport/connect/pool.go
+++ b/internal/transport/connect/pool.go
@@ -1,0 +1,84 @@
+package connect
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+
+	"google.golang.org/grpc"
+)
+
+var (
+	// ErrDuplicateHost is returned by Pool.Set when a connection is already
+	// registered for the given host.
+	ErrDuplicateHost = errors.New("host already defined")
+
+	// ErrHostNotFound is returned by Pool.Conn when no connection is registered
+	// for the given host.
+	ErrHostNotFound = errors.New("no connection for host")
+)
+
+type (
+	// Pool is a concurrency-safe set of gRPC client connections keyed by host.
+	// The zero value is not usable; create one with NewPool.
+	Pool struct {
+		mu        sync.RWMutex
+		conns     map[string]*grpc.ClientConn
+		closeOnce sync.Once
+		closeErr  error
+	}
+)
+
+// NewPool returns an empty Pool ready for use.
+func NewPool() *Pool {
+	return &Pool{
+		conns: make(map[string]*grpc.ClientConn),
+	}
+}
+
+// Conn returns the connection registered for host. It returns ErrHostNotFound
+// if no connection is registered for that host.
+func (p *Pool) Conn(host string) (*grpc.ClientConn, error) {
+	p.mu.RLock()
+	cn, ok := p.conns[host]
+	p.mu.RUnlock()
+
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", ErrHostNotFound, host)
+	}
+
+	return cn, nil
+}
+
+// Set registers conn for host. It returns ErrDuplicateHost if a connection is
+// already registered for that host, leaving the existing connection untouched.
+func (p *Pool) Set(host string, conn *grpc.ClientConn) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if _, ok := p.conns[host]; ok {
+		return fmt.Errorf("%w: %s", ErrDuplicateHost, host)
+	}
+
+	p.conns[host] = conn
+	return nil
+}
+
+// Close shuts down every connection in the pool, joining any errors. It runs
+// at most once; subsequent calls return the same result without re-closing.
+func (p *Pool) Close() error {
+	p.closeOnce.Do(func() {
+		p.mu.Lock()
+		errs := make([]error, 0, len(p.conns))
+		for _, conn := range p.conns {
+			if err := conn.Close(); err != nil {
+				errs = append(errs, err)
+			}
+		}
+
+		p.mu.Unlock()
+		p.closeErr = errors.Join(errs...)
+	})
+
+	return p.closeErr
+}

--- a/internal/transport/connect/pool_test.go
+++ b/internal/transport/connect/pool_test.go
@@ -1,0 +1,185 @@
+package connect_test
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/temporalio/temporal-proxy/internal/transport/connect"
+)
+
+func TestPoolConn(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns ErrHostNotFound when host is absent", func(t *testing.T) {
+		t.Parallel()
+
+		p := connect.NewPool()
+		cn, err := p.Conn("missing")
+		require.Nil(t, cn)
+		require.ErrorIs(t, err, connect.ErrHostNotFound)
+		require.Contains(t, err.Error(), "missing")
+	})
+
+	t.Run("returns the connection when host is present", func(t *testing.T) {
+		t.Parallel()
+
+		p := connect.NewPool()
+		conn := newConn(t)
+		require.NoError(t, p.Set("host", conn))
+
+		cn, err := p.Conn("host")
+		require.NoError(t, err)
+		require.Same(t, conn, cn)
+	})
+}
+
+func TestPoolSet(t *testing.T) {
+	t.Parallel()
+
+	t.Run("stores a new connection", func(t *testing.T) {
+		t.Parallel()
+
+		p := connect.NewPool()
+		require.NoError(t, p.Set("host", newConn(t)))
+	})
+
+	t.Run("rejects a duplicate host", func(t *testing.T) {
+		t.Parallel()
+
+		p := connect.NewPool()
+		require.NoError(t, p.Set("host", newConn(t)))
+
+		err := p.Set("host", newConn(t))
+		require.ErrorIs(t, err, connect.ErrDuplicateHost)
+		require.Contains(t, err.Error(), "host")
+	})
+
+	t.Run("keeps the original connection after a duplicate is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		p := connect.NewPool()
+		original := newConn(t)
+		require.NoError(t, p.Set("host", original))
+		require.Error(t, p.Set("host", newConn(t)))
+
+		cn, err := p.Conn("host")
+		require.NoError(t, err)
+		require.Same(t, original, cn)
+	})
+}
+
+func TestPoolClose(t *testing.T) {
+	t.Parallel()
+
+	t.Run("closes all connections", func(t *testing.T) {
+		t.Parallel()
+
+		p := connect.NewPool()
+		require.NoError(t, p.Set("a", newConn(t)))
+		require.NoError(t, p.Set("b", newConn(t)))
+
+		require.NoError(t, p.Close())
+	})
+
+	t.Run("is safe to call on an empty pool", func(t *testing.T) {
+		t.Parallel()
+
+		require.NoError(t, connect.NewPool().Close())
+	})
+
+	t.Run("only closes once", func(t *testing.T) {
+		t.Parallel()
+
+		p := connect.NewPool()
+		conn := newConn(t)
+		require.NoError(t, p.Set("host", conn))
+
+		// First close shuts the underlying connection down. A second close on
+		// the conn itself would error, so this proves Close short-circuits via
+		// closeOnce instead of re-closing the connections.
+		require.NoError(t, p.Close())
+		require.NoError(t, p.Close())
+	})
+
+	t.Run("aggregates errors from closing connections", func(t *testing.T) {
+		t.Parallel()
+
+		p := connect.NewPool()
+		conn := newConn(t)
+		require.NoError(t, p.Set("host", conn))
+
+		// Close the connection out from under the pool so the pool's own
+		// Close observes an "already closed" error and surfaces it.
+		require.NoError(t, conn.Close())
+		require.Error(t, p.Close())
+	})
+}
+
+func TestPoolConcurrent(t *testing.T) {
+	t.Parallel()
+
+	// This test makes no assertions about ordering; its job is to drive every
+	// Pool method from many goroutines at once so the race detector flags any
+	// unsynchronized access. It only proves something when run under
+	// `go test -race` (mise run test enables it).
+	p := connect.NewPool()
+	t.Cleanup(func() { require.NoError(t, p.Close()) })
+
+	const (
+		workers = 50
+		hosts   = 8
+	)
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+
+	for i := range workers {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+
+			host := fmt.Sprintf("host-%d", i%hosts)
+			conn := newConn(t)
+
+			<-start // line every goroutine up so the operations actually overlap
+
+			// Multiple goroutines fight over each host: one wins, the rest get
+			// ErrDuplicateHost. Close the connection we couldn't hand off so it
+			// doesn't leak.
+			if err := p.Set(host, conn); err != nil {
+				require.ErrorIs(t, err, connect.ErrDuplicateHost)
+				require.NoError(t, conn.Close())
+			}
+
+			// Conn may or may not find the host yet depending on scheduling;
+			// both outcomes are valid, we only care that the read is race-free.
+			if _, err := p.Conn(host); err != nil {
+				require.ErrorIs(t, err, connect.ErrHostNotFound)
+			}
+
+			// Close racing against Set/Conn must also be safe. closeOnce means
+			// only the first caller does the work; the rest are no-ops.
+			require.NoError(t, p.Close())
+		}(i)
+	}
+
+	close(start)
+	wg.Wait()
+}
+
+func newConn(t *testing.T) *grpc.ClientConn {
+	t.Helper()
+
+	conn, err := grpc.NewClient(
+		"passthrough:///test",
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+
+	require.NoError(t, err)
+	return conn
+}


### PR DESCRIPTION
Adding internal/transport/connect, with a concurrency-safe pool of gRPC client connections keyed by host.

This purpose of this will be to share grpc.ClientConn instances across the process...think _the underlying connections proxy's will use for connecting to upstreams_.

It's wired up with FX to provide a usable Pool and ensure connections are closed when shutting down the app.
