### PR TITLE
[config]: Support multiple named upstreams

### DIFF
--- a/dev/config.yaml
+++ b/dev/config.yaml
@@ -4,13 +4,14 @@ tls:
   cert: dev/certs/server.crt
   key: dev/certs/server.key
 
-upstream:
-  hostPort: localhost:7233
-  namespaces:
-    rules:
-      # Always add .remote on the way out, and remove it on the way in.
-      suffix: .remote
-      overrides:
-        # Makes ns2 and ns3 both use ns2.remote on the remote cluster.
-        - local: ns3
-          remote: ns2.remote
+upstreams:
+  - name: default
+    hostPort: localhost:7233
+    namespaces:
+      rules:
+        # Always add .remote on the way out, and remove it on the way in.
+        suffix: .remote
+        overrides:
+          # Makes ns2 and ns3 both use ns2.remote on the remote cluster.
+          - local: ns3
+            remote: ns2.remote

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"errors"
+	"fmt"
 	"io"
 	"os"
 
@@ -12,8 +14,8 @@ import (
 type (
 	// Config is the top-level proxy configuration.
 	Config struct {
-		Listen   ListenConfig `yaml:",inline"`
-		Upstream Upstream     `yaml:"upstream"`
+		Listen    ListenConfig `yaml:",inline"`
+		Upstreams []Upstream   `yaml:"upstreams"`
 	}
 )
 
@@ -47,11 +49,32 @@ func LoadFile(path string) (*Config, error) {
 	return Load(f)
 }
 
-// Validate checks the listen and upstream configuration.
+// Validate checks the listen configuration and every upstream, and requires
+// upstream names to be unique. Per-upstream failures are stamped with an
+// "upstreams[i]" subject; a duplicate name surfaces on the "upstreams[name]"
+// field.
 func (c *Config) Validate() error {
-	return validation.Validate(
-		"",
+	rules := []validation.Rule{
 		validation.Nested("", &c.Listen),
-		validation.Nested("upstream", &c.Upstream),
-	)
+	}
+
+	names := make([]string, len(c.Upstreams))
+	for i := range c.Upstreams {
+		names[i] = c.Upstreams[i].Name
+		rules = append(rules, validation.Nested(fmt.Sprintf("upstreams[%d]", i), &c.Upstreams[i]))
+	}
+
+	rules = append(rules, validation.Field("upstreams[name]", names, validation.Unique[string]()))
+	return validation.Validate("", rules...)
+}
+
+// PrimaryUpstream returns the first configured upstream. It is a temporary
+// bridge for the single-upstream wiring in the proxy and router modules until
+// per-request routing is in place.
+func (c *Config) PrimaryUpstream() (*Upstream, error) {
+	if len(c.Upstreams) == 0 {
+		return nil, errors.New("no upstreams configured")
+	}
+
+	return &c.Upstreams[0], nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -133,9 +133,10 @@ func TestLoadFile_MissingFile(t *testing.T) {
 func TestConfig_Validate(t *testing.T) {
 	t.Parallel()
 
-	validUpstream := config.Upstream{
+	validUpstreams := []config.Upstream{{
+		Name:   "primary",
 		Listen: config.ListenConfig{HostPort: "127.0.0.1:7233"},
-	}
+	}}
 
 	tests := []struct {
 		name       string
@@ -145,15 +146,15 @@ func TestConfig_Validate(t *testing.T) {
 		{
 			name: "valid hostPort, no TLS",
 			cfg: &config.Config{
-				Listen:   config.ListenConfig{HostPort: ":8080"},
-				Upstream: validUpstream,
+				Listen:    config.ListenConfig{HostPort: ":8080"},
+				Upstreams: validUpstreams,
 			},
 		},
 		{
 			name: "invalid hostPort surfaces from ListenConfig",
 			cfg: &config.Config{
-				Listen:   config.ListenConfig{HostPort: "localhost"},
-				Upstream: validUpstream,
+				Listen:    config.ListenConfig{HostPort: "localhost"},
+				Upstreams: validUpstreams,
 			},
 			wantTuples: [][2]string{{"", "hostPort"}},
 		},
@@ -164,7 +165,7 @@ func TestConfig_Validate(t *testing.T) {
 					HostPort: ":8080",
 					TLS:      &config.TLSConfig{}, // empty -> creds.TLS PEM read failures
 				},
-				Upstream: validUpstream,
+				Upstreams: validUpstreams,
 			},
 			wantTuples: [][2]string{
 				{"tls", "cert"},
@@ -178,7 +179,7 @@ func TestConfig_Validate(t *testing.T) {
 					HostPort: "localhost",
 					TLS:      &config.TLSConfig{},
 				},
-				Upstream: validUpstream,
+				Upstreams: validUpstreams,
 			},
 			wantTuples: [][2]string{
 				{"", "hostPort"},
@@ -187,11 +188,45 @@ func TestConfig_Validate(t *testing.T) {
 			},
 		},
 		{
-			name: "missing upstream hostPort surfaces with upstream subject",
+			name: "missing upstream hostPort surfaces with indexed upstream subject",
 			cfg: &config.Config{
 				Listen: config.ListenConfig{HostPort: ":8080"},
+				Upstreams: []config.Upstream{{
+					Name: "primary",
+				}},
 			},
-			wantTuples: [][2]string{{"upstream", "hostPort"}},
+			wantTuples: [][2]string{{"upstreams[0]", "hostPort"}},
+		},
+		{
+			name: "empty upstream name surfaces with indexed upstream subject",
+			cfg: &config.Config{
+				Listen: config.ListenConfig{HostPort: ":8080"},
+				Upstreams: []config.Upstream{{
+					Listen: config.ListenConfig{HostPort: "127.0.0.1:7233"},
+				}},
+			},
+			wantTuples: [][2]string{{"upstreams[0]", "name"}},
+		},
+		{
+			name: "duplicate upstream names surface on the upstreams[name] field",
+			cfg: &config.Config{
+				Listen: config.ListenConfig{HostPort: ":8080"},
+				Upstreams: []config.Upstream{
+					{Name: "dup", Listen: config.ListenConfig{HostPort: "127.0.0.1:7233"}},
+					{Name: "dup", Listen: config.ListenConfig{HostPort: "127.0.0.1:7234"}},
+				},
+			},
+			wantTuples: [][2]string{{"", "upstreams[name]"}},
+		},
+		{
+			name: "templated upstream hostPort is accepted",
+			cfg: &config.Config{
+				Listen: config.ListenConfig{HostPort: ":8080"},
+				Upstreams: []config.Upstream{{
+					Name:   "templated",
+					Listen: config.ListenConfig{HostPort: "{{ .RemoteNamespace }}.acme-cloud.tmprl.cloud:7233"},
+				}},
+			},
 		},
 	}
 
@@ -215,6 +250,30 @@ func TestConfig_Validate(t *testing.T) {
 			require.ElementsMatch(t, tt.wantTuples, got)
 		})
 	}
+}
+
+func TestConfig_PrimaryUpstream(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns the first configured upstream", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &config.Config{Upstreams: []config.Upstream{
+			{Name: "first", Listen: config.ListenConfig{HostPort: "127.0.0.1:7233"}},
+			{Name: "second", Listen: config.ListenConfig{HostPort: "127.0.0.1:7234"}},
+		}}
+
+		up, err := cfg.PrimaryUpstream()
+		require.NoError(t, err)
+		require.Equal(t, "first", up.Name)
+	})
+
+	t.Run("errors when no upstreams are configured", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := (&config.Config{}).PrimaryUpstream()
+		require.Error(t, err)
+	})
 }
 
 func (e *errReader) Read(_ []byte) (int, error) { return 0, e.err }

