### PR TITLE
[proxy]: Run one proxy per upstream

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -49,27 +49,38 @@ func LoadFile(path string) (*Config, error) {
 	return Load(f)
 }
 
-// Validate checks the listen configuration and every upstream, requires
-// upstream names to be unique, and checks that every routing reference names a
-// configured upstream. Failures are stamped with the failing node's YAML path
+// Validate requires at least one upstream, checks the listen configuration and
+// every upstream, requires upstream names to be unique, and checks that every
+// routing reference names a configured upstream. A missing upstream surfaces on
+// the "upstreams" field. Failures are stamped with the failing node's YAML path
 // as the subject (e.g. "upstreams[0].namespaces.rules.overrides[1]"). A
 // duplicate name surfaces on the "upstreams[name]" field, and an unknown
 // routing reference on the "routing"/"routing.rules[i]" subject.
 func (c *Config) Validate() error {
 	rules := []validation.Rule{
+		validation.Field("upstreams", c.Upstreams, func(us []Upstream) error {
+			if len(us) == 0 {
+				return errors.New("at least one upstream is required")
+			}
+
+			return nil
+		}),
 		validation.Nested("", &c.Listen),
 		validation.Nested("routing", &c.Routing),
 		validation.Children("upstreams", c.Upstreams, func(u *Upstream) error { return u.Validate() }),
 	}
 
 	names := make([]string, len(c.Upstreams))
+	hostPorts := make([]string, len(c.Upstreams))
 	known := make(map[string]struct{}, len(c.Upstreams))
 	for i := range c.Upstreams {
 		names[i] = c.Upstreams[i].Name
+		hostPorts[i] = c.Upstreams[i].Listen.HostPort
 		known[names[i]] = struct{}{}
 	}
 
 	rules = append(rules, validation.Field("upstreams[name]", names, validation.Unique[string]()))
+	rules = append(rules, validation.Field("upstreams[hostPort]", hostPorts, validation.Unique[string]()))
 	rules = append(rules, c.Routing.referentialRules(known)...)
 	return validation.Validate("", rules...)
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -188,6 +188,13 @@ func TestConfig_Validate(t *testing.T) {
 			},
 		},
 		{
+			name: "no upstreams surfaces on the upstreams field",
+			cfg: &config.Config{
+				Listen: config.ListenConfig{HostPort: ":8080"},
+			},
+			wantTuples: [][2]string{{"", "upstreams"}},
+		},
+		{
 			name: "missing upstream hostPort surfaces with indexed upstream subject",
 			cfg: &config.Config{
 				Listen: config.ListenConfig{HostPort: ":8080"},
@@ -353,6 +360,29 @@ func TestConfig_PrimaryUpstream(t *testing.T) {
 		_, err := (&config.Config{}).PrimaryUpstream()
 		require.Error(t, err)
 	})
+}
+
+func TestConfig_ValidateRejectsDuplicateHostPorts(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		Listen: config.ListenConfig{HostPort: "127.0.0.1:8443"},
+		Upstreams: []config.Upstream{
+			{Name: "a", Listen: config.ListenConfig{HostPort: "127.0.0.1:7233"}},
+			{Name: "b", Listen: config.ListenConfig{HostPort: "127.0.0.1:7233"}},
+		},
+	}
+
+	err := cfg.Validate()
+	require.Error(t, err)
+	require.ErrorContains(t, err, "upstreams[hostPort]")
+}
+
+func TestUpstream_IsTemplated(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, (&config.Upstream{Listen: config.ListenConfig{HostPort: "{{ .LocalNamespace }}.acme.cloud:7233"}}).IsTemplated())
+	require.False(t, (&config.Upstream{Listen: config.ListenConfig{HostPort: "127.0.0.1:7233"}}).IsTemplated())
 }
 
 func (e *errReader) Read(_ []byte) (int, error) { return 0, e.err }

--- a/internal/config/upstream.go
+++ b/internal/config/upstream.go
@@ -68,6 +68,12 @@ func (u *Upstream) Validate() error {
 	)
 }
 
