### PR TITLE
[router]: Add routing mux and namespace extractor

### DIFF
--- a/cmd/proxy/serve.go
+++ b/cmd/proxy/serve.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/temporalio/temporal-proxy/internal/config"
 	"github.com/temporalio/temporal-proxy/internal/metrics"
+	"github.com/temporalio/temporal-proxy/internal/protoutil"
 	"github.com/temporalio/temporal-proxy/internal/proxy"
 	"github.com/temporalio/temporal-proxy/internal/router"
 	"github.com/temporalio/temporal-proxy/internal/server"
@@ -61,6 +62,7 @@ func serve() *cli.Command {
 				config.Module,
 				connect.Module,
 				metrics.Module,
+				protoutil.Module,
 				proxy.Module,
 				router.Module,
 				server.Module,

--- a/internal/protoutil/doc.go
+++ b/internal/protoutil/doc.go
@@ -1,0 +1,11 @@
+// Package protoutil provides helpers for working with Temporal's protobuf
+// request types at the gRPC boundary, without the caller needing to know the
+// concrete message type for a given method.
+//
+// [Extractor] reads the namespace from an encoded request by resolving its
+// message type from a descriptor registry and a type registry. [Module] wires
+// an Extractor into an fx application, defaulting those registries to
+// [google.golang.org/protobuf/reflect/protoregistry.GlobalFiles] and
+// [google.golang.org/protobuf/reflect/protoregistry.GlobalTypes] when they are
+// not supplied.
+package protoutil

--- a/internal/protoutil/extractor.go
+++ b/internal/protoutil/extractor.go
@@ -1,0 +1,130 @@
+package protoutil
+
+import (
+	"strings"
+	"sync"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+type (
+	// Extractor reads the namespace from an encoded gRPC request. It resolves
+	// the concrete request message type for a full method name from the
+	// descriptor and type registries it was given, decodes the payload into it,
+	// and reads the namespace via the generated accessor. Resolved types are
+	// cached per method, so repeat calls for the same method skip the lookup.
+	// Construct one with NewExtractor; an Extractor is safe for concurrent use.
+	Extractor struct {
+		msgs  sync.Map // fullMethod -> protoreflect.MessageType (nil when unresolvable)
+		files Files
+		types Types
+	}
+
+	// Files resolves a descriptor by its fully qualified name. *protoregistry.Files,
+	// and in particular protoregistry.GlobalFiles, implements it.
+	Files interface {
+		FindDescriptorByName(protoreflect.FullName) (protoreflect.Descriptor, error)
+	}
+
+	// Types resolves a message type by its fully qualified name. *protoregistry.Types,
+	// and in particular protoregistry.GlobalTypes, implements it.
+	Types interface {
+		FindMessageByName(protoreflect.FullName) (protoreflect.MessageType, error)
+	}
+
+	// namespacer is implemented by the generated request types that carry a
+	// namespace. Requests without one (e.g. GetSystemInfo) do not implement it,
+	// so they yield an empty namespace.
+	namespacer interface {
+		GetNamespace() string
+	}
+)
+
+// NewExtractor returns an Extractor that resolves request types using files and
+// types. Production callers pass protoregistry.GlobalFiles and
+// protoregistry.GlobalTypes; tests may pass fakes. Resolution only succeeds for
+// message types registered in the given registries, so the relevant service
+// packages (e.g. go.temporal.io/api/workflowservice/v1) must be imported into
+// the binary.
+func NewExtractor(files Files, types Types) *Extractor {
+	return &Extractor{
+		files: files,
+		types: types,
+	}
+}
+
+// Namespace returns the namespace carried by an encoded request for fullMethod,
+// or the empty string when the method is unknown, the request type carries no
+// namespace, or the payload cannot be decoded.
+func (e *Extractor) Namespace(fullMethod string, payload []byte) string {
+	mt := e.messageType(fullMethod)
+	if mt == nil {
+		return ""
+	}
+
+	msg := mt.New().Interface()
+	if err := proto.Unmarshal(payload, msg); err != nil {
+		return ""
+	}
+
+	ns, ok := msg.(namespacer)
+	if !ok {
+		return ""
+	}
+
+	return ns.GetNamespace()
+}
+
+// messageType returns the request message type for fullMethod, or nil when it
+// cannot be resolved. The result, including a nil miss, is cached so each method
+// is resolved at most once.
+func (e *Extractor) messageType(fullMethod string) protoreflect.MessageType {
+	if v, ok := e.msgs.Load(fullMethod); ok {
+		if v == nil {
+			return nil
+		}
+
+		return v.(protoreflect.MessageType)
+	}
+
+	mt := e.resolveInputType(fullMethod)
+	e.msgs.Store(fullMethod, mt)
+	return mt
+}
+
+// resolveInputType looks up the request message type for a "/pkg.Service/Method"
+// name via the extractor's Files and Types, returning nil when the name is
+// malformed or the service, method, or message type is not resolvable.
+func (e *Extractor) resolveInputType(fullMethod string) protoreflect.MessageType {
+	trimmed := strings.TrimPrefix(fullMethod, "/")
+	slash := strings.LastIndex(trimmed, "/")
+	if slash < 0 {
+		return nil
+	}
+
+	service := trimmed[:slash]
+	method := trimmed[slash+1:]
+
+	d, err := e.files.FindDescriptorByName(protoreflect.FullName(service))
+	if err != nil {
+		return nil
+	}
+
+	sd, ok := d.(protoreflect.ServiceDescriptor)
+	if !ok {
+		return nil
+	}
+
+	md := sd.Methods().ByName(protoreflect.Name(method))
+	if md == nil {
+		return nil
+	}
+
+	mt, err := e.types.FindMessageByName(md.Input().FullName())
+	if err != nil {
+		return nil
+	}
+
+	return mt
+}

--- a/internal/protoutil/extractor_test.go
+++ b/internal/protoutil/extractor_test.go
@@ -1,0 +1,111 @@
+package protoutil_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/api/workflowservice/v1"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+
+	"github.com/temporalio/temporal-proxy/internal/protoutil"
+)
+
+const (
+	wfService    = "temporal.api.workflowservice.v1.WorkflowService"
+	startMethod  = "/" + wfService + "/StartWorkflowExecution"
+	systemMethod = "/" + wfService + "/GetSystemInfo"
+)
+
+type (
+	errFiles struct{ err error }
+	errTypes struct{ err error }
+)
+
+func TestExtractorNamespace(t *testing.T) {
+	t.Parallel()
+
+	start := mustMarshal(t, &workflowservice.StartWorkflowExecutionRequest{Namespace: "ns-1"})
+	system := mustMarshal(t, &workflowservice.GetSystemInfoRequest{})
+
+	tests := []struct {
+		name    string
+		method  string
+		payload []byte
+		want    string
+	}{
+		{name: "namespaced request", method: startMethod, payload: start, want: "ns-1"},
+		{name: "system request has no namespace", method: systemMethod, payload: system, want: ""},
+		{name: "unknown service", method: "/nope.v1.Service/Method", payload: start, want: ""},
+		{name: "name resolves to a non-service", method: "/temporal.api.workflowservice.v1.StartWorkflowExecutionRequest/Method", payload: start, want: ""},
+		{name: "unknown method on real service", method: "/" + wfService + "/NoSuchMethod", payload: start, want: ""},
+		{name: "malformed method name", method: "no-slashes", payload: start, want: ""},
+		{name: "garbage payload", method: startMethod, payload: []byte{0xff, 0xff, 0xff}, want: ""},
+		{name: "empty namespace", method: startMethod, payload: mustMarshal(t, &workflowservice.StartWorkflowExecutionRequest{}), want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ex := protoutil.NewExtractor(protoregistry.GlobalFiles, protoregistry.GlobalTypes)
+			require.Equal(t, tt.want, ex.Namespace(tt.method, tt.payload))
+		})
+	}
+}
+
+func TestExtractorCaching(t *testing.T) {
+	t.Parallel()
+
+	start := mustMarshal(t, &workflowservice.StartWorkflowExecutionRequest{Namespace: "ns-1"})
+
+	t.Run("resolved type is reused", func(t *testing.T) {
+		t.Parallel()
+		ex := protoutil.NewExtractor(protoregistry.GlobalFiles, protoregistry.GlobalTypes)
+		require.Equal(t, "ns-1", ex.Namespace(startMethod, start))
+		require.Equal(t, "ns-1", ex.Namespace(startMethod, start), "second lookup uses the cached type")
+	})
+
+	t.Run("unknown method stays empty on repeat", func(t *testing.T) {
+		t.Parallel()
+		ex := protoutil.NewExtractor(protoregistry.GlobalFiles, protoregistry.GlobalTypes)
+		require.Equal(t, "", ex.Namespace("/nope.v1.Service/Method", start))
+		require.Equal(t, "", ex.Namespace("/nope.v1.Service/Method", start), "cached nil miss must not panic")
+	})
+}
+
+func TestExtractorConsultsInjectedSources(t *testing.T) {
+	t.Parallel()
+
+	start := mustMarshal(t, &workflowservice.StartWorkflowExecutionRequest{Namespace: "ns-1"})
+
+	t.Run("files error yields empty", func(t *testing.T) {
+		t.Parallel()
+		ex := protoutil.NewExtractor(errFiles{err: errors.New("boom")}, protoregistry.GlobalTypes)
+		require.Equal(t, "", ex.Namespace(startMethod, start))
+	})
+
+	t.Run("types error yields empty", func(t *testing.T) {
+		t.Parallel()
+		// Real files resolve the service and method; the injected types then
+		// fails, so extraction stops there. This proves types is consulted.
+		ex := protoutil.NewExtractor(protoregistry.GlobalFiles, errTypes{err: errors.New("boom")})
+		require.Equal(t, "", ex.Namespace(startMethod, start))
+	})
+}
+
+func (f errFiles) FindDescriptorByName(protoreflect.FullName) (protoreflect.Descriptor, error) {
+	return nil, f.err
+}
+
+func (t errTypes) FindMessageByName(protoreflect.FullName) (protoreflect.MessageType, error) {
+	return nil, t.err
+}
+
+func mustMarshal(t *testing.T, m proto.Message) []byte {
+	t.Helper()
+	b, err := proto.Marshal(m)
+	require.NoError(t, err)
+	return b
+}