--- a/internal/config/upstream.go
+++ b/internal/config/upstream.go
@@ -9,8 +9,11 @@ import (
 
 type (
 	// Upstream describes a single upstream Temporal cluster the proxy connects
-	// workers to along with configuration for that remote cluster.
+	// workers to along with configuration for that remote cluster. Name
+	// identifies the upstream so routing rules can refer to it; it must be
+	// unique within the config.
 	Upstream struct {
+		Name       string          `yaml:"name"`
 		Listen     ListenConfig    `yaml:",inline"`
 		Namespaces NamespaceConfig `yaml:"namespaces"`
 	}
@@ -45,11 +48,22 @@ type (
 	}
 )
 
-// Validate checks the upstream listen and namespace configuration.
+// Validate checks the upstream name, dial target, and namespace configuration.
+// A templated hostPort (containing a text/template action) is resolved
+// per-request, so it is not checked as a literal host:port here; a static
+// hostPort still is.
 func (u *Upstream) Validate() error {
 	return validation.Validate(
 		"",
-		validation.Nested("", &u.Listen),
+		validation.Field("name", u.Name, validation.Required[string]()),
+		validation.WhenRules(
+			func() bool { return !isTemplated(u.Listen.HostPort) },
+			validation.Field("hostPort", u.Listen.HostPort, validation.IsHostPort()),
+		),
+		validation.WhenRules(
+			func() bool { return u.Listen.TLS != nil },
+			validation.Nested("tls", u.Listen.TLS),
+		),
 		validation.Nested("namespaces", &u.Namespaces),
 	)
 }
@@ -132,4 +146,12 @@ func (m *NamespaceMapping) Validate() error {
 		validation.Field("local", m.Local, validation.Required[string]()),
 		validation.Field("remote", m.Remote, validation.Required[string]()),
 	)
+}
+
+// isTemplated reports whether s contains a text/template action ("{{ ... }}").
+// Templated upstream targets (e.g. "{{ .RemoteNamespace }}.acme.cloud:7233")
+// are rendered per-request, so they cannot be validated as a literal host:port
+// at config-load time.
+func isTemplated(s string) bool {
+	return strings.Contains(s, "{{") && strings.Contains(s, "}}")
 }

