### PR TITLE
[server]: Warn when running with insecure credentials

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -22,14 +22,17 @@ type (
 		healthSvr *health.Server
 
 		cancelFunc  context.CancelFunc
+		creds       Credentials
 		healthCheck HealthCheck
 		logger      log.Logger
 	}
 
 	// Credentials produces the [grpc.ServerOption] used to configure
-	// transport security for inbound connections.
+	// transport security for inbound connections and reports whether that
+	// transport is encrypted.
 	Credentials interface {
 		ServerOption() (grpc.ServerOption, error)
+		Encrypted() bool
 	}
 
 	// Option configures a [Server] at construction time.
@@ -73,6 +76,7 @@ func New(sopts ...Option) (*Server, error) {
 	return &Server{
 		grpcSvr:     svr,
 		healthSvr:   hc,
+		creds:       opts.creds,
 		healthCheck: opts.healthCheck,
 		logger:      opts.logger,
 	}, nil
@@ -99,6 +103,10 @@ func WithLogger(log log.Logger) Option {
 // is called.
 func (s *Server) Start(ctx context.Context, lis net.Listener) error {
 	s.logger = log.With(s.logger, tag.NewStringerTag("addr", lis.Addr()))
+	if !s.creds.Encrypted() {
+		s.logger.Warn("Running with insecure credentials. Configure TLS for production use.")
+	}
+
 	s.logger.Info("Starting the server")
 
 	ctx, s.cancelFunc = context.WithCancel(ctx)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -20,9 +20,15 @@ import (
 	"github.com/temporalio/temporal-proxy/internal/server"
 )
 
+const insecureMessage = "Running with insecure credentials. Configure TLS for production use."
+
 type (
 	failingCredentials struct {
 		err error
+	}
+
+	stubCredentials struct {
+		secure bool
 	}
 
 	recordingLogger struct {
@@ -82,6 +88,60 @@ func TestNew(t *testing.T) {
 	})
 }
 
+func TestServerInsecureWarning(t *testing.T) {
+	t.Parallel()
+
+	t.Run("warns when credentials are insecure", func(t *testing.T) {
+		t.Parallel()
+
+		logger := &recordingLogger{}
+		svr, err := server.New(
+			server.WithLogger(logger),
+			server.WithCredentials(stubCredentials{secure: false}),
+		)
+		require.NoError(t, err)
+
+		lis := bufconn.Listen(1024)
+		defer func() { _ = lis.Close() }()
+
+		errCh := make(chan error, 1)
+		go func() { errCh <- svr.Start(t.Context(), lis) }()
+
+		require.Eventually(t, func() bool {
+			return logger.contains(insecureMessage)
+		}, time.Second, 10*time.Millisecond)
+
+		require.NoError(t, svr.Stop(t.Context()))
+		<-errCh
+	})
+
+	t.Run("does not warn when credentials are secure", func(t *testing.T) {
+		t.Parallel()
+
+		logger := &recordingLogger{}
+		svr, err := server.New(
+			server.WithLogger(logger),
+			server.WithCredentials(stubCredentials{secure: true}),
+		)
+		require.NoError(t, err)
+
+		lis := bufconn.Listen(1024)
+		defer func() { _ = lis.Close() }()
+
+		errCh := make(chan error, 1)
+		go func() { errCh <- svr.Start(t.Context(), lis) }()
+
+		require.Eventually(t, func() bool {
+			return logger.contains("Starting the server")
+		}, time.Second, 10*time.Millisecond)
+
+		require.NoError(t, svr.Stop(t.Context()))
+		<-errCh
+
+		require.False(t, logger.contains(insecureMessage))
+	})
+}
+
 func TestServerStartAndStop(t *testing.T) {
 	t.Parallel()
 
@@ -137,6 +197,14 @@ func TestServerStartAndStop(t *testing.T) {
 func (f failingCredentials) ServerOption() (grpc.ServerOption, error) {
 	return nil, f.err
 }
+
+func (f failingCredentials) Encrypted() bool { return false }
+
+func (c stubCredentials) ServerOption() (grpc.ServerOption, error) {
+	return grpc.Creds(insecure.NewCredentials()), nil
+}
+
+func (c stubCredentials) Encrypted() bool { return c.secure }
 
 func (l *recordingLogger) record(msg string) {
 	l.mu.Lock()

--- a/internal/transport/creds/insecure.go
+++ b/internal/transport/creds/insecure.go
@@ -34,3 +34,9 @@ func (c *Insecure) ServerOption() (grpc.ServerOption, error) {
 func (c *Insecure) Validate() error {
 	return nil
 }
+
+// Encrypted reports whether the transport is encrypted. Insecure disables
+// transport security entirely, so it always returns false.
+func (c *Insecure) Encrypted() bool {
+	return false
+}

--- a/internal/transport/creds/insecure_test.go
+++ b/internal/transport/creds/insecure_test.go
@@ -30,3 +30,10 @@ func TestInsecure_Validate(t *testing.T) {
 	// Insecure has no certificate material to inspect; Validate is a no-op.
 	require.NoError(t, creds.NewInsecure().Validate())
 }
+
+func TestInsecure_Encrypted(t *testing.T) {
+	t.Parallel()
+
+	// Insecure disables transport security, so it is never secure.
+	require.False(t, creds.NewInsecure().Encrypted())
+}

--- a/internal/transport/creds/mtls.go
+++ b/internal/transport/creds/mtls.go
@@ -21,15 +21,10 @@ type (
 		certFile   string
 		keyFile    string
 		serverName string
-		skipVerify bool
 	}
 
 	// MTLSOptions holds optional configuration for [MTLS] connections.
 	MTLSOptions struct {
-		// InsecureSkipVerify disables server certificate verification on the
-		// client side. This should only be used in testing; never in production.
-		InsecureSkipVerify bool
-
 		// ServerName overrides the server name used to verify the server's
 		// certificate hostname. Useful when the server's certificate CN does not
 		// match its dial address.
@@ -46,7 +41,6 @@ func NewMTLS(caFile, certFile, keyFile string, opts MTLSOptions) *MTLS {
 		certFile:   certFile,
 		keyFile:    keyFile,
 		serverName: opts.ServerName,
-		skipVerify: opts.InsecureSkipVerify,
 	}
 }
 
@@ -70,11 +64,10 @@ func (c *MTLS) DialOption() (grpc.DialOption, error) {
 	}
 
 	return grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
-		Certificates:       []tls.Certificate{cert},
-		MinVersion:         minTLSVersion,
-		RootCAs:            ca,
-		ServerName:         c.serverName,
-		InsecureSkipVerify: c.skipVerify,
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   minTLSVersion,
+		RootCAs:      ca,
+		ServerName:   c.serverName,
 	})), nil
 }
 
@@ -133,4 +126,11 @@ func (c *MTLS) Validate() error {
 			)
 		}),
 	)