--- a/internal/protoutil/fx.go
+++ b/internal/protoutil/fx.go
@@ -1,0 +1,34 @@
+package protoutil
+
+import (
+	"go.uber.org/fx"
+	"google.golang.org/protobuf/reflect/protoregistry"
+)
+
+// Module provides an [*Extractor]. Files and Types default to the global
+// protobuf registries when the application supplies neither, so most consumers
+// wire this module with no extra dependencies; supplying either (for example in
+// tests) overrides the corresponding default.
+var Module = fx.Options(fx.Provide(
+	func(p ExtractorParams) *Extractor {
+		if p.Files == nil {
+			p.Files = protoregistry.GlobalFiles
+		}
+
+		if p.Types == nil {
+			p.Types = protoregistry.GlobalTypes
+		}
+
+		return NewExtractor(p.Files, p.Types)
+	},
+))
+
+// ExtractorParams collects the dependencies used to build the [*Extractor].
+// Both are optional: when absent, Module falls back to the global protobuf
+// registries.
+type ExtractorParams struct {
+	fx.In
+
+	Files Files `optional:"true"`
+	Types Types `optional:"true"`
+}

--- a/internal/protoutil/fx_test.go
+++ b/internal/protoutil/fx_test.go
@@ -1,0 +1,47 @@
+package protoutil_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.uber.org/fx"
+
+	"github.com/temporalio/temporal-proxy/internal/protoutil"
+)
+
+func TestModule(t *testing.T) {
+	t.Parallel()
+
+	start := mustMarshal(t, &workflowservice.StartWorkflowExecutionRequest{Namespace: "ns-1"})
+
+	t.Run("provides an extractor backed by the global registries", func(t *testing.T) {
+		t.Parallel()
+
+		var ex *protoutil.Extractor
+		app := fx.New(
+			protoutil.Module,
+			fx.Populate(&ex),
+			fx.NopLogger,
+		)
+		require.NoError(t, app.Err())
+		require.NotNil(t, ex)
+		require.Equal(t, "ns-1", ex.Namespace(startMethod, start))
+	})
+
+	t.Run("supplied Files overrides the default", func(t *testing.T) {
+		t.Parallel()
+
+		var ex *protoutil.Extractor
+		app := fx.New(
+			fx.Supply(fx.Annotate(errFiles{err: errors.New("boom")}, fx.As(new(protoutil.Files)))),
+			protoutil.Module,
+			fx.Populate(&ex),
+			fx.NopLogger,
+		)
+		require.NoError(t, app.Err())
+		require.NotNil(t, ex)
+		require.Equal(t, "", ex.Namespace(startMethod, start))
+	})
+}