--- a/internal/config/upstream_test.go
+++ b/internal/config/upstream_test.go
@@ -11,6 +11,13 @@ import (
 	"github.com/temporalio/temporal-proxy/pkg/validation"
 )
 
+// namespaceConfigYAML wraps a `namespaces:` body (each line indented to sit
+// under a single named upstream) so Load produces one upstream carrying those
+// translation rules.
+func namespaceConfigYAML(namespacesBody string) string {
+	return "upstreams:\n  - name: primary\n    namespaces:\n" + namespacesBody
+}
+
 func TestNamespaceRules_Local(t *testing.T) {
 	t.Parallel()
 
@@ -22,46 +29,46 @@ func TestNamespaceRules_Local(t *testing.T) {
 	}{
 		{
 			name:     "no prefix, suffix, or override returns input unchanged",
-			yaml:     "upstream:\n  namespaces:\n    rules: {}\n",
+			yaml:     namespaceConfigYAML("      rules: {}\n"),
 			remoteNS: "payments",
 			want:     "payments",
 		},
 		{
 			name:     "strips configured prefix",
-			yaml:     "upstream:\n  namespaces:\n    rules:\n      prefix: \"acme-\"\n",
+			yaml:     namespaceConfigYAML("      rules:\n        prefix: \"acme-\"\n"),
 			remoteNS: "acme-payments",
 			want:     "payments",
 		},
 		{
 			name:     "strips configured suffix",
-			yaml:     "upstream:\n  namespaces:\n    rules:\n      suffix: \".cloud\"\n",
+			yaml:     namespaceConfigYAML("      rules:\n        suffix: \".cloud\"\n"),
 			remoteNS: "payments.cloud",
 			want:     "payments",
 		},
 		{
 			name:     "strips both prefix and suffix",
-			yaml:     "upstream:\n  namespaces:\n    rules:\n      prefix: \"acme-\"\n      suffix: \".cloud\"\n",
+			yaml:     namespaceConfigYAML("      rules:\n        prefix: \"acme-\"\n        suffix: \".cloud\"\n"),
 			remoteNS: "acme-payments.cloud",
 			want:     "payments",
 		},
 		{
 			name: "override wins over prefix/suffix",
-			yaml: "upstream:\n  namespaces:\n    rules:\n" +
-				"      prefix: \"acme-\"\n" +
-				"      suffix: \".cloud\"\n" +
-				"      overrides:\n" +
-				"        - local: billing\n" +
-				"          remote: legacy-billing-prod\n",
+			yaml: namespaceConfigYAML("      rules:\n" +
+				"        prefix: \"acme-\"\n" +
+				"        suffix: \".cloud\"\n" +
+				"        overrides:\n" +
+				"          - local: billing\n" +
+				"            remote: legacy-billing-prod\n"),
 			remoteNS: "legacy-billing-prod",
 			want:     "billing",
 		},
 		{
 			name: "no override match falls back to prefix/suffix stripping",
-			yaml: "upstream:\n  namespaces:\n    rules:\n" +
-				"      prefix: \"acme-\"\n" +
-				"      overrides:\n" +
-				"        - local: billing\n" +
-				"          remote: legacy-billing\n",
+			yaml: namespaceConfigYAML("      rules:\n" +
+				"        prefix: \"acme-\"\n" +
+				"        overrides:\n" +
+				"          - local: billing\n" +
+				"            remote: legacy-billing\n"),
 			remoteNS: "acme-payments",
 			want:     "payments",
 		},
@@ -73,7 +80,7 @@ func TestNamespaceRules_Local(t *testing.T) {
 
 			cfg, err := config.Load(strings.NewReader(tc.yaml))
 			require.NoError(t, err)
-			require.Equal(t, tc.want, cfg.Upstream.Namespaces.Rules.Local(tc.remoteNS))
+			require.Equal(t, tc.want, cfg.Upstreams[0].Namespaces.Rules.Local(tc.remoteNS))
 		})
 	}
 }
