### PR TITLE
[ci]: Add goreleaser release workflow

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,9 +2,9 @@
 
 ## Dependencies
 
-This project uses [mise] to pin every tool it depends on. Install mise, then run `mise install`
-to fetch everything declared in the `[tools]` section of `mise.toml` (currently Go, buf, and
-mkcert). After that, `mise deps` syncs the pinned dev tools (golangci-lint, mockgen).
+This project uses [mise] to pin every tool it depends on. Install mise, then run `mise install` to fetch everything
+declared in the `[tools]` section of `mise.toml` (currently Go, buf, and mkcert). After that, `mise deps` syncs the
+pinned dev tools (golangci-lint, mockgen).
 
 ## Useful Commands
 
@@ -21,32 +21,30 @@ mkcert). After that, `mise deps` syncs the pinned dev tools (golangci-lint, mock
 
 ## Testing the proxy locally
 
-`mise run server` starts everything you need: a Temporal dev server (the upstream, on
-`localhost:7233` with namespaces `ns1.remote` and `ns2.remote`) and the proxy itself, listening on
-`localhost:8444` with TLS terminated using the dev certs in `dev/certs/`. The inbound server
-requires a client certificate (mTLS), so requests must present `dev/certs/client.crt`.
+`mise run server` starts everything you need: a Temporal dev server (the upstream, on `localhost:7233` with namespaces
+`ns1.remote` and `ns2.remote`) and the proxy itself, listening on `localhost:8444` with TLS terminated using the dev
+certs in `dev/certs/`. The inbound server requires a client certificate (mTLS), so requests must present
+`dev/certs/client.crt`.
 
-In a second shell, use the `grpc` task to send requests. It wraps `buf curl` with the dev certs and
-gRPC-over-HTTP2 flags:
+In a second shell, use the `grpc` task to send requests. It wraps `buf curl` with the dev certs and gRPC-over-HTTP2
+flags:
 
 ```sh
 mise run grpc <Method> [json-body]
 ```
 
-A bare method name is assumed to be on `WorkflowService`. Anything containing a slash is used as a
-full `service/method` path.
+A bare method name is assumed to be on `WorkflowService`. Anything containing a slash is used as a full `service/method`
+path.
 
 ### Confirming requests are forwarded upstream
 
-`GetSystemInfo` takes no namespace and is the cleanest proof that a request is relayed to the real
-Temporal frontend:
+`GetSystemInfo` takes no namespace and is the cleanest proof that a request is relayed to the real Temporal frontend:
 
 ```sh
 mise run grpc GetSystemInfo
 ```
 
-A response with the upstream's capabilities means the call traversed the proxy and reached the
-frontend.
+A response with the upstream's capabilities means the call traversed the proxy and reached the frontend.
 
 To exercise a namespace-scoped call, use `DescribeNamespace`:
 
@@ -54,15 +52,14 @@ To exercise a namespace-scoped call, use `DescribeNamespace`:
 mise run grpc DescribeNamespace '{"namespace":"ns1.remote"}'
 ```
 
-> **Note:** namespace names are currently forwarded verbatim - the `upstream.namespaces.rules` in
-> `dev/config.yaml` are parsed and validated but not yet applied. Until translation is wired up, you
-> must send the real upstream name (`ns1.remote`), not the local alias (`ns1`). Sending `ns1`
-> returns `NotFound`.
+> **Note:** namespace names are currently forwarded verbatim - the `upstream.namespaces.rules` in `dev/config.yaml` are
+> parsed and validated but not yet applied. Until translation is wired up, you must send the real upstream name
+> (`ns1.remote`), not the local alias (`ns1`). Sending `ns1` returns `NotFound`.
 
 ### Checking the front door (not proxied)
 
-The health service is answered locally by the inbound server, so it verifies the front door is up
-but does not prove forwarding. It uses a different schema, so call `buf curl` directly:
+The health service is answered locally by the inbound server, so it verifies the front door is up but does not prove
+forwarding. It uses a different schema, so call `buf curl` directly:
 
 ```sh
 buf curl --protocol grpc --http2-prior-knowledge \
@@ -71,4 +68,16 @@ buf curl --protocol grpc --http2-prior-knowledge \
   --key dev/certs/client.key \
   --schema buf.build/grpc/grpc \
   https://localhost:8444/grpc.health.v1.Health/Check
+```
+
+## Releases
+
+To trigger a release you'll require push access. Running the tag task will handle the details for you.
+
+```bash
+mise run tag <patch|minor|major> [--suffix <suffix>]
+
+# Examples
+mise run tag patch
+mise run tag minor --suffix -alpha.<yyyyMMdd>
 ```

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,33 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+      - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PAT }}
+
+      - uses: ./.github/actions/setup
+      - name: Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: goreleaser release --clean

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -77,23 +77,14 @@ release:
     name: temporal-proxy
   draft: false
   prerelease: auto
-  name_template: "Release {{ .Version }}"
+  name_template: "{{ .Version }} Release"
   header: |
-    ## Temporal Proxy
-
-    Version {{ .Version }} release!
-
-    ### Container Image
-
-    Container image is available on GitHub Container Registry:
-
-    ```bash
-    docker pull temporalio/{{ .ProjectName }}:{{ .Version }}
-    ```
+    ## Temporal Proxy {{.Version}}
 
     ### Installation
 
-    Download the appropriate binary for your platform from the assets below, or use the container image.
+    Download the appropriate binary for your platform from the assets below. You can also use the container
+    image found at <https://hub.docker.com/r/temporalio/temporal-proxy>.
 
   footer: |
     **Full Changelog**: https://github.com/temporalio/{{ .ProjectName }}/compare/{{ .PreviousTag }}...{{ .Tag }}

--- a/.mise/tasks/tag
+++ b/.mise/tasks/tag
@@ -43,8 +43,8 @@ generate_tag_name() {
 
 create_tag() {
   local tag="${1}"
-  echo git tag -s "${tag}" -m "Release ${tag}"
-  echo git push origin "${tag}"
+  git tag -s "${tag}" -m "Release ${tag}"
+  git push origin "${tag}"
   echo "Tag ${tag} created and pushed. GitHub Actions will handle build and release."
 }
 


### PR DESCRIPTION
Add a release workflow that runs on v* tag pushes and drives goreleaser to publish a GitHub release (binaries, checksums, notes) and build/push multi-arch Docker images to Docker Hub.