--- a/internal/router/fx.go
+++ b/internal/router/fx.go
@@ -2,6 +2,7 @@ package router
 
 import (
 	"fmt"
+	"strings"
 
 	"go.uber.org/fx"
 	"google.golang.org/grpc"
@@ -10,6 +11,7 @@ import (
 	"github.com/temporalio/temporal-proxy/internal/config"
 	"github.com/temporalio/temporal-proxy/internal/transport/connect"
 	"github.com/temporalio/temporal-proxy/internal/transport/socket"
+	"github.com/temporalio/temporal-proxy/pkg/match"
 )
 
 // Module is the fx module that provides the transparent-forwarding pieces: a
@@ -39,6 +41,52 @@ var Module = fx.Options(fx.Provide(
 		}
 
 		return Handler(conn), nil
+	},
+	func(c *config.Config) (*Mux, error) {
+		rules := make([]Rule, 0, len(c.Routing.Rules))
+		for i, r := range c.Routing.Rules {
+			p := r.Match.Namespace
+			if p == "" {
+				p = "*"
+			}
+
+			ns, err := match.Compile(p)
+			if err != nil {
+				return nil, fmt.Errorf("routing: rules[%d].match.namespace: %w", i, err)
+			}
+
+			meta := make(map[string]Matcher, len(r.Match.Metadata))
+			seen := make(map[string]string, len(r.Match.Metadata))
+			for k, v := range r.Match.Metadata {
+				lk := strings.ToLower(k)
+				if prev, ok := seen[lk]; ok {
+					return nil, fmt.Errorf(
+						"routing: rules[%d].match.metadata: keys %q and %q both map to %q when lowercased",
+						i, prev, k, lk,
+					)
+				}
+
+				seen[lk] = k
+				m, err := match.Compile(v)
+				if err != nil {
+					return nil, fmt.Errorf("routing: rules[%d].match.metadata[%q]: %w", i, k, err)
+				}
+
+				meta[lk] = m
+			}
+
+			rules = append(rules, Rule{
+				upstream: r.Upstream,
+				ns:       ns,
+				meta:     meta,
+			})
+		}
+
+		return New(
+			c.Routing.DefaultUpstream,
+			c.Routing.SystemUpstream,
+			rules...,
+		), nil
 	},
 ))
 