@@ -89,46 +96,46 @@ func TestNamespaceRules_Remote(t *testing.T) {
 	}{
 		{
 			name:    "no prefix, suffix, or override returns input unchanged",
-			yaml:    "upstream:\n  namespaces:\n    rules: {}\n",
+			yaml:    namespaceConfigYAML("      rules: {}\n"),
 			localNS: "payments",
 			want:    "payments",
 		},
 		{
 			name:    "applies configured prefix",
-			yaml:    "upstream:\n  namespaces:\n    rules:\n      prefix: \"acme-\"\n",
+			yaml:    namespaceConfigYAML("      rules:\n        prefix: \"acme-\"\n"),
 			localNS: "payments",
 			want:    "acme-payments",
 		},
 		{
 			name:    "applies configured suffix",
-			yaml:    "upstream:\n  namespaces:\n    rules:\n      suffix: \".cloud\"\n",
+			yaml:    namespaceConfigYAML("      rules:\n        suffix: \".cloud\"\n"),
 			localNS: "payments",
 			want:    "payments.cloud",
 		},
 		{
 			name:    "applies both prefix and suffix",
-			yaml:    "upstream:\n  namespaces:\n    rules:\n      prefix: \"acme-\"\n      suffix: \".cloud\"\n",
+			yaml:    namespaceConfigYAML("      rules:\n        prefix: \"acme-\"\n        suffix: \".cloud\"\n"),
 			localNS: "payments",
 			want:    "acme-payments.cloud",
 		},
 		{
 			name: "override wins over prefix/suffix",
-			yaml: "upstream:\n  namespaces:\n    rules:\n" +
-				"      prefix: \"acme-\"\n" +
-				"      suffix: \".cloud\"\n" +
-				"      overrides:\n" +
-				"        - local: billing\n" +
-				"          remote: legacy-billing-prod\n",
+			yaml: namespaceConfigYAML("      rules:\n" +
+				"        prefix: \"acme-\"\n" +
+				"        suffix: \".cloud\"\n" +
+				"        overrides:\n" +
+				"          - local: billing\n" +
+				"            remote: legacy-billing-prod\n"),
 			localNS: "billing",
 			want:    "legacy-billing-prod",
 		},
 		{
 			name: "no override match falls back to prefix/suffix wrapping",
-			yaml: "upstream:\n  namespaces:\n    rules:\n" +
-				"      prefix: \"acme-\"\n" +
-				"      overrides:\n" +
-				"        - local: billing\n" +
-				"          remote: legacy-billing\n",
+			yaml: namespaceConfigYAML("      rules:\n" +
+				"        prefix: \"acme-\"\n" +
+				"        overrides:\n" +
+				"          - local: billing\n" +
+				"            remote: legacy-billing\n"),
 			localNS: "payments",
 			want:    "acme-payments",
 		},
@@ -140,7 +147,7 @@ func TestNamespaceRules_Remote(t *testing.T) {
 
 			cfg, err := config.Load(strings.NewReader(tc.yaml))
 			require.NoError(t, err)
-			require.Equal(t, tc.want, cfg.Upstream.Namespaces.Rules.Remote(tc.localNS))
+			require.Equal(t, tc.want, cfg.Upstreams[0].Namespaces.Rules.Remote(tc.localNS))
 		})
 	}
 }
