### PR TITLE
[config]: Add routing rules with upstream reference validation

### DIFF
--- a/dev/config.yaml
+++ b/dev/config.yaml
@@ -15,3 +15,6 @@ upstreams:
           # Makes ns2 and ns3 both use ns2.remote on the remote cluster.
           - local: ns3
             remote: ns2.remote
+
+routing:
+  default: default

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"errors"
-	"fmt"
 	"io"
 	"os"
 
@@ -15,6 +14,7 @@ type (
 	// Config is the top-level proxy configuration.
 	Config struct {
 		Listen    ListenConfig `yaml:",inline"`
+		Routing   Routing      `yaml:"routing"`
 		Upstreams []Upstream   `yaml:"upstreams"`
 	}
 )
@@ -49,22 +49,28 @@ func LoadFile(path string) (*Config, error) {
 	return Load(f)
 }
 
-// Validate checks the listen configuration and every upstream, and requires
-// upstream names to be unique. Per-upstream failures are stamped with an
-// "upstreams[i]" subject; a duplicate name surfaces on the "upstreams[name]"
-// field.
+// Validate checks the listen configuration and every upstream, requires
+// upstream names to be unique, and checks that every routing reference names a
+// configured upstream. Failures are stamped with the failing node's YAML path
+// as the subject (e.g. "upstreams[0].namespaces.rules.overrides[1]"). A
+// duplicate name surfaces on the "upstreams[name]" field, and an unknown
+// routing reference on the "routing"/"routing.rules[i]" subject.
 func (c *Config) Validate() error {
 	rules := []validation.Rule{
 		validation.Nested("", &c.Listen),
+		validation.Nested("routing", &c.Routing),
+		validation.Children("upstreams", c.Upstreams, func(u *Upstream) error { return u.Validate() }),
 	}
 
 	names := make([]string, len(c.Upstreams))
+	known := make(map[string]struct{}, len(c.Upstreams))
 	for i := range c.Upstreams {
 		names[i] = c.Upstreams[i].Name
-		rules = append(rules, validation.Nested(fmt.Sprintf("upstreams[%d]", i), &c.Upstreams[i]))
+		known[names[i]] = struct{}{}
 	}
 
 	rules = append(rules, validation.Field("upstreams[name]", names, validation.Unique[string]()))
+	rules = append(rules, c.Routing.referentialRules(known)...)
 	return validation.Validate("", rules...)
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -252,6 +252,85 @@ func TestConfig_Validate(t *testing.T) {
 	}
 }
 