--- a/internal/router/fx_test.go
+++ b/internal/router/fx_test.go
@@ -135,3 +135,81 @@ func TestModule(t *testing.T) {
 		require.NoError(t, app.Stop(stopCtx))
 	})
 }
+
+func TestModuleMux(t *testing.T) {
+	t.Parallel()
+
+	t.Run("compiles routing config into a Mux", func(t *testing.T) {
+		t.Parallel()
+
+		var mux *router.Mux
+
+		app := fx.New(
+			fx.Supply(&config.Config{
+				Routing: config.Routing{
+					DefaultUpstream: "default",
+					SystemUpstream:  "system",
+					Rules: []config.RoutingRule{
+						{Upstream: "prod", Match: config.RoutingMatch{Namespace: "prod-*"}},
+						// Metadata key is upper-cased in config; the provider must
+						// lowercase it to match canonical gRPC metadata keys.
+						{Upstream: "gold", Match: config.RoutingMatch{Metadata: map[string]string{"X-Tier": "gold"}}},
+					},
+				},
+			}),
+			router.Module,
+			fx.Populate(&mux),
+			fx.NopLogger,
+		)
+		require.NoError(t, app.Err())
+		require.NotNil(t, mux)
+
+		require.Equal(t, "prod", mux.Switch("prod-1", nil), "namespace rule")
+		require.Equal(t, "gold", mux.Switch("any", map[string][]string{"x-tier": {"gold"}}), "metadata rule with lowercased key")
+		require.Equal(t, "default", mux.Switch("other", nil), "no match falls to default")
+		require.Equal(t, "system", mux.Switch("", nil), "no namespace falls to system")
+	})
+
+	t.Run("rejects an invalid rule", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			match config.RoutingMatch
+			exp   string
+		}{
+			{
+				match: config.RoutingMatch{Namespace: "a*b"},
+				exp:   "rules[0].match.namespace",
+			},
+			{
+				match: config.RoutingMatch{Metadata: map[string]string{"k": "a*b"}},
+				exp:   `rules[0].match.metadata["k"]`,
+			},
+			{
+				// Keys differing only by case collide once lowercased; which one
+				// would win depends on random map iteration, so this must fail.
+				match: config.RoutingMatch{Metadata: map[string]string{"X-Tier": "gold", "x-tier": "silver"}},
+				exp:   `both map to "x-tier" when lowercased`,
+			},
+		}
+
+		var mux *router.Mux
+		for _, tt := range tests {
+			app := fx.New(
+				fx.Supply(&config.Config{
+					Routing: config.Routing{
+						Rules: []config.RoutingRule{
+							{Upstream: "x", Match: tt.match},
+						},
+					},
+				}),
+				router.Module,
+				fx.Populate(&mux),
+				fx.NopLogger,
+			)
+
+			require.Error(t, app.Err())
+			require.ErrorContains(t, app.Err(), tt.exp)
+		}
+	})
+}

