### PR TITLE
[ci]: Simplify codecov PR comment to diff coverage only

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -6,3 +6,8 @@ coverage:
     patch:
       default:
         informational: true
+
+comment:
+  layout: "condensed_header, condensed_footer"
+  hide_project_coverage: true
+  require_changes: false


### PR DESCRIPTION
## What

Codecov currently posts its default verbose PR comment (project-vs-diff comparison, per-file table, flags, full footer). Coverage here is informational, not gating, and that comment crowds out the actual review conversation.

This adds a `comment` block to `.github/codecov.yml`:

- `layout: "condensed_header, condensed_footer"` - one-line diff coverage summary + link to the full Codecov report, nothing else
- `hide_project_coverage: true` - drops the project-vs-diff comparison table, leaving only diff coverage
- `require_changes: false` - preserves the current always-post behavior

## Notes

- Codecov reads `codecov.yml` from the PR **base** branch, so this only takes effect once merged to `main`; it won't change existing open PR comments.
- If the condensed footer link ends up too subtle, the fallback is swapping `condensed_header` for `header` (slightly larger, still diff-only).