+func TestConfig_Validate_RoutingReferences(t *testing.T) {
+	t.Parallel()
+
+	base := func(r config.Routing) *config.Config {
+		return &config.Config{
+			Listen:  config.ListenConfig{HostPort: ":8080"},
+			Routing: r,
+			Upstreams: []config.Upstream{
+				{Name: "primary", Listen: config.ListenConfig{HostPort: "127.0.0.1:7233"}},
+				{Name: "system", Listen: config.ListenConfig{HostPort: "127.0.0.1:7234"}},
+			},
+		}
+	}
+
+	tests := []struct {
+		name       string
+		cfg        *config.Config
+		wantTuples [][2]string
+	}{
+		{
+			name: "default and system reference known upstreams",
+			cfg:  base(config.Routing{DefaultUpstream: "primary", SystemUpstream: "system"}),
+		},
+		{
+			name:       "unknown default upstream",
+			cfg:        base(config.Routing{DefaultUpstream: "missing"}),
+			wantTuples: [][2]string{{"routing", "default"}},
+		},
+		{
+			name:       "unknown system upstream",
+			cfg:        base(config.Routing{SystemUpstream: "missing"}),
+			wantTuples: [][2]string{{"routing", "system"}},
+		},
+		{
+			name: "rule references known upstream",
+			cfg: base(config.Routing{Rules: []config.RoutingRule{
+				{Upstream: "primary", Match: config.RoutingMatch{Namespace: "payments"}},
+			}}),
+		},
+		{
+			name: "rule references unknown upstream",
+			cfg: base(config.Routing{Rules: []config.RoutingRule{
+				{Upstream: "missing", Match: config.RoutingMatch{Namespace: "payments"}},
+			}}),
+			wantTuples: [][2]string{{"routing.rules[0]", "upstream"}},
+		},
+		{
+			name: "rule with empty upstream is required, not a bad reference",
+			cfg: base(config.Routing{Rules: []config.RoutingRule{
+				{Match: config.RoutingMatch{Namespace: "payments"}},
+			}}),
+			wantTuples: [][2]string{{"routing.rules[0]", "upstream"}},
+		},
+		{
+			name: "unknown default, system, and rule aggregate",
+			cfg: base(config.Routing{
+				DefaultUpstream: "missing",
+				SystemUpstream:  "gone",
+				Rules: []config.RoutingRule{
+					{Upstream: "nope", Match: config.RoutingMatch{Namespace: "payments"}},
+				},
+			}),
+			wantTuples: [][2]string{
+				{"routing", "default"},
+				{"routing", "system"},
+				{"routing.rules[0]", "upstream"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assertTuples(t, tt.cfg.Validate(), tt.wantTuples)
+		})
+	}
+}
+
 func TestConfig_PrimaryUpstream(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/routing.go
+++ b/internal/config/routing.go
@@ -1,0 +1,116 @@
+package config
+
+import (
+	"fmt"
+
+	"github.com/temporalio/temporal-proxy/pkg/validation"
+)
+
+type (
+	// Routing selects which upstream serves a request. DefaultUpstream is the
+	// fallback when no rule matches and SystemUpstream serves system-namespace
+	// traffic; both name an upstream and are optional. Rules are evaluated in
+	// order against the incoming request.
+	Routing struct {
+		DefaultUpstream string        `yaml:"default"`
+		SystemUpstream  string        `yaml:"system"`
+		Rules           []RoutingRule `yaml:"rules"`
+	}
+
+	// RoutingRule sends every request matched by Match to the named Upstream.
+	RoutingRule struct {
+		Upstream string       `yaml:"upstream"`
+		Match    RoutingMatch `yaml:"match"`
+	}
+
+	// RoutingMatch describes the request attributes a rule matches on. A match
+	// requires at least one of Namespace or Metadata: an empty match would
+	// apply to every request, which is what DefaultUpstream is for.
+	RoutingMatch struct {
+		Namespace string            `yaml:"namespace"`
+		Metadata  map[string]string `yaml:"metadata"`
+	}
+)
+
+// Validate checks every rule. Per-rule failures are stamped with a "rules[i]"
+// subject. It does not verify that the referenced upstreams exist; that check
+// needs the full set of upstream names and lives in Config.Validate.
+func (r *Routing) Validate() error {
+	rules := make([]validation.Rule, len(r.Rules))
+	for i := range r.Rules {
+		rules[i] = validation.Nested(fmt.Sprintf("rules[%d]", i), &r.Rules[i])
+	}
+
+	return validation.Validate("", rules...)
+}
+
+// referentialRules returns the rules that check every upstream reference
+// (DefaultUpstream, SystemUpstream, and each rule's Upstream) against the set
+// of known upstream names. Each failure is stamped with the referring node's
+// YAML path so it lands on the right key (e.g. "routing.rules[0]"/"upstream").
+// Empty references are skipped: default and system are optional, and a rule's
+// missing upstream is already reported as required by RoutingRule.Validate.
+//
+// The rules are appended at the Config level rather than composed under
+// Routing.Validate because they need the full set of upstream names, which is
+// only known there.
+func (r *Routing) referentialRules(known map[string]struct{}) []validation.Rule {
+	check := knownUpstream(known)
+	ref := func(subject, field, name string) validation.Rule {
+		return func() validation.Errors {
+			if name == "" {
+				return nil
+			}
+
+			err := check(name)
+			if err == nil {
+				return nil
+			}
+
+			return validation.Errors{{Subject: subject, Field: field, Message: err.Error()}}
+		}
+	}
+
+	rules := []validation.Rule{
+		ref("routing", "default", r.DefaultUpstream),
+		ref("routing", "system", r.SystemUpstream),
+	}
+
+	for i := range r.Rules {
+		rules = append(rules, ref(fmt.Sprintf("routing.rules[%d]", i), "upstream", r.Rules[i].Upstream))
+	}
+
+	return rules
+}
+
+// Validate requires the referenced upstream and checks the match.
+func (r *RoutingRule) Validate() error {
+	return validation.Validate(
+		"",
+		validation.Field("upstream", r.Upstream, validation.Required[string]()),
+		validation.Nested("", &r.Match),
+	)
+}
+
+// Validate requires at least one of Namespace or Metadata to be set.
+func (m *RoutingMatch) Validate() error {
+	return validation.Validate(
+		"",
+		validation.WhenRules(
+			func() bool { return len(m.Metadata) == 0 },
+			validation.Field("namespace", m.Namespace, validation.Required[string]()),
+		),
+	)
+}
+
+// knownUpstream returns a check that fails when its value is not a key in
+// known.
+func knownUpstream(known map[string]struct{}) validation.Check[string] {
+	return func(name string) error {
+		if _, ok := known[name]; !ok {
+			return fmt.Errorf("references unknown upstream %q", name)
+		}
+
+		return nil
+	}
+}

--- a/internal/config/routing_test.go
+++ b/internal/config/routing_test.go
@@ -1,0 +1,167 @@
+package config_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/temporalio/temporal-proxy/internal/config"
+	"github.com/temporalio/temporal-proxy/pkg/validation"
+)
+
+func TestRouting_Validate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		routing    *config.Routing
+		wantTuples [][2]string
+	}{
+		{
+			name:    "empty routing yields no error",
+			routing: &config.Routing{},
+		},
+		{
+			name: "default and system are not checked for references here",
+			routing: &config.Routing{
+				DefaultUpstream: "unknown",
+				SystemUpstream:  "also-unknown",
+			},
+		},
+		{
+			name: "valid rules yield no error",
+			routing: &config.Routing{
+				Rules: []config.RoutingRule{
+					{Upstream: "primary", Match: config.RoutingMatch{Namespace: "payments"}},
+					{Upstream: "system", Match: config.RoutingMatch{Metadata: map[string]string{"tier": "gold"}}},
+				},
+			},
+		},
+		{
+			name: "invalid rule surfaces with its index",
+			routing: &config.Routing{
+				Rules: []config.RoutingRule{
+					{Match: config.RoutingMatch{Namespace: "payments"}},
+				},
+			},
+			wantTuples: [][2]string{{"rules[0]", "upstream"}},
+		},
+		{
+			name: "invalid rules keep their own indices",
+			routing: &config.Routing{
+				Rules: []config.RoutingRule{
+					{Upstream: "primary", Match: config.RoutingMatch{Namespace: "payments"}},
+					{Match: config.RoutingMatch{}},
+				},
+			},
+			wantTuples: [][2]string{{"rules[1]", "upstream"}, {"rules[1]", "namespace"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assertTuples(t, tt.routing.Validate(), tt.wantTuples)
+		})
+	}
+}
+
+func TestRoutingRule_Validate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		rule       *config.RoutingRule
+		wantTuples [][2]string
+	}{
+		{
+			name: "valid upstream and match",
+			rule: &config.RoutingRule{
+				Upstream: "primary",
+				Match:    config.RoutingMatch{Namespace: "payments"},
+			},
+		},
+		{
+			name: "missing upstream",
+			rule: &config.RoutingRule{
+				Match: config.RoutingMatch{Namespace: "payments"},
+			},
+			wantTuples: [][2]string{{"", "upstream"}},
+		},
+		{
+			name:       "missing upstream and empty match aggregate",
+			rule:       &config.RoutingRule{},
+			wantTuples: [][2]string{{"", "upstream"}, {"", "namespace"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assertTuples(t, tt.rule.Validate(), tt.wantTuples)
+		})
+	}
+}
+
+func TestRoutingMatch_Validate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		match      *config.RoutingMatch
+		wantTuples [][2]string // (Subject, Field); empty slice means no error expected
+	}{
+		{
+			name:  "namespace set, no metadata",
+			match: &config.RoutingMatch{Namespace: "payments"},
+		},
+		{
+			name:  "metadata set, no namespace",
+			match: &config.RoutingMatch{Metadata: map[string]string{"tier": "gold"}},
+		},
+		{
+			name: "both namespace and metadata set",
+			match: &config.RoutingMatch{
+				Namespace: "payments",
+				Metadata:  map[string]string{"tier": "gold"},
+			},
+		},
+		{
+			name:       "neither namespace nor metadata set",
+			match:      &config.RoutingMatch{},
+			wantTuples: [][2]string{{"", "namespace"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assertTuples(t, tt.match.Validate(), tt.wantTuples)
+		})
+	}
+}
+
+// assertTuples asserts that err carries exactly the (Subject, Field) pairs in
+// want. An empty want means err must be nil.
+func assertTuples(t *testing.T, err error, want [][2]string) {
+	t.Helper()
+
+	if len(want) == 0 {
+		require.NoError(t, err)
+		return
+	}
+
+	var errs validation.Errors
+	require.True(t, errors.As(err, &errs), "expected validation.Errors, got %T", err)
+
+	got := make([][2]string, len(errs))
+	for i, e := range errs {
+		got[i] = [2]string{e.Subject, e.Field}
+	}
+
+	require.ElementsMatch(t, want, got)
+}