+// IsTemplated reports whether the upstream's hostPort contains a text/template
+// action and so must be resolved per request.
+func (u *Upstream) IsTemplated() bool {
+	return isTemplated(u.Listen.HostPort)
+}
+
 // Validate checks the namespace translation rules.
 func (c *NamespaceConfig) Validate() error {
 	return validation.Validate(

--- a/internal/proxy/fx.go
+++ b/internal/proxy/fx.go
@@ -14,40 +14,47 @@ import (
 // Module is the fx module that constructs the proxy [Server] from [ProxyParams]
 // and binds its lifecycle to the application.
 var Module = fx.Options(fx.Invoke(func(p ProxyParams) error {
-	upstream, err := p.Config.PrimaryUpstream()
-	if err != nil {
-		return fmt.Errorf("invalid upstream configuration: %w", err)
+	for i := range p.Config.Upstreams {
+		upstream := &p.Config.Upstreams[i]
+
+		if err := upstream.Validate(); err != nil {
+			return fmt.Errorf("invalid upstream configuration: %w", err)
+		}
+
+		if upstream.IsTemplated() {
+			return fmt.Errorf(
+				"upstream %q has a templated hostPort %q: templated upstreams are not yet supported",
+				upstream.Name,
+				upstream.Listen.HostPort,
+			)
+		}
+
+		opts := []Option{WithCredentials(upstreamCreds(upstream))}
+		if p.Logger != nil {
+			opts = append(opts, WithLogger(p.Logger))
+		}
+
+		svr, err := New(upstream.Listen.HostPort, opts...)
+		if err != nil {
+			return fmt.Errorf("failed to create proxy for upstream %q: %w", upstream.Name, err)
+		}
+
+		p.Lifecycle.Append(fx.Hook{
+			OnStart: func(context.Context) error {
+				go func() {
+					if err := svr.Start(p.Context); err != nil {
+						// The proxy stopped serving unexpectedly. Bring the app
+						// down rather than linger in a non-serving state; Start
+						// has already logged the cause.
+						_ = p.Shutdowner.Shutdown(fx.ExitCode(1))
+					}
+				}()
+
+				return nil
+			},
+			OnStop: svr.Stop,
+		})
 	}
-
-	if err := upstream.Validate(); err != nil {
-		return fmt.Errorf("invalid upstream configuration: %w", err)
-	}
-
-	opts := []Option{WithCredentials(upstreamCreds(upstream))}
-	if p.Logger != nil {
-		opts = append(opts, WithLogger(p.Logger))
-	}
-
-	svr, err := New(upstream.Listen.HostPort, opts...)
-	if err != nil {
-		return fmt.Errorf("failed to create proxy: %w", err)
-	}
-
-	p.Lifecycle.Append(fx.Hook{
-		OnStart: func(context.Context) error {
-			go func() {
-				if err := svr.Start(p.Context); err != nil {
-					// The proxy stopped serving unexpectedly. Bring the app down
-					// rather than linger in a non-serving state; Start has
-					// already logged the cause.
-					_ = p.Shutdowner.Shutdown(fx.ExitCode(1))
-				}
-			}()
-
-			return nil
-		},
-		OnStop: svr.Stop,
-	})
 
 	return nil
 }))

--- a/internal/proxy/fx_test.go
+++ b/internal/proxy/fx_test.go
@@ -66,6 +66,70 @@ func TestModule(t *testing.T) {
 	})
 }
 
+func TestModuleMultipleUpstreams(t *testing.T) {
+	t.Parallel()
+
+	const (
+		a = "127.0.0.1:47234"
+		b = "127.0.0.1:47235"
+	)
+
+	app := newProxyApp(t, &config.Config{
+		Upstreams: []config.Upstream{
+			{Name: "a", Listen: config.ListenConfig{HostPort: a}},
+			{Name: "b", Listen: config.ListenConfig{HostPort: b}},
+		},
+	})
+	require.NoError(t, app.Err())
+
+	startCtx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	require.NoError(t, app.Start(startCtx))
+
+	// Both upstreams get their own proxy, so both sockets must serve.
+	for _, upstream := range []string{a, b} {
+		conn := dialUnix(t, upstream)
+		resp, err := grpc_health_v1.NewHealthClient(conn).Check(
+			startCtx, &grpc_health_v1.HealthCheckRequest{}, grpc.WaitForReady(true),
+		)
+		require.NoError(t, err, "upstream %s should serve after start", upstream)
+		require.Equal(t, grpc_health_v1.HealthCheckResponse_SERVING, resp.GetStatus())
+		_ = conn.Close()
+	}
+
+	stopCtx, stopCancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer stopCancel()
+	require.NoError(t, app.Stop(stopCtx))
+
+	// Every proxy must be stopped too. A fresh dial without WaitForReady fails
+	// fast once the listener is gone; if a hook had captured the wrong server,
+	// one socket would linger and keep serving here.
+	for _, upstream := range []string{a, b} {
+		conn := dialUnix(t, upstream)
+		checkCtx, checkCancel := context.WithTimeout(t.Context(), 2*time.Second)
+		_, err := grpc_health_v1.NewHealthClient(conn).Check(
+			checkCtx, &grpc_health_v1.HealthCheckRequest{},
+		)
+
+		checkCancel()
+		require.Error(t, err, "upstream %s should not serve after stop", upstream)
+		require.NoError(t, conn.Close())
+	}
+}
+
+func TestModuleRejectsTemplatedUpstream(t *testing.T) {
+	t.Parallel()
+
+	app := newProxyApp(t, &config.Config{
+		Upstreams: []config.Upstream{
+			{Name: "tmpl", Listen: config.ListenConfig{HostPort: "{{ .LocalNamespace }}.acme.cloud:7233"}},
+		},
+	})
+
+	require.Error(t, app.Err())
+	require.ErrorContains(t, app.Err(), "templated")
+}
+
 func newProxyApp(t *testing.T, cfg *config.Config, opts ...fx.Option) *fx.App {
 	t.Helper()
 


### PR DESCRIPTION
The proxy previously assumed a single upstream, so multi-upstream configs had no way to route worker traffic to multiple destinations.

This builds one inner proxy per named upstream in internal/proxy so each upstream gets its own listener/dial path. To make that safe, the config layer now requires upstream hostPorts to be distinct (two upstreams sharing a hostPort is a configuration error).
