### PR TITLE
[config]: Clean up review nits

### DIFF
--- a/cmd/proxy/serve.go
+++ b/cmd/proxy/serve.go
@@ -23,7 +23,7 @@ func serve() *cli.Command {
 				Aliases:   []string{"c"},
 				Usage:     "Path to the config file",
 				TakesFile: true,
-				Sources:   cli.EnvVars("CODEC_SERVER_CONFIG"),
+				Sources:   cli.EnvVars("PROXY_CONFIG"),
 				Required:  true,
 			},
 			&cli.StringFlag{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,7 +10,7 @@ import (
 )
 
 type (
-	// Config is the top-level codec-server configuration.
+	// Config is the top-level proxy configuration.
 	Config struct {
 		Listen   ListenConfig `yaml:",inline"`
 		Upstream Upstream     `yaml:"upstream"`
@@ -47,6 +47,7 @@ func LoadFile(path string) (*Config, error) {
 	return Load(f)
 }
 
+// Validate checks the listen and upstream configuration.
 func (c *Config) Validate() error {
 	return validation.Validate(
 		"",

--- a/internal/config/doc.go
+++ b/internal/config/doc.go
@@ -1,4 +1,4 @@
-// Package config loads and validates the codec-server YAML configuration.
+// Package config loads and validates the proxy YAML configuration.
 // Use Load to parse from an io.Reader or LoadFile to read from disk. Both
 // expand ${VAR} references using the process environment before unmarshalling.
 package config

--- a/internal/config/listen.go
+++ b/internal/config/listen.go
@@ -26,6 +26,7 @@ type (
 	}
 )
 
+// Validate checks the host:port and, when present, the TLS configuration.
 func (l *ListenConfig) Validate() error {
 	return validation.Validate(
 		"",
@@ -37,6 +38,8 @@ func (l *ListenConfig) Validate() error {
 	)
 }
 
+// Validate checks the configured certificate material: mutual TLS when a CA is
+// set, otherwise server-only TLS.
 func (t *TLSConfig) Validate() error {
 	return validation.Validate(
 		"",

--- a/internal/config/upstream.go
+++ b/internal/config/upstream.go
@@ -45,6 +45,7 @@ type (
 	}
 )
 
+// Validate checks the upstream listen and namespace configuration.
 func (u *Upstream) Validate() error {
 	return validation.Validate(
 		"",
@@ -53,6 +54,7 @@ func (u *Upstream) Validate() error {
 	)
 }
 
+// Validate checks the namespace translation rules.
 func (c *NamespaceConfig) Validate() error {
 	return validation.Validate(
 		"",
@@ -101,6 +103,8 @@ func (r *NamespaceRules) UnmarshalYAML(unmarshal func(any) error) error {
 	return nil
 }
 
+// Validate checks that override entries are complete and that no local or
+// remote name is mapped more than once.
 func (r *NamespaceRules) Validate() error {
 	if len(r.Overrides) == 0 {
 		return nil
@@ -121,6 +125,7 @@ func (r *NamespaceRules) Validate() error {
 	return validation.Validate("", rules...)
 }
 
+// Validate requires both the local and remote namespace names.
 func (m *NamespaceMapping) Validate() error {
 	return validation.Validate(
 		"",

--- a/pkg/validation/validate.go
+++ b/pkg/validation/validate.go
@@ -1,5 +1,7 @@
 package validation
 
+import "errors"
+
 // Validate runs each rule, accumulating failures into a single error (which
 // will typically be an [Errors] instance). Any [Error] whose Subject is empty is
 // stamped with subject.
@@ -23,7 +25,7 @@ func Validate(subject string, rules ...Rule) error {
 }
 
 func toErrors(field string, err error) Errors {
-	if ves, ok := err.(Errors); ok {
+	if ves, ok := errors.AsType[Errors](err); ok {
 		out := make(Errors, len(ves))
 		copy(out, ves)
 		for i := range out {
@@ -35,7 +37,7 @@ func toErrors(field string, err error) Errors {
 		return out
 	}
 
-	if ve, ok := err.(Error); ok {
+	if ve, ok := errors.AsType[Error](err); ok {
 		if ve.Field == "" {
 			ve.Field = field
 		}


### PR DESCRIPTION
A batch of small consistency fixes flagged in review, none of which change runtime behaviour for the current call sites.

I had copy-pasted several structs/identifiers from a another project and never updated them for the proxy. Names, godoc, etc. have been updated accordingly.

In pkg/validation, toErrors matched its Errors/Error cases with raw type assertions. It now uses errors.AsType so a wrapped Errors/Error in the chain is still recognised. The Errors-then-Error check order is preserved, so behaviour for the current direct call sites is unchanged.