--- a/internal/config/upstream_test.go
+++ b/internal/config/upstream_test.go
@@ -348,7 +348,7 @@ func TestNamespaceConfig_Validate(t *testing.T) {
 			cfg:  &config.NamespaceConfig{},
 		},
 		{
-			name: "rules failure surfaces with override-index subject preserved",
+			name: "rules failure surfaces with rules path prefixed onto the subject",
 			cfg: &config.NamespaceConfig{
 				Rules: config.NamespaceRules{
 					Overrides: []config.NamespaceMapping{
@@ -357,7 +357,7 @@ func TestNamespaceConfig_Validate(t *testing.T) {
 				},
 			},
 			wantTuples: [][2]string{
-				{"overrides[0]", "remote"},
+				{"rules.overrides[0]", "remote"},
 			},
 		},
 	}
@@ -427,7 +427,7 @@ func TestUpstream_Validate(t *testing.T) {
 			},
 		},
 		{
-			name: "namespace override failure surfaces with override-index subject",
+			name: "namespace override failure surfaces with the full namespaces path",
 			upstream: &config.Upstream{
 				Name:   "primary",
 				Listen: config.ListenConfig{HostPort: "127.0.0.1:7233"},
@@ -440,7 +440,7 @@ func TestUpstream_Validate(t *testing.T) {
 				},
 			},
 			wantTuples: [][2]string{
-				{"overrides[0]", "remote"},
+				{"namespaces.rules.overrides[0]", "remote"},
 			},
 		},
 		{
@@ -458,8 +458,8 @@ func TestUpstream_Validate(t *testing.T) {
 			},
 			wantTuples: [][2]string{
 				{"", "hostPort"},
-				{"overrides[0]", "local"},
-				{"overrides[0]", "remote"},
+				{"namespaces.rules.overrides[0]", "local"},
+				{"namespaces.rules.overrides[0]", "remote"},
 			},
 		},
 	}

