### PR TITLE
[creds]: Validate certificate key sizes

### DIFF
--- a/internal/transport/creds/mtls.go
+++ b/internal/transport/creds/mtls.go
@@ -109,10 +109,11 @@ func (c *MTLS) ServerOption() (grpc.ServerOption, error) {
 
 // Validate checks both the leaf certificate and the CA certificate for
 // configuration problems. The leaf must be unexpired, signed with a strong
-// algorithm, and use a key type compatible with [preferredCipherSuites]; the CA
-// must be unexpired, have the CA basic constraint set, and be signed with a
-// strong algorithm. Both files are always checked; failures are collected
-// into a single [validation.Errors] so callers see every problem in one call.
+// algorithm, use a key type compatible with [preferredCipherSuites], and have a
+// sufficiently large key; the CA must be unexpired, have the CA basic
+// constraint set, be signed with a strong algorithm, and have a sufficiently
+// large key. Both files are always checked; failures are collected into a
+// single [validation.Errors] so callers see every problem in one call.
 func (c *MTLS) Validate() error {
 	return validation.Validate(
 		"",
@@ -121,6 +122,7 @@ func (c *MTLS) Validate() error {
 				path,
 				CertificateNotExpired(),
 				UsesSecureCertificateAlgorithm(preferredCipherSuites...),
+				HasSufficientKeySize(),
 			)
 		}),
 		validation.Field("key", c.keyFile, ValidatePEMKeyFile),
@@ -130,6 +132,7 @@ func (c *MTLS) Validate() error {
 				CertificateNotExpired(),
 				IsCACertificate(),
 				UsesSecureCertificateAlgorithm(),
+				HasSufficientKeySize(),
 			)
 		}),
 	)

--- a/internal/transport/creds/tls.go
+++ b/internal/transport/creds/tls.go
@@ -90,6 +90,7 @@ func (c *TLS) Validate() error {
 				path,
 				CertificateNotExpired(),
 				UsesSecureCertificateAlgorithm(preferredCipherSuites...),
+				HasSufficientKeySize(),
 			)
 		}),
 		validation.Field("key", c.keyFile, ValidatePEMKeyFile),

--- a/internal/transport/creds/validation.go
+++ b/internal/transport/creds/validation.go
@@ -15,6 +15,16 @@ import (
 	"github.com/temporalio/temporal-proxy/pkg/validation"
 )
 