@@ -387,14 +394,32 @@ func TestUpstream_Validate(t *testing.T) {
 		wantTuples [][2]string
 	}{
 		{
-			name: "valid listen and no overrides",
+			name: "valid name and listen, no overrides",
 			upstream: &config.Upstream{
+				Name:   "primary",
 				Listen: config.ListenConfig{HostPort: "127.0.0.1:7233"},
 			},
 		},
 		{
-			name: "invalid hostPort surfaces from Listen",
+			name: "missing name surfaces required error",
 			upstream: &config.Upstream{
+				Listen: config.ListenConfig{HostPort: "127.0.0.1:7233"},
+			},
+			wantTuples: [][2]string{
+				{"", "name"},
+			},
+		},
+		{
+			name: "templated hostPort is accepted",
+			upstream: &config.Upstream{
+				Name:   "primary",
+				Listen: config.ListenConfig{HostPort: "{{ .RemoteNamespace }}.acme-cloud.tmprl.cloud:7233"},
+			},
+		},
+		{
+			name: "invalid static hostPort surfaces from Listen",
+			upstream: &config.Upstream{
+				Name:   "primary",
 				Listen: config.ListenConfig{HostPort: "not-a-host-port"},
 			},
 			wantTuples: [][2]string{
@@ -404,6 +429,7 @@ func TestUpstream_Validate(t *testing.T) {
 		{
 			name: "namespace override failure surfaces with override-index subject",
 			upstream: &config.Upstream{
+				Name:   "primary",
 				Listen: config.ListenConfig{HostPort: "127.0.0.1:7233"},
 				Namespaces: config.NamespaceConfig{
 					Rules: config.NamespaceRules{
@@ -420,6 +446,7 @@ func TestUpstream_Validate(t *testing.T) {
 		{
 			name: "listen and namespace failures aggregate",
 			upstream: &config.Upstream{
+				Name:   "primary",
 				Listen: config.ListenConfig{HostPort: "not-a-host-port"},
 				Namespaces: config.NamespaceConfig{
 					Rules: config.NamespaceRules{

--- a/internal/proxy/fx.go
+++ b/internal/proxy/fx.go
@@ -14,16 +14,21 @@ import (
 // Module is the fx module that constructs the proxy [Server] from [ProxyParams]
 // and binds its lifecycle to the application.
 var Module = fx.Options(fx.Invoke(func(p ProxyParams) error {
-	if err := p.Config.Upstream.Validate(); err != nil {
+	upstream, err := p.Config.PrimaryUpstream()
+	if err != nil {
 		return fmt.Errorf("invalid upstream configuration: %w", err)
 	}
 
-	opts := []Option{WithCredentials(p.creds())}
+	if err := upstream.Validate(); err != nil {
+		return fmt.Errorf("invalid upstream configuration: %w", err)
+	}
+
+	opts := []Option{WithCredentials(upstreamCreds(upstream))}
 	if p.Logger != nil {
 		opts = append(opts, WithLogger(p.Logger))
 	}
 
-	svr, err := New(p.Config.Upstream.Listen.HostPort, opts...)
+	svr, err := New(upstream.Listen.HostPort, opts...)
 	if err != nil {
 		return fmt.Errorf("failed to create proxy: %w", err)
 	}
@@ -63,11 +68,11 @@ type ProxyParams struct {
 	Logger logger.Logger `optional:"true"`
 }
 
-// creds derives the credentials used to dial the upstream frontend from the
-// upstream TLS configuration: mutual TLS when a CA is set, server-verified
+// upstreamCreds derives the credentials used to dial the upstream frontend from
+// the upstream TLS configuration: mutual TLS when a CA is set, server-verified
 // client TLS when TLS is configured without one, and insecure otherwise.
-func (p *ProxyParams) creds() Credentials {
-	tls := p.Config.Upstream.Listen.TLS
+func upstreamCreds(upstream *config.Upstream) Credentials {
+	tls := upstream.Listen.TLS
 	if tls == nil {
 		return creds.NewInsecure()
 	}

--- a/internal/proxy/fx_test.go
+++ b/internal/proxy/fx_test.go
@@ -25,7 +25,7 @@ func TestModule(t *testing.T) {
 		const upstream = "127.0.0.1:47233"
 
 		app := newProxyApp(t, &config.Config{
-			Upstream: config.Upstream{Listen: config.ListenConfig{HostPort: upstream}},
+			Upstreams: []config.Upstream{{Name: "primary", Listen: config.ListenConfig{HostPort: upstream}}},
 		})
 		require.NoError(t, app.Err())
 
@@ -40,7 +40,7 @@ func TestModule(t *testing.T) {
 		log := logger.NewTestLogger()
 		app := newProxyApp(
 			t,
-			&config.Config{Upstream: config.Upstream{Listen: config.ListenConfig{HostPort: upstream}}},
+			&config.Config{Upstreams: []config.Upstream{{Name: "primary", Listen: config.ListenConfig{HostPort: upstream}}}},
 			fx.Provide(func() logger.Logger { return log }),
 		)
 		require.NoError(t, app.Err())
@@ -54,7 +54,7 @@ func TestModule(t *testing.T) {
 		t.Parallel()
 
 		app := newProxyApp(t, &config.Config{
-			Upstream: config.Upstream{Listen: config.ListenConfig{HostPort: "not-a-host-port"}},
+			Upstreams: []config.Upstream{{Name: "primary", Listen: config.ListenConfig{HostPort: "not-a-host-port"}}},
 		})
 
 		require.Error(t, app.Err())

--- a/internal/router/fx.go
+++ b/internal/router/fx.go
@@ -8,34 +8,35 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/temporalio/temporal-proxy/internal/config"
+	"github.com/temporalio/temporal-proxy/internal/transport/connect"
 	"github.com/temporalio/temporal-proxy/internal/transport/socket"
 )
 
 // Module is the fx module that provides the transparent-forwarding pieces: a
 // pass-through [google.golang.org/grpc/encoding.CodecV2] and a
-// [google.golang.org/grpc.StreamHandler]. The handler dials the proxy's unix
-// socket, whose path is derived from the upstream host:port in configuration,
-// and the connection is closed on shutdown. Consumers (the server module)
-// depend on these by type without importing this package directly.
+// [google.golang.org/grpc.StreamHandler]. The handler obtains a connection to
+// the proxy's unix socket, whose path is derived from the upstream host:port in
+// configuration, from the shared [connect.Pool].
 var Module = fx.Options(fx.Provide(
 	Codec,
 	func(p RouterParams) (grpc.StreamHandler, error) {
-		sockPath, err := socket.UnixPath(p.Config.Upstream.Listen.HostPort)
+		upstream, err := p.Config.PrimaryUpstream()
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve upstream: %w", err)
+		}
+
+		sockPath, err := socket.UnixPath(upstream.Listen.HostPort)
 		if err != nil {
 			return nil, fmt.Errorf("failed to resolve proxy socket path: %w", err)
 		}
 
-		conn, err := grpc.NewClient(
+		conn, err := p.Pool.GetOrSet(
 			"unix://"+sockPath,
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create upstream client: %w", err)
 		}
-
-		p.Lifecycle.Append(fx.StopHook(func() error {
-			return conn.Close()
-		}))
 
 		return Handler(conn), nil
 	},
@@ -45,7 +46,7 @@ var Module = fx.Options(fx.Provide(
 // forwarding stream handler.
 type RouterParams struct {
 	fx.In
-	Lifecycle fx.Lifecycle
 
 	Config *config.Config
+	Pool   *connect.Pool
 }

--- a/internal/router/fx_test.go
+++ b/internal/router/fx_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/temporalio/temporal-proxy/internal/config"
 	"github.com/temporalio/temporal-proxy/internal/router"
+	"github.com/temporalio/temporal-proxy/internal/transport/connect"
 	"github.com/temporalio/temporal-proxy/internal/transport/socket"
 )
 
@@ -32,8 +33,9 @@ func TestModule(t *testing.T) {
 
 		app := fx.New(
 			fx.Supply(&config.Config{
-				Upstream: config.Upstream{Listen: config.ListenConfig{HostPort: "127.0.0.1:7233"}},
+				Upstreams: []config.Upstream{{Name: "primary", Listen: config.ListenConfig{HostPort: "127.0.0.1:7233"}}},
 			}),
+			connect.Module,
 			router.Module,
 			fx.Populate(&codec, &handler),
 			fx.NopLogger,
@@ -96,8 +98,9 @@ func TestModule(t *testing.T) {
 		)
 		app := fx.New(
 			fx.Supply(&config.Config{
-				Upstream: config.Upstream{Listen: config.ListenConfig{HostPort: upstream}},
+				Upstreams: []config.Upstream{{Name: "primary", Listen: config.ListenConfig{HostPort: upstream}}},
 			}),
+			connect.Module,
 			router.Module,
 			fx.Populate(&codec, &handler),
 			fx.NopLogger,

--- a/internal/server/fx_test.go
+++ b/internal/server/fx_test.go
@@ -32,8 +32,8 @@ func TestModule(t *testing.T) {
 			t,
 			fx.Supply(&config.Config{
 				Listen: config.ListenConfig{HostPort: "127.0.0.1:0"},
-				Upstream: config.Upstream{
-					Listen: config.ListenConfig{HostPort: "127.0.0.1:7233"},
+				Upstreams: []config.Upstream{
+					{Name: "primary", Listen: config.ListenConfig{HostPort: "127.0.0.1:7233"}},
 				},
 			}),
 		)
@@ -59,8 +59,8 @@ func TestModule(t *testing.T) {
 			fx.Supply(
 				&config.Config{
 					Listen: config.ListenConfig{HostPort: "127.0.0.1:0"},
-					Upstream: config.Upstream{
-						Listen: config.ListenConfig{HostPort: "127.0.0.1:7233"},
+					Upstreams: []config.Upstream{
+						{Name: "primary", Listen: config.ListenConfig{HostPort: "127.0.0.1:7233"}},
 					},
 				},
 				fx.Annotate(hc, fx.As(new(server.HealthCheck))),
@@ -114,8 +114,8 @@ func TestModule(t *testing.T) {
 			t,
 			fx.Supply(&config.Config{
 				Listen: config.ListenConfig{HostPort: "1.2.3.4:0"},
-				Upstream: config.Upstream{
-					Listen: config.ListenConfig{HostPort: "127.0.0.1:7233"},
+				Upstreams: []config.Upstream{
+					{Name: "primary", Listen: config.ListenConfig{HostPort: "127.0.0.1:7233"}},
 				},
 			}),
 		)
@@ -145,8 +145,8 @@ func TestModuleWiresInjectedCodecAndHandler(t *testing.T) {
 	app := fx.New(
 		fx.Supply(fx.Annotate(t.Context(), fx.As(new(context.Context)))),
 		fx.Supply(&config.Config{
-			Listen:   config.ListenConfig{HostPort: addr},
-			Upstream: config.Upstream{Listen: config.ListenConfig{HostPort: "127.0.0.1:7233"}},
+			Listen:    config.ListenConfig{HostPort: addr},
+			Upstreams: []config.Upstream{{Name: "primary", Listen: config.ListenConfig{HostPort: "127.0.0.1:7233"}}},
 		}),
 		fx.Provide(
 			func() encoding.CodecV2 { return rec },

--- a/internal/transport/connect/doc.go
+++ b/internal/transport/connect/doc.go
@@ -1,4 +1,5 @@
 // Package connect manages a pool of reusable gRPC client connections keyed by
 // host. Use NewPool to create a Pool, Set to register a connection for a host,
-// Conn to retrieve it, and Close to shut every connection down exactly once.
+// Conn to retrieve it, GetOrSet to retrieve or lazily dial one, and Close to
+// shut every connection down exactly once.
 package connect

--- a/internal/transport/connect/pool.go
+++ b/internal/transport/connect/pool.go
@@ -50,6 +50,32 @@ func (p *Pool) Conn(host string) (*grpc.ClientConn, error) {
 	return cn, nil
 }
 
+// GetOrSet returns the connection registered for host, creating and registering
+// one with grpc.NewClient(host, opts...) when none exists yet. If callers race to
+// create the same host, each dials but only one connection is kept; the losers are
+// closed and every caller receives the same *grpc.ClientConn.
+func (p *Pool) GetOrSet(host string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+	if conn, _ := p.Conn(host); conn != nil {
+		return conn, nil
+	}
+
+	conn, err := grpc.NewClient(host, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to %s, %w", host, err)
+	}
+
+	if err := p.Set(host, conn); err != nil {
+		if errors.Is(err, ErrDuplicateHost) {
+			_ = conn.Close()    // lost the race; don't leak our dial
+			return p.Conn(host) // return the connection that won
+		}
+
+		return nil, err
+	}
+
+	return conn, nil
+}
+
 // Set registers conn for host. It returns ErrDuplicateHost if a connection is
 // already registered for that host, leaving the existing connection untouched.
 func (p *Pool) Set(host string, conn *grpc.ClientConn) error {

--- a/internal/transport/connect/pool_test.go
+++ b/internal/transport/connect/pool_test.go
@@ -172,6 +172,87 @@ func TestPoolConcurrent(t *testing.T) {
 	wg.Wait()
 }
 
+func TestPoolGetOrSet(t *testing.T) {
+	t.Parallel()
+
+	insecureOpt := grpc.WithTransportCredentials(insecure.NewCredentials())
+
+	t.Run("creates and registers a connection when host is absent", func(t *testing.T) {
+		t.Parallel()
+
+		p := connect.NewPool()
+		t.Cleanup(func() { require.NoError(t, p.Close()) })
+
+		conn, err := p.GetOrSet("host", insecureOpt)
+		require.NoError(t, err)
+		require.NotNil(t, conn)
+
+		// The connection is registered, so a subsequent read returns the same one.
+		cn, err := p.Conn("host")
+		require.NoError(t, err)
+		require.Same(t, conn, cn)
+	})
+
+	t.Run("returns the existing connection when host is present", func(t *testing.T) {
+		t.Parallel()
+
+		p := connect.NewPool()
+		t.Cleanup(func() { require.NoError(t, p.Close()) })
+
+		existing := newConn(t)
+		require.NoError(t, p.Set("host", existing))
+
+		conn, err := p.GetOrSet("host", insecureOpt)
+		require.NoError(t, err)
+		require.Same(t, existing, conn)
+	})
+
+	t.Run("returns an error when dialing fails", func(t *testing.T) {
+		t.Parallel()
+
+		p := connect.NewPool()
+		t.Cleanup(func() { require.NoError(t, p.Close()) })
+
+		// No transport credentials option, so grpc.NewClient fails synchronously.
+		conn, err := p.GetOrSet("host")
+		require.Nil(t, conn)
+		require.ErrorContains(t, err, "failed to connect")
+	})
+
+	t.Run("hands every concurrent caller the same connection", func(t *testing.T) {
+		t.Parallel()
+
+		// Many goroutines race to create the same host. Only one dial can be
+		// retained; the losers must be closed and every caller must receive the
+		// winner. This only proves something under `go test -race`.
+		p := connect.NewPool()
+		t.Cleanup(func() { require.NoError(t, p.Close()) })
+
+		const workers = 50
+
+		var wg sync.WaitGroup
+		start := make(chan struct{})
+		conns := make([]*grpc.ClientConn, workers)
+
+		for i := range workers {
+			wg.Go(func() {
+				<-start // line every goroutine up so the calls actually overlap
+
+				conn, err := p.GetOrSet("host", insecureOpt)
+				require.NoError(t, err)
+				conns[i] = conn
+			})
+		}
+
+		close(start)
+		wg.Wait()
+
+		for i := range workers {
+			require.Same(t, conns[0], conns[i])
+		}
+	})
+}
+
 func newConn(t *testing.T) *grpc.ClientConn {
 	t.Helper()
 


### PR DESCRIPTION
The proxy held a single Config.Upstream, which blocks the dynamic routing work (RFC #32): routing rules need to refer to upstreams by name, and a deployment serves more than one. This replaces it with Config.Upstreams, a named list, as the foundation for the routing block, engine, and connection registry that will follow.

Upstream targets may be templated (e.g. "{{ .RemoteNamespace }}.acme:7233") once rendering lands, so Upstream.Validate skips the literal IsHostPort check when the value contains a template action; a static hostPort is still validated. The inbound ListenConfig.Validate stays strict, since a listener address is never templated.

Config.PrimaryUpstream returns the first entry as an explicit, documented bridge rather than scatter an Upstreams[0] assumption across the fx modules; it will be removed when routing selects the upstream per request.