--- a/pkg/validation/combinators.go
+++ b/pkg/validation/combinators.go
@@ -1,11 +1,17 @@
 package validation
 
-// Validator is satisfied by any type whose Validate method returns an
-// error. Types that already follow the standard "Validate() error"
-// convention satisfy this interface implicitly.
-type Validator interface {
-	Validate() error
-}
+import "fmt"
+
+type (
+	// Validator is satisfied by any type whose Validate method returns an
+	// error. Types that already follow the standard "Validate() error"
+	// convention satisfy this interface implicitly.
+	Validator interface {
+		Validate() error
+	}
+
+	validatorFunc func() error
+)
 
 // When runs the supplied checks only when pred(v) returns true. When pred
 // returns false the combinator yields nil and no inner check runs. Inner
@@ -53,12 +59,14 @@ func WhenRules(pred func() bool, rules ...Rule) Rule {
 	}
 }
 
-// Nested embeds the result of v.Validate as a Rule. Entries whose
-// Subject was left empty by the child are stamped with subject; entries
-// the child already attributed (or whose Subject is non-empty for any
-// reason) are preserved unchanged. A nil error from v yields no entries,
-// and any non-validation error is wrapped as a single entry whose
-// Message is err.Error() and whose Subject is subject.
+// Nested embeds the result of v.Validate as a Rule, prefixing subject onto
+// each entry to build a dotted path. An entry the child left unattributed gets
+// Subject set to subject; an entry the child already attributed gets its
+// Subject prefixed (subject + "." + child), so deeper nesting composes into a
+// path like "classes[0].subjects[1]". A nil error from v yields no entries, an
+// empty subject leaves entries unchanged, and any non-validation error is
+// wrapped as a single entry whose Message is err.Error() and whose Subject is
+// subject.
 func Nested(subject string, v Validator) Rule {
 	return func() Errors {
 		err := v.Validate()
@@ -74,9 +82,36 @@ func Nested(subject string, v Validator) Rule {
 		for i := range errs {
 			if errs[i].Subject == "" {
 				errs[i].Subject = subject
+			} else {
+				errs[i].Subject = subject + "." + errs[i].Subject
 			}
 		}
 
 		return errs
 	}
 }
+
+// Children is the slice counterpart to Nested: it validates each element of
+// items with validate, prefixing a "name[i]" segment onto the resulting
+// subjects to build a dotted path (e.g. "classes[0].subjects[1]"). Empty
+// subjects become the segment; already-set ones are prefixed into a path. The
+// per-element validate is supplied explicitly rather than via the Validator
+// interface, so callers can thread external context by closing over it - for
+// example Children("classes", c.Classes, func(x *Class) error { return x.validate(ctx) }).
+// A nil or empty slice yields no entries and never calls validate.
+func Children[S ~[]T, T any](name string, items S, validate func(*T) error) Rule {
+	return func() Errors {
+		var errs Errors
+		for i := range items {
+			item := &items[i]
+			segment := fmt.Sprintf("%s[%d]", name, i)
+			errs = append(errs, Nested(segment, validatorFunc(func() error {
+				return validate(item)
+			}))()...)
+		}
+
+		return errs
+	}
+}
+
+func (f validatorFunc) Validate() error { return f() }

--- a/pkg/validation/combinators_test.go
+++ b/pkg/validation/combinators_test.go
@@ -9,6 +9,11 @@ import (
 	"github.com/temporalio/temporal-proxy/pkg/validation"
 )
 
+type recordingValidator struct {
+	calls int
+	err   error
+}
+
 func TestWhen_PredicateFalse_DoesNotInvokeChecks(t *testing.T) {
 	t.Parallel()
 
@@ -185,16 +190,6 @@ func TestWhenRules_IntegratesWithValidate(t *testing.T) {
 	require.Equal(t, "inner", errs[0].Field)
 }
 
-type recordingValidator struct {
-	calls int
-	err   error
-}
-
-func (r *recordingValidator) Validate() error {
-	r.calls++
-	return r.err
-}
-
 func TestNested_NilError_NoEntries(t *testing.T) {
 	t.Parallel()
 
@@ -222,7 +217,7 @@ func TestNested_StampsEmptySubjects(t *testing.T) {
 	require.Equal(t, "keyFile", out[1].Field)
 }
 
-func TestNested_PreservesExplicitSubjects(t *testing.T) {
+func TestNested_PrefixesChildSubjects(t *testing.T) {
 	t.Parallel()
 
 	v := &recordingValidator{
@@ -234,8 +229,8 @@ func TestNested_PreservesExplicitSubjects(t *testing.T) {
 
 	out := validation.Nested("outer", v)()
 	require.Len(t, out, 2)
-	require.Equal(t, "explicit", out[0].Subject, "explicit subject must be preserved")
-	require.Equal(t, "outer", out[1].Subject, "empty subject must be stamped")
+	require.Equal(t, "outer.explicit", out[0].Subject, "child subject must be prefixed into a path")
+	require.Equal(t, "outer", out[1].Subject, "empty subject must be set to the segment")
 }
 
 func TestNested_SingleValidationError(t *testing.T) {
@@ -305,4 +300,67 @@ func TestNested_OuterValidate_DoesNotReStampExplicitSubject(t *testing.T) {
 	require.True(t, errors.As(err, &errs))
 	require.Len(t, errs, 1)
 	require.Equal(t, "tls", errs[0].Subject)
+}
+
+func TestChildren_EmptyAndNil(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	validate := func(*int) error { called = true; return nil }
+
+	require.Empty(t, validation.Children("xs", []int{}, validate)())
+	require.Empty(t, validation.Children[[]int]("xs", nil, validate)())
+	require.False(t, called, "validate must not run for an empty slice")
+}
+
+func TestChildren_ReceivesEachElement(t *testing.T) {
+	t.Parallel()
+
+	var seen []int
+	validate := func(n *int) error {
+		seen = append(seen, *n)
+		return nil
+	}
+
+	require.Empty(t, validation.Children("xs", []int{10, 20, 30}, validate)())
+	require.Equal(t, []int{10, 20, 30}, seen)
+}
+
+func TestChildren_PrefixesIndexedSegment(t *testing.T) {
+	t.Parallel()
+
+	// Only the second element fails, with one attributed and one unattributed
+	// entry, so we can pin both the index and the path composition.
+	validate := func(n *int) error {
+		if *n != 1 {
+			return nil
+		}
+		return validation.Errors{
+			{Subject: "inner", Field: "x", Message: "boom"},
+			{Field: "y", Message: "boom"},
+		}
+	}
+
+	out := validation.Children("items", []int{0, 1}, validate)()
+	require.Len(t, out, 2)
+	require.Equal(t, "items[1].inner", out[0].Subject, "attributed child subject must be prefixed into a path")
+	require.Equal(t, "items[1]", out[1].Subject, "unattributed entry gets the segment")
+}
+
+func TestChildren_MultipleFailuresAccumulate(t *testing.T) {
+	t.Parallel()
+
+	validate := func(s *string) error { return errors.New(*s) }
+
+	out := validation.Children("items", []string{"a", "b"}, validate)()
+	require.Len(t, out, 2)
+	require.Equal(t, "items[0]", out[0].Subject)
+	require.Equal(t, "a", out[0].Message)
+	require.Equal(t, "items[1]", out[1].Subject)
+	require.Equal(t, "b", out[1].Message)
+}
+
+func (r *recordingValidator) Validate() error {
+	r.calls++
+	return r.err
 }


### PR DESCRIPTION
Add a routing section to the proxy config as the configuration-side precursor to per-request routing. Routing carries an optional default and system upstream plus an ordered list of rules, each naming the upstream that should serve the requests its match selects. Matching against live requests is intentionally out of scope here.

Validation spans two levels. A rule must name an upstream, and a match must set at least one of namespace or metadata (an empty match would apply to every request, which is what default is for). Referential integrity for the default, system, and each rule's upstream is checked in Config.Validate, the only place the full set of upstream names is known.