--- a/internal/router/mux.go
+++ b/internal/router/mux.go
@@ -1,0 +1,83 @@
+package router
+
+import "slices"
+
+type (
+	// Mux selects the upstream that serves a request by matching it against an
+	// ordered list of rules. It holds upstream names only, not connections, so
+	// callers map the name Switch returns to a connection. A Mux is read-only
+	// after construction and safe for concurrent use.
+	Mux struct {
+		def   string
+		sys   string
+		rules []Rule
+	}
+
+	// Matcher reports whether a string satisfies some pattern. Rules use it to
+	// match namespaces and metadata values, keeping Mux decoupled from any
+	// particular matching implementation.
+	Matcher interface {
+		Match(string) bool
+	}
+
+	// Rule routes every request it matches to a named upstream. A request
+	// matches when the rule's namespace matcher accepts the request namespace
+	// and, for every constrained metadata key, at least one of the request's
+	// values for that key is accepted. Metadata keys are compared as stored, so
+	// the rule builder is responsible for canonicalizing them (gRPC lowercases
+	// metadata keys). Construct rules within this package.
+	Rule struct {
+		upstream string
+		ns       Matcher
+		meta     map[string]Matcher
+	}
+)
+
+// New returns a Mux that evaluates rules in order. defUpstream is returned when
+// no rule matches; sysUpstream, when non-empty, serves a request that carries
+// no namespace and matches no rule. Either name may be empty, in which case
+// Switch can return "" to signal that the request is unroutable.
+func New(defUpstream, sysUpstream string, rules ...Rule) *Mux {
+	return &Mux{
+		def:   defUpstream,
+		sys:   sysUpstream,
+		rules: slices.Clone(rules),
+	}
+}
+
+// Switch returns the name of the upstream that serves a request with the given
+// namespace and metadata. Rules are evaluated in order and the first match
+// wins. When no rule matches, a request with no namespace goes to the system
+// upstream if one is configured, and every other request goes to the default
+// upstream. The result is empty when the selected upstream is unset, which the
+// caller reports as an unroutable request.
+func (m *Mux) Switch(ns string, md map[string][]string) string {
+	for _, rule := range m.rules {
+		if rule.matches(ns, md) {
+			return rule.upstream
+		}
+	}
+
+	if ns == "" && m.sys != "" {
+		return m.sys
+	}
+
+	return m.def
+}
+
+// matches reports whether the rule accepts a request with the given namespace
+// and metadata: the namespace must match and, for every metadata key the rule
+// constrains, at least one of the request's values for that key must match.
+func (r *Rule) matches(ns string, md map[string][]string) bool {
+	if r.ns == nil || !r.ns.Match(ns) {
+		return false
+	}
+
+	for key, matcher := range r.meta {
+		if matcher == nil || !slices.ContainsFunc(md[key], matcher.Match) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/internal/router/mux_test.go
+++ b/internal/router/mux_test.go
@@ -1,0 +1,86 @@
+package router
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type matcherFunc func(string) bool
+
+func TestMuxSwitch(t *testing.T) {
+	t.Parallel()
+
+	mux := New(
+		"default",
+		"system",
+		Rule{upstream: "prod", ns: matchPrefix("prod-")},
+		Rule{upstream: "gold", ns: matchAll(), meta: map[string]Matcher{"x-tier": matchExact("gold")}},
+		Rule{upstream: "combo", ns: matchPrefix("eu-"), meta: map[string]Matcher{"x-region": matchPrefix("eu")}},
+	)
+
+	tests := []struct {
+		name string
+		ns   string
+		md   map[string][]string
+		want string
+	}{
+		{name: "namespace prefix rule", ns: "prod-1", want: "prod"},
+		{name: "metadata-only rule", ns: "anything", md: map[string][]string{"x-tier": {"gold"}}, want: "gold"},
+		{name: "metadata any of many values", ns: "anything", md: map[string][]string{"x-tier": {"bronze", "gold"}}, want: "gold"},
+		{name: "combined namespace and metadata", ns: "eu-1", md: map[string][]string{"x-region": {"eu-west"}}, want: "combo"},
+		{name: "combined rule fails on metadata", ns: "eu-1", md: map[string][]string{"x-region": {"us-east"}}, want: "default"},
+		{name: "metadata-only rule matches empty namespace", ns: "", md: map[string][]string{"x-tier": {"gold"}}, want: "gold"},
+		{name: "constrained metadata key absent", ns: "other", md: map[string][]string{"unrelated": {"gold"}}, want: "default"},
+		{name: "no namespace falls to system", ns: "", want: "system"},
+		{name: "namespaced no match falls to default", ns: "other", want: "default"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, mux.Switch(tt.ns, tt.md))
+		})
+	}
+}
+
+func TestMuxSwitchFirstMatchWins(t *testing.T) {
+	t.Parallel()
+
+	mux := New(
+		"default",
+		"",
+		Rule{upstream: "first", ns: matchPrefix("prod-")},
+		Rule{upstream: "second", ns: matchPrefix("prod-")},
+	)
+
+	require.Equal(t, "first", mux.Switch("prod-1", nil))
+}
+
+func TestMuxSwitchNoDefault(t *testing.T) {
+	t.Parallel()
+
+	mux := New(
+		"",
+		"",
+		Rule{upstream: "prod", ns: matchPrefix("prod-")},
+	)
+
+	require.Equal(t, "", mux.Switch("other", nil), "no rule and no default yields empty")
+	require.Equal(t, "", mux.Switch("", nil), "no namespace, no system, no default yields empty")
+}
+
+func (f matcherFunc) Match(s string) bool { return f(s) }
+
+func matchExact(want string) Matcher {
+	return matcherFunc(func(s string) bool { return s == want })
+}
+
+func matchPrefix(p string) Matcher {
+	return matcherFunc(func(s string) bool { return strings.HasPrefix(s, p) })
+}
+
+func matchAll() Matcher {
+	return matcherFunc(func(string) bool { return true })
+}


### PR DESCRIPTION
Introduce the building blocks for per-request routing.

router.Mux compiles the configured routing block into an ordered list of rules, matching namespace and metadata values with pkg/match globs and canonicalizing metadata keys to lowercase. Switch selects an upstream per request: the first matching rule wins, a request with no namespace falls back to the system upstream, and everything else to the default. It is provided via fx from config.

protoutil.Extractor reads a request's local namespace by resolving the concrete request message type for a gRPC method from injected descriptor and type registries (defaulting to the global protobuf registries) and reading GetNamespace, caching the resolution per method. It is provided via fx and registered in the proxy application.

> [!NOTE]
These are not yet wired into the forwarding handler; connecting the extracted namespace and the mux to upstream selection is coming 🔜 