### PR TITLE
[server]: Fix potential race in Start/Stop

### DIFF
--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -49,7 +49,7 @@ run = ["go fix ./...", "go tool -modfile=dev/tools.mod golangci-lint fmt"]
 
 [tasks.test]
 description = "Run unit tests"
-run = "go test -cover ./..."
+run = "go test -race -cover ./..."
 
 [tasks."test:bench"]
 description = "Run bench tests"

--- a/internal/server/fx.go
+++ b/internal/server/fx.go
@@ -49,7 +49,12 @@ var Module = fx.Option(fx.Invoke(func(p ServerParams) error {
 			go func() {
 				defer func() { _ = lis.Close() }()
 
-				svr.Start(p.Context, lis) // nolint:errcheck
+				if err := svr.Start(p.Context, lis); err != nil {
+					// The server stopped serving unexpectedly. Bring the app
+					// down rather than linger in a non-serving state; Start has
+					// already logged the cause.
+					_ = p.Shutdowner.Shutdown(fx.ExitCode(1))
+				}
 			}()
 
 			return nil
@@ -63,13 +68,13 @@ var Module = fx.Option(fx.Invoke(func(p ServerParams) error {
 }))
 
 // ServerParams collects the fx-provided dependencies needed to construct a
-// [Server]. HostPort, Credentials, HealthCheck, and Logger are optional and
-// fall back to the defaults used by [New] (or [DefaultHostPort]) when not
-// supplied. HostPort must be provided as a named string value tagged
-// "serverHostPort".
+// [Server]. Context and Config are required; HealthCheck and Logger are
+// optional and fall back to the defaults used by [New] when not supplied. The
+// listen address and transport credentials are derived from Config.
 type ServerParams struct {
 	fx.In
-	Lifecycle fx.Lifecycle
+	Lifecycle  fx.Lifecycle
+	Shutdowner fx.Shutdowner
 
 	// Required values
 	Context context.Context

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"net"
+	"sync"
 	"time"
 
 	"go.temporal.io/server/common/log"
@@ -21,10 +22,14 @@ type (
 		grpcSvr   *grpc.Server
 		healthSvr *health.Server
 
-		cancelFunc  context.CancelFunc
 		creds       Credentials
 		healthCheck HealthCheck
-		logger      log.Logger
+
+		// mu guards logger and cancelFunc, which Start writes from its own
+		// goroutine while Stop reads them from the caller's goroutine.
+		mu         sync.Mutex
+		cancelFunc context.CancelFunc
+		logger     log.Logger
 	}
 
 	// Credentials produces the [grpc.ServerOption] used to configure
@@ -102,24 +107,44 @@ func WithLogger(log log.Logger) Option {
 // the periodic health check, which runs until ctx is cancelled or [Server.Stop]
 // is called.
 func (s *Server) Start(ctx context.Context, lis net.Listener) error {
+	ctx, cancel := context.WithCancel(ctx)
+
+	s.mu.Lock()
 	s.logger = log.With(s.logger, tag.NewStringerTag("addr", lis.Addr()))
 	if !s.creds.Encrypted() {
 		s.logger.Warn("Running with insecure credentials. Configure TLS for production use.")
 	}
 
-	s.logger.Info("Starting the server")
+	s.cancelFunc = cancel
+	logger := s.logger
+	s.mu.Unlock()
 
-	ctx, s.cancelFunc = context.WithCancel(ctx)
+	logger.Info("Starting the server")
+
 	go s.runHealthCheck(ctx)
-	return s.grpcSvr.Serve(lis)
+
+	// Serve returns a non-nil error only when it stops for a reason other than
+	// a graceful stop (GracefulStop makes it return nil), so anything here is a
+	// genuine failure worth surfacing.
+	if err := s.grpcSvr.Serve(lis); err != nil {
+		logger.Error("Server stopped serving", tag.Error(err))
+		return err
+	}
+
+	return nil
 }
 
 // Stop gracefully shuts the server down, halting the health check loop and
 // waiting for in-flight RPCs to complete.
 func (s *Server) Stop(ctx context.Context) error {
-	s.logger.Info("Shutting down")
-	if s.cancelFunc != nil {
-		s.cancelFunc()
+	s.mu.Lock()
+	logger := s.logger
+	cancel := s.cancelFunc
+	s.mu.Unlock()
+
+	logger.Info("Shutting down")
+	if cancel != nil {
+		cancel()
 	}
 
 	s.grpcSvr.GracefulStop()

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -108,6 +108,7 @@ func WithLogger(log log.Logger) Option {
 // is called.
 func (s *Server) Start(ctx context.Context, lis net.Listener) error {
 	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 
 	s.mu.Lock()
 	s.logger = log.With(s.logger, tag.NewStringerTag("addr", lis.Addr()))


### PR DESCRIPTION
Server.Start runs in its own goroutine (spawned by the fx OnStart hook) where it wrote s.logger and s.cancelFunc, while Stop read both fields from the caller's goroutine during OnStop. There was no synchronization between the two, so concurrent start/stop produced a data race that `go test -race` flagged reliably in the server lifecycle tests.

Guard logger and cancelFunc with a sync.Mutex. Start derives the cancel func into a local, takes the lock only to publish the two fields and snapshot the logger, then releases it before the blocking Serve call so no lock is held across I/O. Stop snapshots both fields under the lock and does its work (cancel, GracefulStop) unlocked.

I also surfaced unexpected serve errors so if Serve fails, the proxy stops/logs appropriately.

The graceful-stop path is unchanged (Serve returns nil, nothing is logged, no shutdown is triggered), so the existing lifecycle tests still pass. Verified with `go test -race -count=5 ./internal/server/` (previously failing).