+}
+
+// Encrypted reports whether the transport is encrypted. mTLS always encrypts the
+// transport; InsecureSkipVerify weakens peer verification but does not disable
+// encryption, so it returns true.
+func (c *MTLS) Encrypted() bool {
+	return true
 }

--- a/internal/transport/creds/mtls_test.go
+++ b/internal/transport/creds/mtls_test.go
@@ -91,17 +91,6 @@ func TestMTLS_DialOption(t *testing.T) {
 func TestMTLS_Options(t *testing.T) {
 	t.Parallel()
 
-	t.Run("InsecureSkipVerify is propagated", func(t *testing.T) {
-		t.Parallel()
-
-		caFile, certFile, keyFile := testutil.GenerateMTLSCerts(t)
-		opt, err := creds.NewMTLS(caFile, certFile, keyFile, creds.MTLSOptions{
-			InsecureSkipVerify: true,
-		}).DialOption()
-		require.NoError(t, err)
-		require.NotNil(t, opt)
-	})
-
 	t.Run("ServerName is propagated", func(t *testing.T) {
 		t.Parallel()
 
@@ -254,4 +243,9 @@ func TestMTLS_Validate(t *testing.T) {
 		require.ErrorAs(t, err, &verrs)
 		require.Len(t, verrs, 2)
 	})
+}
+
+func TestMTLS_Encrypted(t *testing.T) {
+	t.Parallel()
+	require.True(t, creds.NewMTLS("", "", "", creds.MTLSOptions{}).Encrypted())
 }

--- a/internal/transport/creds/tls.go
+++ b/internal/transport/creds/tls.go
@@ -95,3 +95,9 @@ func (c *TLS) Validate() error {
 		validation.Field("key", c.keyFile, ValidatePEMKeyFile),
 	)
 }
+
+// Encrypted reports whether the transport is encrypted. TLS always encrypts the
+// transport, so it returns true.
+func (c *TLS) Encrypted() bool {
+	return true
+}

--- a/internal/transport/creds/tls_test.go
+++ b/internal/transport/creds/tls_test.go
@@ -140,3 +140,11 @@ func TestTLS_Validate(t *testing.T) {
 		require.ErrorContains(t, err, "failed to read PEM file")
 	})
 }
+
+func TestTLS_Encrypted(t *testing.T) {
+	t.Parallel()
+
+	// TLS encrypts the transport in both client and server modes.
+	require.True(t, creds.NewClientTLS().Encrypted())
+	require.True(t, creds.NewServerTLS("", "").Encrypted())
+}


### PR DESCRIPTION
The proxy silently falls back to insecure (no-TLS) credentials whenever no `tls` block is configured. That's a reasonable default for local development or when TLS is terminated at another layer, but it gives an operator no signal that inbound transport is unencrypted, which is easy to ship to production by accident.

This adds a startup warning so the insecure posture is at least visible in the logs.
