### PR TITLE
[readme]: Add codecov and godoc badges

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,6 +37,12 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup
       - run: mise run test
+      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          files: coverage.out
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   build:
     runs-on: ubuntu-latest

--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -75,7 +75,7 @@ run = ["go fix ./...", "go tool -modfile=dev/tools.mod golangci-lint fmt"]
 
 [tasks.test]
 description = "Run unit tests"
-run = "go test -race -cover ./..."
+run = "go test -race -covermode=atomic -coverprofile=coverage.out ./..."
 
 [tasks."test:bench"]
 description = "Run bench tests"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Temporal Proxy ([Pre-release])
 
 [![ci](https://github.com/temporalio/temporal-proxy/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/temporalio/temporal-proxy/actions/workflows/ci.yaml)
+[![codecov](https://codecov.io/gh/temporalio/temporal-proxy/branch/main/graph/badge.svg)](https://codecov.io/gh/temporalio/temporal-proxy)
+[![Go Reference](https://pkg.go.dev/badge/github.com/temporalio/temporal-proxy.svg)](https://pkg.go.dev/github.com/temporalio/temporal-proxy)
 [![license](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
 A gRPC proxy that sits between Temporal SDK clients, workers, and the Temporal UI on one side and one or more upstream


### PR DESCRIPTION
The README only advertised CI and license status. Add a code-coverage badge and a pkg.go.dev reference badge so the project's coverage and API docs are discoverable from the repo's README.