+const (
+	// minRSAKeyBits is the smallest RSA modulus size accepted by
+	// HasSufficientKeySize. 2048 bits is the current NIST-recommended minimum.
+	minRSAKeyBits = 2048
+
+	// minECDSAKeyBits is the smallest ECDSA curve size accepted by
+	// HasSufficientKeySize. 256 bits (e.g. P-256) is the recommended minimum.
+	minECDSAKeyBits = 256
+)
+
 var (
 	// weakAlgorithms lists signature algorithms considered cryptographically broken.
 	// SHA-1 and MD5 are vulnerable to collision attacks; MD2 is obsolete; DSA is deprecated in X.509.
@@ -207,6 +217,42 @@ func UsesSecureCertificateAlgorithm(allowedSuites ...uint16) Validator {
 				Subject: cert.Subject.CommonName,
 				Field:   "key_type",
 				Message: fmt.Sprintf("key type %q incompatible with allowed cipher suites", kt),
+			}
+		}
+
+		return nil
+	}
+}
+
+// HasSufficientKeySize returns a Validator that rejects certificates whose
+// public key is below the recommended minimum size: RSA keys must be at least
+// minRSAKeyBits and ECDSA keys at least minECDSAKeyBits. Key types other than
+// RSA and ECDSA (e.g. Ed25519) are unsupported and rejected, since the proxy's
+// allowed cipher suites cover only RSA and ECDSA keys.
+func HasSufficientKeySize() Validator {
+	return func(cert *x509.Certificate) error {
+		switch pub := cert.PublicKey.(type) {
+		case *rsa.PublicKey:
+			if bits := pub.N.BitLen(); bits < minRSAKeyBits {
+				return validation.Error{
+					Subject: cert.Subject.CommonName,
+					Field:   "key_size",
+					Message: fmt.Sprintf("RSA key size %d below minimum %d", bits, minRSAKeyBits),
+				}
+			}
+		case *ecdsa.PublicKey:
+			if bits := pub.Curve.Params().BitSize; bits < minECDSAKeyBits {
+				return validation.Error{
+					Subject: cert.Subject.CommonName,
+					Field:   "key_size",
+					Message: fmt.Sprintf("ECDSA key size %d below minimum %d", bits, minECDSAKeyBits),
+				}
+			}
+		default:
+			return validation.Error{
+				Subject: cert.Subject.CommonName,
+				Field:   "key_type",
+				Message: fmt.Sprintf("unsupported public key type %T", pub),
 			}
 		}
 

--- a/internal/transport/creds/validation_test.go
+++ b/internal/transport/creds/validation_test.go
@@ -1,6 +1,9 @@
 package creds_test
 
 import (
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/tls"
@@ -292,6 +295,70 @@ func TestUsesSecureCertificateAlgorithm_WeakAlgorithm(t *testing.T) {
 	require.Contains(t, err.Error(), "weak signature algorithm")
 }
 
+func TestHasSufficientKeySize(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		certPEM func(t *testing.T) []byte
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "RSA 2048 passes",
+			certPEM: func(t *testing.T) []byte { return rsaCert(t, 2048) },
+			wantErr: false,
+		},
+		{
+			name:    "RSA 4096 passes",
+			certPEM: func(t *testing.T) []byte { return rsaCert(t, 4096) },
+			wantErr: false,
+		},
+		{
+			name:    "RSA 1024 fails",
+			certPEM: func(t *testing.T) []byte { return rsaCert(t, 1024) },
+			wantErr: true,
+			errMsg:  "RSA key size 1024 below minimum 2048",
+		},
+		{
+			name:    "ECDSA P-256 passes",
+			certPEM: func(t *testing.T) []byte { return ecdsaCert(t, elliptic.P256()) },
+			wantErr: false,
+		},
+		{
+			name:    "ECDSA P-384 passes",
+			certPEM: func(t *testing.T) []byte { return ecdsaCert(t, elliptic.P384()) },
+			wantErr: false,
+		},
+		{
+			name:    "ECDSA P-224 fails",
+			certPEM: func(t *testing.T) []byte { return ecdsaCert(t, elliptic.P224()) },
+			wantErr: true,
+			errMsg:  "ECDSA key size 224 below minimum 256",
+		},
+		{
+			name:    "Ed25519 fails",
+			certPEM: ed25519Cert,
+			wantErr: true,
+			errMsg:  "unsupported public key type",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := creds.ValidatePEM(tt.certPEM(t), creds.HasSufficientKeySize())
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestValidatePEMKeyFile(t *testing.T) {
 	t.Parallel()
 
@@ -372,6 +439,53 @@ func validKey(t *testing.T) string {
 	t.Helper()
 	_, keyFile := testutil.GenerateSelfSignedCert(t)
 	return keyFile
+}
+
+// rsaCert generates a self-signed RSA certificate with a key of the given bit
+// size and returns its PEM encoding. Unlike testutil.RSACert, the key size is
+// caller-controlled so tests can exercise below-minimum keys.
+func rsaCert(t *testing.T, bits int) []byte {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, bits)
+	require.NoError(t, err)
+
+	tmpl := validTemplate()
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}
+
+// ecdsaCert generates a self-signed ECDSA certificate over the given curve and
+// returns its PEM encoding, allowing tests to exercise below-minimum curves.
+func ecdsaCert(t *testing.T, curve elliptic.Curve) []byte {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(curve, rand.Reader)
+	require.NoError(t, err)
+
+	tmpl := validTemplate()
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}
+
+// ed25519Cert generates a self-signed Ed25519 certificate and returns its PEM
+// encoding. Ed25519 is unsupported by HasSufficientKeySize, so this exercises
+// the rejection path for key types other than RSA and ECDSA.
+func ed25519Cert(t *testing.T) []byte {
+	t.Helper()
+
+	pub, key, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	tmpl := validTemplate()
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, pub, key)
+	require.NoError(t, err)
+
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
 }
 
 func validTemplate() *x509.Certificate {


### PR DESCRIPTION
TLS and mTLS certificate validation already rejected expired certs, weak signature algorithms, and key types incompatible with the configured cipher suites, but placed no lower bound on key strength. A 1024-bit RSA or 224-bit ECDSA certificate would pass validation despite being below current recommendations.

This adds a HasSufficientKeySize validator that rejects RSA keys smaller than 2048 bits and ECDSA keys smaller than 256 bits, matching NIST guidance. Key types without a size parameter (e.g. Ed25519) pass through unchecked. The validator is wired into all three certificate chains: the TLS leaf, the mTLS leaf, and the mTLS CA.

> [!NOTE]
> The 2048-bit RSA / 256-bit ECDSA minimums correspond to the 112-bit security strength baseline in NIST SP 800-57 Part 1 Rev. 5 (Table 2): https://csrc.nist.gov/pubs/sp/800/57/pt1/r5/final