### PR TITLE
[router]: Add Prometheus metrics for routing decisions and errors

### DIFF
--- a/cmd/proxy/serve.go
+++ b/cmd/proxy/serve.go
@@ -44,6 +44,12 @@ func serve() *cli.Command {
 				Value:   ":9090",
 				Sources: cli.EnvVars("METRICS_ADDR"),
 			},
+			&cli.StringFlag{
+				Name:    "metrics-namespace",
+				Usage:   "The prometheus namespace for metrics",
+				Value:   "tmprl_proxy",
+				Sources: cli.EnvVars("METRICS_NAMESPACE"),
+			},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			log := logger.NewZeroLogger(os.Stderr, logger.ParseLevel(cmd.String("level")))
@@ -53,6 +59,7 @@ func serve() *cli.Command {
 					fx.Annotate(ctx, fx.As(new(context.Context))),
 					fx.Annotate(cmd.String("config"), config.ConfigFileTag),
 					fx.Annotate(cmd.String("metrics-addr"), metrics.AddrTag),
+					fx.Annotate(cmd.String("metrics-namespace"), metrics.NamespaceTag),
 				),
 				fx.Provide(
 					func() logger.Logger { return log },

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/internal/metrics/doc.go
+++ b/internal/metrics/doc.go
@@ -1,5 +1,6 @@
 // Package metrics wires Prometheus metrics into the proxy. Its fx [Module]
-// provides a promauto.Factory bound to the injected Prometheus registry and
+// provides a namespaced [Factory] bound to the injected Prometheus registry and
 // serves that registry at /metrics over HTTP, binding the server to the fx
-// application lifecycle.
+// application lifecycle. Consumers inject the [Factory], optionally scoping it
+// to a subsystem with [Factory.ForSubsystem], to declare their collectors.
 package metrics

--- a/internal/metrics/factory.go
+++ b/internal/metrics/factory.go
@@ -1,0 +1,49 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// Factory binds a Prometheus namespace (and optionally a subsystem) to a
+// promauto.Factory so callers create collectors that are automatically
+// namespaced and registered, without each call site repeating the prefix. It is
+// the dependency other packages inject to declare their own metrics.
+type Factory struct {
+	namespace string // Prometheus namespace prefixed onto every collector.
+	subsystem string // Optional subsystem, prefixed after the namespace.
+	factory   promauto.Factory
+}
+
+// New returns a Factory that prefixes ns onto every collector it creates, using
+// factory to build and register them with the underlying registry.
+func New(ns string, factory promauto.Factory) *Factory {
+	return &Factory{
+		namespace: ns,
+		factory:   factory,
+	}
+}
+
+// ForSubsystem returns a copy of the Factory scoped to subsys, so collectors it
+// creates are named namespace_subsys_<name>. The receiver is left unchanged, so
+// one namespace-level Factory can spawn independent per-subsystem factories.
+func (f *Factory) ForSubsystem(subsys string) *Factory {
+	return &Factory{
+		namespace: f.namespace,
+		subsystem: subsys,
+		factory:   f.factory,
+	}
+}
+
+// NewCounter creates and registers a CounterVec. It forces the bound namespace
+// (and subsystem, when set) onto opts, overriding any the caller set, so every
+// counter shares the same prefix. labelNames are the counter's variable label
+// dimensions.
+func (f *Factory) NewCounter(opts prometheus.CounterOpts, labelNames []string) *prometheus.CounterVec {
+	opts.Namespace = f.namespace
+	if f.subsystem != "" {
+		opts.Subsystem = f.subsystem
+	}
+
+	return f.factory.NewCounterVec(opts, labelNames)
+}

--- a/internal/metrics/factory_test.go
+++ b/internal/metrics/factory_test.go
@@ -1,0 +1,128 @@
+package metrics_test
+
+import (
+	"strings"
+	"testing"
+
+	goprom "github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+
+	"github.com/temporalio/temporal-proxy/internal/metrics"
+	"github.com/temporalio/temporal-proxy/pkg/logger"
+)
+
+func TestFactoryNewCounter(t *testing.T) {
+	t.Parallel()
+
+	t.Run("prefixes the bound namespace and registers", func(t *testing.T) {
+		t.Parallel()
+
+		reg := goprom.NewRegistry()
+		m := metrics.New("myns", promauto.With(reg))
+
+		m.NewCounter(goprom.CounterOpts{
+			Subsystem: "sub",
+			Name:      "things_total",
+			Help:      "Things counted.",
+		}, []string{"kind"}).WithLabelValues("a").Inc()
+
+		require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+# HELP myns_sub_things_total Things counted.
+# TYPE myns_sub_things_total counter
+myns_sub_things_total{kind="a"} 1
+`), "myns_sub_things_total"))
+	})
+
+	t.Run("overrides a caller-set namespace", func(t *testing.T) {
+		t.Parallel()
+
+		reg := goprom.NewRegistry()
+		m := metrics.New("bound", promauto.With(reg))
+
+		// The caller's Namespace must be ignored in favor of the bound one, so the
+		// series is bound_count_total and never ignored_count_total.
+		m.NewCounter(goprom.CounterOpts{
+			Namespace: "ignored",
+			Name:      "count_total",
+			Help:      "Counted.",
+		}, nil).WithLabelValues().Inc()
+
+		require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+# HELP bound_count_total Counted.
+# TYPE bound_count_total counter
+bound_count_total 1
+`), "bound_count_total"))
+
+		n, err := testutil.GatherAndCount(reg, "ignored_count_total")
+		require.NoError(t, err)
+		require.Zero(t, n, "caller-set namespace must not leak into the metric name")
+	})
+
+	t.Run("ForSubsystem scopes the subsystem without mutating the parent", func(t *testing.T) {
+		t.Parallel()
+
+		reg := goprom.NewRegistry()
+		parent := metrics.New("app", promauto.With(reg))
+		sub := parent.ForSubsystem("router")
+
+		// The derived factory forces its subsystem, overriding any the caller sets.
+		sub.NewCounter(goprom.CounterOpts{
+			Subsystem: "ignored",
+			Name:      "hits_total",
+			Help:      "Hits.",
+		}, nil).WithLabelValues().Inc()
+
+		// The parent keeps no subsystem, proving ForSubsystem did not mutate it.
+		parent.NewCounter(goprom.CounterOpts{
+			Name: "starts_total",
+			Help: "Starts.",
+		}, nil).WithLabelValues().Inc()
+
+		require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+# HELP app_router_hits_total Hits.
+# TYPE app_router_hits_total counter
+app_router_hits_total 1
+`), "app_router_hits_total"))
+
+		require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+# HELP app_starts_total Starts.
+# TYPE app_starts_total counter
+app_starts_total 1
+`), "app_starts_total"))
+	})
+}
+
+func TestModuleProvidesNamespacedMetrics(t *testing.T) {
+	t.Parallel()
+
+	reg := goprom.NewRegistry()
+
+	var m *metrics.Factory
+	app := fx.New(
+		fx.Supply(
+			fx.Annotate(freeAddr(t), metrics.AddrTag),
+			fx.Annotate("wired", metrics.NamespaceTag),
+			fx.Annotate(reg, fx.As(new(goprom.Registerer))),
+			fx.Annotate(reg, fx.As(new(goprom.Gatherer))),
+			fx.Annotate(logger.NewNoopLogger(), fx.As(new(logger.Logger))),
+		),
+		metrics.Module,
+		fx.Populate(&m),
+		fx.NopLogger,
+	)
+	require.NoError(t, app.Err())
+	require.NotNil(t, m)
+
+	// The provider must feed the "metricsNamespace" value into New, so a counter
+	// built from the injected Metrics carries the "wired" prefix.
+	m.NewCounter(goprom.CounterOpts{Name: "wired_total", Help: "Wired."}, nil).WithLabelValues().Inc()
+
+	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+# HELP wired_wired_total Wired.
+# TYPE wired_wired_total counter
+wired_wired_total 1
+`), "wired_wired_total"))
+}

--- a/internal/metrics/fx.go
+++ b/internal/metrics/fx.go
@@ -15,22 +15,31 @@ import (
 	"github.com/temporalio/temporal-proxy/pkg/logger/tag"
 )
 
-// AddrTag annotates the host:port the metrics HTTP server listens on,
-// supplied to fx as the named value "metricsAddr".
-var AddrTag = fx.ResultTags(`name:"metricsAddr"`)
+var (
+	// AddrTag annotates the host:port the metrics HTTP server listens on,
+	// supplied to fx as the named value "metricsAddr".
+	AddrTag = fx.ResultTags(`name:"metricsAddr"`)
 
-// Module provides a promauto.Factory bound to the injected Prometheus
+	// NamespaceTag annotates the Prometheus namespace prefixed onto every
+	// collector, supplied to fx as the named value "metricsNamespace".
+	NamespaceTag = fx.ResultTags(`name:"metricsNamespace"`)
+)
+
+// Module provides a namespaced [Factory] bound to the injected Prometheus
 // registry and serves the registry at /metrics on the address named
-// "metricsAddr". Consumers inject the factory to declare their collectors,
-// which auto-register, and should pre-resolve labeled handles once at setup
-// rather than per request to keep the emit path lock-free and allocation-free.
+// "metricsAddr". Consumers inject the [Factory] to declare their collectors,
+// which auto-register under the configured namespace, and should pre-resolve
+// labeled handles once at setup rather than per request to keep the emit path
+// lock-free and allocation-free.
 //
 // The HTTP server is bound to the fx lifecycle: it starts in a background
 // goroutine on OnStart and shuts down gracefully on OnStop. If the server
 // stops for any reason other than a clean shutdown, the whole app is brought
 // down with a non-zero exit code.
 var Module = fx.Options(
-	fx.Provide(promauto.With),
+	fx.Provide(func(p MetricsParams) *Factory {
+		return New(p.Namespace, promauto.With(p.Registerer))
+	}),
 	fx.Invoke(func(p MetricsParams) error {
 		if p.Addr == "" {
 			return errors.New("metrics addr not set")
@@ -82,17 +91,19 @@ var Module = fx.Options(
 )
 
 // MetricsParams holds the fx-injected dependencies needed to run the metrics
-// HTTP server. Addr is the named "metricsAddr" listen address. Registerer is
-// where collectors register and Gatherer is what the /metrics handler scrapes;
-// supplying both lets callers (and tests) choose between the package-global
-// registry and an isolated one.
+// HTTP server and build the namespaced [Factory]. Addr is the named
+// "metricsAddr" listen address and Namespace is the named "metricsNamespace"
+// Prometheus prefix. Registerer is where collectors register and Gatherer is
+// what the /metrics handler scrapes; supplying both lets callers (and tests)
+// choose between the package-global registry and an isolated one.
 type MetricsParams struct {
 	fx.In
 	Lifecycle  fx.Lifecycle
 	Shutdowner fx.Shutdowner
 
-	Addr   string `name:"metricsAddr"`
-	Logger logger.Logger
+	Addr      string `name:"metricsAddr"`
+	Namespace string `name:"metricsNamespace"`
+	Logger    logger.Logger
 
 	Gatherer   prometheus.Gatherer
 	Registerer prometheus.Registerer

--- a/internal/metrics/fx_test.go
+++ b/internal/metrics/fx_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	goprom "github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
 
@@ -25,7 +24,7 @@ func TestModule(t *testing.T) {
 
 		addr := freeAddr(t)
 
-		var factory promauto.Factory
+		var factory *metrics.Factory
 		app := newTestApp(t, addr, fx.Populate(&factory))
 		require.NoError(t, app.Err())
 
@@ -33,12 +32,13 @@ func TestModule(t *testing.T) {
 		t.Cleanup(cancel)
 		require.NoError(t, app.Start(ctx))
 
-		// Emit a gauge so the scrape has something proxy-specific to assert on.
-		factory.NewGauge(goprom.GaugeOpts{
-			Namespace: "temporal_proxy",
-			Name:      "answer",
-			Help:      "smoke-test gauge",
-		}).Set(42)
+		// Emit a counter via the provided Factory so the scrape has something
+		// proxy-specific to assert on. newTestApp supplies the "tmprl_proxy"
+		// namespace, so the series is tmprl_proxy_answer_total.
+		factory.NewCounter(goprom.CounterOpts{
+			Name: "answer_total",
+			Help: "smoke-test counter",
+		}, nil).WithLabelValues().Inc()
 
 		url := "http://" + addr + "/metrics"
 
@@ -53,7 +53,7 @@ func TestModule(t *testing.T) {
 			return ok
 		}, 5*time.Second, 20*time.Millisecond)
 
-		require.Contains(t, body, "temporal_proxy_answer")
+		require.Contains(t, body, "tmprl_proxy_answer_total")
 
 		ctx, cancel = context.WithTimeout(t.Context(), 5*time.Second)
 		t.Cleanup(cancel)
@@ -115,6 +115,7 @@ func newTestApp(t *testing.T, addr string, opts ...fx.Option) *fx.App {
 	base := []fx.Option{
 		fx.Supply(
 			fx.Annotate(addr, metrics.AddrTag),
+			fx.Annotate("tmprl_proxy", metrics.NamespaceTag),
 			fx.Annotate(reg, fx.As(new(goprom.Registerer))),
 			fx.Annotate(reg, fx.As(new(goprom.Gatherer))),
 			fx.Annotate(logger.NewNoopLogger(), fx.As(new(logger.Logger))),

--- a/internal/router/director_test.go
+++ b/internal/router/director_test.go
@@ -1,0 +1,114 @@
+package router
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/temporalio/temporal-proxy/internal/metrics"
+)
+
+func TestDirectorResolve(t *testing.T) {
+	t.Parallel()
+
+	t.Run("default decision with a connection", func(t *testing.T) {
+		t.Parallel()
+
+		reg := prometheus.NewRegistry()
+		d := &director{
+			conns:    map[string]*grpc.ClientConn{"primary": {}},
+			mux:      New("primary", "", Rule{upstream: "primary", ns: matchPrefix("prod-")}),
+			reporter: testReporter(reg),
+		}
+
+		target, err := d.Resolve(t.Context(), "/svc/M", "other", nil)
+		require.NoError(t, err)
+		require.Equal(t, "primary", target.Upstream)
+		require.NotNil(t, target.Conn)
+
+		requireDecisions(t, reg, `
+# HELP tmprl_proxy_router_decisions_total Total routing decisions, labeled by chosen upstream and outcome.
+# TYPE tmprl_proxy_router_decisions_total counter
+tmprl_proxy_router_decisions_total{outcome="default",upstream="primary"} 1
+tmprl_proxy_router_decisions_total{outcome="match",upstream="primary"} 0
+tmprl_proxy_router_decisions_total{outcome="system",upstream="primary"} 0
+tmprl_proxy_router_decisions_total{outcome="unroutable",upstream="unknown"} 0
+`)
+	})
+
+	t.Run("no connection for chosen upstream", func(t *testing.T) {
+		t.Parallel()
+
+		reg := prometheus.NewRegistry()
+		d := &director{
+			conns:    map[string]*grpc.ClientConn{},
+			mux:      New("primary", ""),
+			reporter: testReporter(reg),
+		}
+
+		_, err := d.Resolve(t.Context(), "/svc/M", "other", nil)
+		require.Equal(t, codes.Unavailable, status.Code(err))
+
+		requireDecisions(t, reg, `
+# HELP tmprl_proxy_router_decisions_total Total routing decisions, labeled by chosen upstream and outcome.
+# TYPE tmprl_proxy_router_decisions_total counter
+tmprl_proxy_router_decisions_total{outcome="default",upstream="primary"} 1
+tmprl_proxy_router_decisions_total{outcome="match",upstream="primary"} 0
+tmprl_proxy_router_decisions_total{outcome="system",upstream="primary"} 0
+tmprl_proxy_router_decisions_total{outcome="unroutable",upstream="unknown"} 0
+`)
+		requireErrors(t, reg, `
+# HELP tmprl_proxy_router_forwarding_errors_total Total router-originated forwarding failures, labeled by upstream and reason.
+# TYPE tmprl_proxy_router_forwarding_errors_total counter
+tmprl_proxy_router_forwarding_errors_total{reason="no_connection",upstream="primary"} 1
+tmprl_proxy_router_forwarding_errors_total{reason="stream_setup",upstream="primary"} 0
+`)
+	})
+
+	t.Run("unroutable request", func(t *testing.T) {
+		t.Parallel()
+
+		reg := prometheus.NewRegistry()
+		d := &director{
+			conns:    map[string]*grpc.ClientConn{},
+			mux:      New("", ""),
+			reporter: testReporter(reg),
+		}
+
+		_, err := d.Resolve(t.Context(), "/svc/M", "other", nil)
+		require.Equal(t, codes.FailedPrecondition, status.Code(err))
+
+		requireDecisions(t, reg, `
+# HELP tmprl_proxy_router_decisions_total Total routing decisions, labeled by chosen upstream and outcome.
+# TYPE tmprl_proxy_router_decisions_total counter
+tmprl_proxy_router_decisions_total{outcome="default",upstream="primary"} 0
+tmprl_proxy_router_decisions_total{outcome="match",upstream="primary"} 0
+tmprl_proxy_router_decisions_total{outcome="system",upstream="primary"} 0
+tmprl_proxy_router_decisions_total{outcome="unroutable",upstream="unknown"} 1
+`)
+	})
+}
+
+// testReporter builds a Reporter over reg with the production namespace and
+// subsystem, so emitted series match the tmprl_proxy_router_* names asserted
+// below.
+func testReporter(reg *prometheus.Registry) *Reporter {
+	return NewReporter(metrics.New("tmprl_proxy", promauto.With(reg)).ForSubsystem("router"), []string{"primary"})
+}
+
+func requireDecisions(t *testing.T, g prometheus.Gatherer, want string) {
+	t.Helper()
+	require.NoError(t, testutil.GatherAndCompare(g, strings.NewReader(want), "tmprl_proxy_router_decisions_total"))
+}
+
+func requireErrors(t *testing.T, g prometheus.Gatherer, want string) {
+	t.Helper()
+	require.NoError(t, testutil.GatherAndCompare(g, strings.NewReader(want), "tmprl_proxy_router_forwarding_errors_total"))
+}

--- a/internal/router/fx.go
+++ b/internal/router/fx.go
@@ -12,6 +12,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/temporalio/temporal-proxy/internal/config"
+	"github.com/temporalio/temporal-proxy/internal/metrics"
 	"github.com/temporalio/temporal-proxy/internal/protoutil"
 	"github.com/temporalio/temporal-proxy/internal/transport/connect"
 	"github.com/temporalio/temporal-proxy/internal/transport/socket"
@@ -49,11 +50,21 @@ var Module = fx.Options(fx.Provide(
 
 		return Handler(
 			&director{
-				conns: conns,
-				mux:   p.Mux,
+				conns:    conns,
+				mux:      p.Mux,
+				reporter: p.Reporter,
 			},
 			p.Extractor,
+			p.Reporter,
 		), nil
+	},
+	func(c *config.Config, f *metrics.Factory) *Reporter {
+		names := make([]string, 0, len(c.Upstreams))
+		for i := range c.Upstreams {
+			names = append(names, c.Upstreams[i].Name)
+		}
+
+		return NewReporter(f.ForSubsystem("router"), names)
 	},
 	func(c *config.Config) (*Mux, error) {
 		rules := make([]Rule, 0, len(c.Routing.Rules))
@@ -113,34 +124,42 @@ type (
 		Extractor *protoutil.Extractor
 		Mux       *Mux
 		Pool      *connect.Pool
+		Reporter  *Reporter
 	}
 
 	// director is the [Director] used by the module's handler. It maps the
 	// upstream name chosen by the Mux to that upstream's pooled connection.
 	director struct {
-		conns map[string]*grpc.ClientConn
-		mux   *Mux
+		conns    map[string]*grpc.ClientConn
+		mux      *Mux
+		reporter *Reporter
 	}
 )
 
 // Resolve routes a request by matching it against the Mux and returning the
-// connection for the resulting upstream. It fails with FailedPrecondition when
+// Target for the resulting upstream. It fails with FailedPrecondition when
 // no upstream matches (and no default is configured) and with Unavailable when
-// the matched upstream has no connection.
+// the matched upstream has no connection. It records a decision metric on
+// every call, plus a no_connection forwarding-error metric when the chosen
+// upstream has no connection.
 func (d *director) Resolve(
 	ctx context.Context,
 	_, namespace string,
 	md map[string][]string,
-) (*grpc.ClientConn, error) {
-	upstream := d.mux.Switch(namespace, md)
-	if upstream == "" {
-		return nil, status.Error(codes.FailedPrecondition, "no upstream matched the request and no default is configured")
+) (Target, error) {
+	upstream, outcome := d.mux.Switch(namespace, md)
+	if outcome == OutcomeUnroutable {
+		d.reporter.Decision(upstreamUnknown, OutcomeUnroutable)
+		return Target{}, status.Error(codes.FailedPrecondition, "no upstream matched the request and no default is configured")
 	}
+
+	d.reporter.Decision(upstream, outcome)
 
 	cc, ok := d.conns[upstream]
 	if !ok {
-		return nil, status.Errorf(codes.Unavailable, "router: no connection for upstream %q", upstream)
+		d.reporter.ForwardingError(upstream, reasonNoConnection)
+		return Target{}, status.Errorf(codes.Unavailable, "router: no connection for upstream %q", upstream)
 	}
 
-	return cc, nil
+	return Target{Upstream: upstream, Conn: cc}, nil
 }

--- a/internal/router/fx_test.go
+++ b/internal/router/fx_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
 	"google.golang.org/grpc"
@@ -15,6 +17,7 @@ import (
 	"google.golang.org/grpc/test/bufconn"
 
 	"github.com/temporalio/temporal-proxy/internal/config"
+	"github.com/temporalio/temporal-proxy/internal/metrics"
 	"github.com/temporalio/temporal-proxy/internal/protoutil"
 	"github.com/temporalio/temporal-proxy/internal/router"
 	"github.com/temporalio/temporal-proxy/internal/transport/connect"
@@ -36,6 +39,7 @@ func TestModule(t *testing.T) {
 			fx.Supply(&config.Config{
 				Upstreams: []config.Upstream{{Name: "primary", Listen: config.ListenConfig{HostPort: "127.0.0.1:7233"}}},
 			}),
+			fx.Provide(func() *metrics.Factory { return metrics.New("tmprl_proxy", promauto.With(prometheus.NewRegistry())) }),
 			connect.Module,
 			protoutil.Module,
 			router.Module,
@@ -103,6 +107,7 @@ func TestModule(t *testing.T) {
 				Routing:   config.Routing{DefaultUpstream: "primary"},
 				Upstreams: []config.Upstream{{Name: "primary", Listen: config.ListenConfig{HostPort: upstream}}},
 			}),
+			fx.Provide(func() *metrics.Factory { return metrics.New("tmprl_proxy", promauto.With(prometheus.NewRegistry())) }),
 			connect.Module,
 			protoutil.Module,
 			router.Module,
@@ -168,10 +173,14 @@ func TestModuleMux(t *testing.T) {
 		require.NoError(t, app.Err())
 		require.NotNil(t, mux)
 
-		require.Equal(t, "prod", mux.Switch("prod-1", nil), "namespace rule")
-		require.Equal(t, "gold", mux.Switch("any", map[string][]string{"x-tier": {"gold"}}), "metadata rule with lowercased key")
-		require.Equal(t, "default", mux.Switch("other", nil), "no match falls to default")
-		require.Equal(t, "system", mux.Switch("", nil), "no namespace falls to system")
+		got, _ := mux.Switch("prod-1", nil)
+		require.Equal(t, "prod", got, "namespace rule")
+		got, _ = mux.Switch("any", map[string][]string{"x-tier": {"gold"}})
+		require.Equal(t, "gold", got, "metadata rule with lowercased key")
+		got, _ = mux.Switch("other", nil)
+		require.Equal(t, "default", got, "no match falls to default")
+		got, _ = mux.Switch("", nil)
+		require.Equal(t, "system", got, "no namespace falls to system")
 	})
 
 	t.Run("rejects an invalid rule", func(t *testing.T) {

--- a/internal/router/handler.go
+++ b/internal/router/handler.go
@@ -12,14 +12,22 @@ import (
 )
 
 type (
-	// Director selects the upstream connection for a request. Resolve receives
-	// the full method, the namespace peeked from the first request message
-	// (empty when the client sent no message), and the incoming metadata, and
-	// returns the connection to forward the stream over. A non-nil error aborts
-	// the stream and is returned to the caller verbatim, so implementations
-	// should return a gRPC status error.
+	// Target is the routing result returned by Director.Resolve on success: the
+	// chosen upstream's name (always non-empty) and the connection to forward the
+	// stream over. On a non-nil error the Target is unused and callers must ignore
+	// its fields.
+	Target struct {
+		Upstream string
+		Conn     *grpc.ClientConn
+	}
+
+	// Director selects the upstream for a request. Resolve receives the full
+	// method, the namespace peeked from the first request message (empty when the
+	// client sent no message), and the incoming metadata, and returns the Target to
+	// forward over. A non-nil error aborts the stream and is returned to the caller
+	// verbatim, so implementations should return a gRPC status error.
 	Director interface {
-		Resolve(ctx context.Context, method, namespace string, md map[string][]string) (*grpc.ClientConn, error)
+		Resolve(ctx context.Context, method, namespace string, md map[string][]string) (Target, error)
 	}
 
 	// Reflector extracts the Temporal namespace from a request. Namespace
@@ -30,13 +38,14 @@ type (
 	}
 )
 
-// Handler returns a grpc.StreamHandler suitable for grpc.UnknownServiceHandler.
-// It buffers the first request frame so r can peek the request namespace, asks d
-// for the upstream connection, then transparently forwards the stream to that
-// upstream using the same full method name: it replays the buffered first frame,
-// pumps raw frames in both directions, and propagates header, trailer, and
-// status verbatim.
-func Handler(d Director, r Reflector) grpc.StreamHandler {
+// Handler returns a grpc.StreamHandler suitable for grpc.UnknownServiceHandler,
+// reporting a stream_setup forwarding error via rep when opening the upstream
+// stream fails. It buffers the first request frame so r can peek the request
+// namespace, asks d for the upstream connection, then transparently forwards
+// the stream to that upstream using the same full method name: it replays the
+// buffered first frame, pumps raw frames in both directions, and propagates
+// header, trailer, and status verbatim.
+func Handler(d Director, r Reflector, rep *Reporter) grpc.StreamHandler {
 	return func(_ any, serverStream grpc.ServerStream) error {
 		ctx := serverStream.Context()
 		sts := grpc.ServerTransportStreamFromContext(ctx)
@@ -67,18 +76,22 @@ func Handler(d Director, r Reflector) grpc.StreamHandler {
 			namespace = r.Namespace(method, first.payload)
 		}
 
-		cc, err := d.Resolve(ctx, method, namespace, maps.Clone(md))
+		target, err := d.Resolve(ctx, method, namespace, maps.Clone(md))
 		if err != nil {
 			return err
 		}
 
-		stream, err := cc.NewStream(
+		stream, err := target.Conn.NewStream(
 			outCtx,
 			&grpc.StreamDesc{ServerStreams: true, ClientStreams: true},
 			method,
 			grpc.ForceCodecV2(Codec()),
 		)
 		if err != nil {
+			if rep != nil {
+				rep.ForwardingError(target.Upstream, reasonStreamSetup)
+			}
+
 			return err
 		}
 

--- a/internal/router/handler_test.go
+++ b/internal/router/handler_test.go
@@ -6,9 +6,13 @@ import (
 	"errors"
 	"io"
 	"net"
+	"strings"
 	"sync"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -20,6 +24,7 @@ import (
 	"google.golang.org/grpc/test/bufconn"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/temporalio/temporal-proxy/internal/metrics"
 	"github.com/temporalio/temporal-proxy/internal/router"
 	"github.com/temporalio/temporal-proxy/internal/server"
 )
@@ -49,7 +54,10 @@ type (
 		payload []byte
 	}
 
-	stubDirector struct{ cc *grpc.ClientConn }
+	stubDirector struct {
+		upstream string
+		cc       *grpc.ClientConn
+	}
 
 	stubReflector struct{}
 )
@@ -121,6 +129,7 @@ func TestHandlerRoutesUsingReflectorAndDirector(t *testing.T) {
 
 	reflector := &recordingReflector{ns: "ns-from-reflector"}
 	var director *recordingDirector
+	m, _ := newTestReporter(t)
 	relay := newRelayWith(
 		t,
 		func(s *grpc.Server) { s.RegisterService(&echoDesc, nil) },
@@ -129,6 +138,7 @@ func TestHandlerRoutesUsingReflectorAndDirector(t *testing.T) {
 			return director
 		},
 		reflector,
+		m,
 	)
 
 	ctx := metadata.AppendToOutgoingContext(t.Context(), "x-route", "gold")
@@ -187,6 +197,7 @@ func TestHandlerForwardsEmptyMessageHalfClose(t *testing.T) {
 
 	reflector := &recordingReflector{ns: "unused"}
 	var director *recordingDirector
+	m, _ := newTestReporter(t)
 	relay := newRelayWith(
 		t,
 		func(s *grpc.Server) { s.RegisterService(&countDesc, nil) },
@@ -195,6 +206,7 @@ func TestHandlerForwardsEmptyMessageHalfClose(t *testing.T) {
 			return director
 		},
 		reflector,
+		m,
 	)
 
 	stream, err := relay.NewStream(
@@ -327,8 +339,9 @@ func TestHandlerCoHostsLocalHealthWithForwarding(t *testing.T) {
 	upstreamConn := dialBufconn(t, upstreamLis)
 	t.Cleanup(func() { _ = upstreamConn.Close() })
 
+	m, _ := newTestReporter(t)
 	svr, err := server.New(
-		server.WithUnknownServiceHandler(router.Handler(stubDirector{upstreamConn}, stubReflector{})),
+		server.WithUnknownServiceHandler(router.Handler(stubDirector{cc: upstreamConn}, stubReflector{}, m)),
 		server.WithServerCodec(router.Codec()),
 	)
 	require.NoError(t, err)
@@ -350,6 +363,89 @@ func TestHandlerCoHostsLocalHealthWithForwarding(t *testing.T) {
 
 	require.NoError(t, svr.Stop(t.Context()))
 	<-errCh
+}
+
+func TestHandlerRecordsStreamSetupError(t *testing.T) {
+	t.Parallel()
+
+	echoDesc := grpc.ServiceDesc{
+		ServiceName: "test.v1.Echo",
+		HandlerType: (*any)(nil),
+		Methods: []grpc.MethodDesc{
+			{
+				MethodName: "Ping",
+				Handler: func(_ any, _ context.Context, dec func(any) error, _ grpc.UnaryServerInterceptor) (any, error) {
+					return &grpc_health_v1.HealthCheckResponse{}, dec(new(grpc_health_v1.HealthCheckRequest))
+				},
+			},
+		},
+	}
+
+	upstreamLis := bufconn.Listen(1024 * 1024)
+	upstream := grpc.NewServer()
+	upstream.RegisterService(&echoDesc, nil)
+	serve(t, upstream, upstreamLis)
+
+	// A closed connection makes NewStream fail synchronously, exercising the
+	// stream_setup path.
+	brokenConn := dialBufconn(t, upstreamLis)
+	require.NoError(t, brokenConn.Close())
+
+	m, reg := newTestReporter(t, "primary")
+	relayLis := bufconn.Listen(1024 * 1024)
+	relay := grpc.NewServer(
+		grpc.ForceServerCodecV2(router.Codec()),
+		grpc.UnknownServiceHandler(router.Handler(stubDirector{upstream: "primary", cc: brokenConn}, stubReflector{}, m)),
+	)
+	serve(t, relay, relayLis)
+
+	relayConn := dialBufconn(t, relayLis)
+	t.Cleanup(func() { _ = relayConn.Close() })
+
+	err := relayConn.Invoke(t.Context(), "/test.v1.Echo/Ping", &grpc_health_v1.HealthCheckRequest{}, new(grpc_health_v1.HealthCheckResponse))
+	require.Error(t, err)
+
+	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+# HELP tmprl_proxy_router_forwarding_errors_total Total router-originated forwarding failures, labeled by upstream and reason.
+# TYPE tmprl_proxy_router_forwarding_errors_total counter
+tmprl_proxy_router_forwarding_errors_total{reason="no_connection",upstream="primary"} 0
+tmprl_proxy_router_forwarding_errors_total{reason="stream_setup",upstream="primary"} 1
+`), "tmprl_proxy_router_forwarding_errors_total"))
+}
+
+func TestHandlerRelayedUpstreamErrorIsNotAForwardingError(t *testing.T) {
+	t.Parallel()
+
+	m, reg := newTestReporter(t, "primary")
+	relayLis := bufconn.Listen(1024 * 1024)
+
+	upstreamLis := bufconn.Listen(1024 * 1024)
+	upstream := grpc.NewServer()
+	grpc_health_v1.RegisterHealthServer(upstream, health.NewServer())
+	serve(t, upstream, upstreamLis)
+	upstreamConn := dialBufconn(t, upstreamLis)
+	t.Cleanup(func() { _ = upstreamConn.Close() })
+
+	relay := grpc.NewServer(
+		grpc.ForceServerCodecV2(router.Codec()),
+		grpc.UnknownServiceHandler(router.Handler(stubDirector{upstream: "primary", cc: upstreamConn}, stubReflector{}, m)),
+	)
+	serve(t, relay, relayLis)
+
+	relayConn := dialBufconn(t, relayLis)
+	t.Cleanup(func() { _ = relayConn.Close() })
+
+	// The upstream returns NotFound for an unknown service; the proxy relays it.
+	_, err := grpc_health_v1.NewHealthClient(relayConn).Check(t.Context(), &grpc_health_v1.HealthCheckRequest{Service: "nope"})
+	require.Equal(t, codes.NotFound, status.Code(err))
+
+	// A relayed non-OK status must NOT be counted as a forwarding error.
+	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+# HELP tmprl_proxy_router_forwarding_errors_total Total router-originated forwarding failures, labeled by upstream and reason.
+# TYPE tmprl_proxy_router_forwarding_errors_total counter
+tmprl_proxy_router_forwarding_errors_total{reason="no_connection",upstream="primary"} 0
+tmprl_proxy_router_forwarding_errors_total{reason="stream_setup",upstream="primary"} 0
+`), "tmprl_proxy_router_forwarding_errors_total"))
 }
 
 func TestStatusError(t *testing.T) {
@@ -381,8 +477,8 @@ func TestStatusError(t *testing.T) {
 	})
 }
 
-func (s stubDirector) Resolve(context.Context, string, string, map[string][]string) (*grpc.ClientConn, error) {
-	return s.cc, nil
+func (s stubDirector) Resolve(context.Context, string, string, map[string][]string) (router.Target, error) {
+	return router.Target{Upstream: s.upstream, Conn: s.cc}, nil
 }
 
 func (stubReflector) Namespace(string, []byte) string { return "" }
@@ -402,14 +498,14 @@ func (r *recordingReflector) snapshot() (calls int, method string, payload []byt
 	return r.calls, r.method, bytes.Clone(r.payload)
 }
 
-func (d *recordingDirector) Resolve(_ context.Context, method, namespace string, md map[string][]string) (*grpc.ClientConn, error) {
+func (d *recordingDirector) Resolve(_ context.Context, method, namespace string, md map[string][]string) (router.Target, error) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	d.calls++
 	d.method = method
 	d.namespace = namespace
 	d.md = md
-	return d.cc, nil
+	return router.Target{Upstream: "test-upstream", Conn: d.cc}, nil
 }
 
 func (d *recordingDirector) snapshot() (calls int, method, namespace string, md map[string][]string) {
@@ -438,27 +534,41 @@ func serve(t *testing.T, srv *grpc.Server, lis *bufconn.Listener) {
 	t.Cleanup(srv.Stop)
 }
 
+// newTestReporter builds a Reporter backed by a fresh registry, using the
+// production namespace and subsystem so emitted series match the
+// tmprl_proxy_router_* names, for tests that need to observe (or discard) what
+// the handler records.
+func newTestReporter(t *testing.T, upstreams ...string) (*router.Reporter, *prometheus.Registry) {
+	t.Helper()
+	reg := prometheus.NewRegistry()
+	factory := metrics.New("tmprl_proxy", promauto.With(reg)).ForSubsystem("router")
+	return router.NewReporter(factory, upstreams), reg
+}
+
 // newRelayToUpstream stands up a fake upstream (configured by registerUpstream),
 // then a bare relay server that forwards all methods to it via router.Handler
 // using pass-through routing. Returns a client conn pointed at the relay.
 func newRelayToUpstream(t *testing.T, registerUpstream func(*grpc.Server)) *grpc.ClientConn {
 	t.Helper()
 
+	m, _ := newTestReporter(t)
 	return newRelayWith(
 		t, registerUpstream,
-		func(cc *grpc.ClientConn) router.Director { return stubDirector{cc} },
+		func(cc *grpc.ClientConn) router.Director { return stubDirector{cc: cc} },
 		stubReflector{},
+		m,
 	)
 }
 
-// newRelayWith is like newRelayToUpstream but lets the caller supply the Director
-// and Reflector, so tests can observe how the handler routes. makeDirector
-// receives the connection to the fake upstream.
+// newRelayWith is like newRelayToUpstream but lets the caller supply the Director,
+// Reflector, and Reporter, so tests can observe how the handler routes and what
+// it records. makeDirector receives the connection to the fake upstream.
 func newRelayWith(
 	t *testing.T,
 	registerUpstream func(*grpc.Server),
 	makeDirector func(cc *grpc.ClientConn) router.Director,
 	reflector router.Reflector,
+	reporter *router.Reporter,
 ) *grpc.ClientConn {
 	t.Helper()
 
@@ -473,7 +583,7 @@ func newRelayWith(
 	relayLis := bufconn.Listen(1024 * 1024)
 	relay := grpc.NewServer(
 		grpc.ForceServerCodecV2(router.Codec()),
-		grpc.UnknownServiceHandler(router.Handler(makeDirector(upstreamConn), reflector)),
+		grpc.UnknownServiceHandler(router.Handler(makeDirector(upstreamConn), reflector, reporter)),
 	)
 	serve(t, relay, relayLis)
 

--- a/internal/router/mux.go
+++ b/internal/router/mux.go
@@ -2,6 +2,17 @@ package router
 
 import "slices"
 
+const (
+	// OutcomeMatch means a rule matched the request.
+	OutcomeMatch Outcome = iota
+	// OutcomeDefault means the request fell through to the default upstream.
+	OutcomeDefault
+	// OutcomeSystem means a no-namespace request went to the system upstream.
+	OutcomeSystem
+	// OutcomeUnroutable means no upstream was selected (result "").
+	OutcomeUnroutable
+)
+
 type (
 	// Mux selects the upstream that serves a request by matching it against an
 	// ordered list of rules. It holds upstream names only, not connections, so
@@ -19,6 +30,9 @@ type (
 	Matcher interface {
 		Match(string) bool
 	}
+
+	// Outcome describes why Switch chose (or failed to choose) an upstream.
+	Outcome byte
 
 	// Rule routes every request it matches to a named upstream. A request
 	// matches when the rule's namespace matcher accepts the request namespace
@@ -45,24 +59,25 @@ func New(defUpstream, sysUpstream string, rules ...Rule) *Mux {
 	}
 }
 
-// Switch returns the name of the upstream that serves a request with the given
-// namespace and metadata. Rules are evaluated in order and the first match
-// wins. When no rule matches, a request with no namespace goes to the system
-// upstream if one is configured, and every other request goes to the default
-// upstream. The result is empty when the selected upstream is unset, which the
-// caller reports as an unroutable request.
-func (m *Mux) Switch(ns string, md map[string][]string) string {
+// Switch returns the upstream that serves a request with the given namespace and
+// metadata, and the Outcome describing why it was chosen. Rules are evaluated in
+// order and the first match wins. With no matching rule, a request with no
+// namespace goes to the system upstream if configured, and every other request
+// goes to the default upstream. An empty result (the selected upstream is unset)
+// is reported as OutcomeUnroutable and the caller treats the request as
+// unroutable.
+func (m *Mux) Switch(ns string, md map[string][]string) (string, Outcome) {
 	for _, rule := range m.rules {
 		if rule.matches(ns, md) {
-			return rule.upstream
+			return rule.upstream, outcomeFor(rule.upstream, OutcomeMatch)
 		}
 	}
 
 	if ns == "" && m.sys != "" {
-		return m.sys
+		return m.sys, outcomeFor(m.sys, OutcomeSystem)
 	}
 
-	return m.def
+	return m.def, outcomeFor(m.def, OutcomeDefault)
 }
 
 // matches reports whether the rule accepts a request with the given namespace
@@ -80,4 +95,29 @@ func (r *Rule) matches(ns string, md map[string][]string) bool {
 	}
 
 	return true
+}
+
+// String returns the metric label value for the outcome.
+func (o Outcome) String() string {
+	switch o {
+	case OutcomeMatch:
+		return "match"
+	case OutcomeDefault:
+		return "default"
+	case OutcomeSystem:
+		return "system"
+	default:
+		return "unroutable"
+	}
+}
+
+// outcomeFor collapses an empty upstream name to OutcomeUnroutable, preserving
+// the invariant that a "" result is always unroutable regardless of which path
+// produced it.
+func outcomeFor(name string, o Outcome) Outcome {
+	if name == "" {
+		return OutcomeUnroutable
+	}
+
+	return o
 }

--- a/internal/router/mux_test.go
+++ b/internal/router/mux_test.go
@@ -21,26 +21,29 @@ func TestMuxSwitch(t *testing.T) {
 	)
 
 	tests := []struct {
-		name string
-		ns   string
-		md   map[string][]string
-		want string
+		name    string
+		ns      string
+		md      map[string][]string
+		want    string
+		outcome Outcome
 	}{
-		{name: "namespace prefix rule", ns: "prod-1", want: "prod"},
-		{name: "metadata-only rule", ns: "anything", md: map[string][]string{"x-tier": {"gold"}}, want: "gold"},
-		{name: "metadata any of many values", ns: "anything", md: map[string][]string{"x-tier": {"bronze", "gold"}}, want: "gold"},
-		{name: "combined namespace and metadata", ns: "eu-1", md: map[string][]string{"x-region": {"eu-west"}}, want: "combo"},
-		{name: "combined rule fails on metadata", ns: "eu-1", md: map[string][]string{"x-region": {"us-east"}}, want: "default"},
-		{name: "metadata-only rule matches empty namespace", ns: "", md: map[string][]string{"x-tier": {"gold"}}, want: "gold"},
-		{name: "constrained metadata key absent", ns: "other", md: map[string][]string{"unrelated": {"gold"}}, want: "default"},
-		{name: "no namespace falls to system", ns: "", want: "system"},
-		{name: "namespaced no match falls to default", ns: "other", want: "default"},
+		{name: "namespace prefix rule", ns: "prod-1", want: "prod", outcome: OutcomeMatch},
+		{name: "metadata-only rule", ns: "anything", md: map[string][]string{"x-tier": {"gold"}}, want: "gold", outcome: OutcomeMatch},
+		{name: "metadata any of many values", ns: "anything", md: map[string][]string{"x-tier": {"bronze", "gold"}}, want: "gold", outcome: OutcomeMatch},
+		{name: "combined namespace and metadata", ns: "eu-1", md: map[string][]string{"x-region": {"eu-west"}}, want: "combo", outcome: OutcomeMatch},
+		{name: "combined rule fails on metadata", ns: "eu-1", md: map[string][]string{"x-region": {"us-east"}}, want: "default", outcome: OutcomeDefault},
+		{name: "metadata-only rule matches empty namespace", ns: "", md: map[string][]string{"x-tier": {"gold"}}, want: "gold", outcome: OutcomeMatch},
+		{name: "constrained metadata key absent", ns: "other", md: map[string][]string{"unrelated": {"gold"}}, want: "default", outcome: OutcomeDefault},
+		{name: "no namespace falls to system", ns: "", want: "system", outcome: OutcomeSystem},
+		{name: "namespaced no match falls to default", ns: "other", want: "default", outcome: OutcomeDefault},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			require.Equal(t, tt.want, mux.Switch(tt.ns, tt.md))
+			got, outcome := mux.Switch(tt.ns, tt.md)
+			require.Equal(t, tt.want, got)
+			require.Equal(t, tt.outcome, outcome)
 		})
 	}
 }
@@ -55,7 +58,9 @@ func TestMuxSwitchFirstMatchWins(t *testing.T) {
 		Rule{upstream: "second", ns: matchPrefix("prod-")},
 	)
 
-	require.Equal(t, "first", mux.Switch("prod-1", nil))
+	got, outcome := mux.Switch("prod-1", nil)
+	require.Equal(t, "first", got)
+	require.Equal(t, OutcomeMatch, outcome)
 }
 
 func TestMuxSwitchNoDefault(t *testing.T) {
@@ -67,8 +72,27 @@ func TestMuxSwitchNoDefault(t *testing.T) {
 		Rule{upstream: "prod", ns: matchPrefix("prod-")},
 	)
 
-	require.Equal(t, "", mux.Switch("other", nil), "no rule and no default yields empty")
-	require.Equal(t, "", mux.Switch("", nil), "no namespace, no system, no default yields empty")
+	got, outcome := mux.Switch("other", nil)
+	require.Equal(t, "", got, "no rule and no default yields empty")
+	require.Equal(t, OutcomeUnroutable, outcome)
+
+	got, outcome = mux.Switch("", nil)
+	require.Equal(t, "", got, "no namespace, no system, no default yields empty")
+	require.Equal(t, OutcomeUnroutable, outcome)
+}
+
+func TestMuxSwitchEmptyRuleUpstreamIsUnroutable(t *testing.T) {
+	t.Parallel()
+
+	mux := New(
+		"default",
+		"",
+		Rule{upstream: "", ns: matchAll()},
+	)
+
+	got, outcome := mux.Switch("other", nil)
+	require.Equal(t, "", got, "a matching rule with an empty upstream still yields no upstream")
+	require.Equal(t, OutcomeUnroutable, outcome)
 }
 
 func (f matcherFunc) Match(s string) bool { return f(s) }

--- a/internal/router/reporter.go
+++ b/internal/router/reporter.go
@@ -1,0 +1,102 @@
+package router
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/temporalio/temporal-proxy/internal/metrics"
+)
+
+const (
+	// upstreamUnknown is the upstream label used for unroutable decisions, where
+	// no upstream was chosen.
+	upstreamUnknown = "unknown"
+
+	reasonNoConnection = "no_connection"
+	reasonStreamSetup  = "stream_setup"
+)
+
+type (
+	// Reporter records router telemetry to Prometheus: routing decisions and the
+	// forwarding failures the router itself originates. It pre-resolves a counter
+	// for every meaningful (upstream, outcome) and (upstream, reason) combination
+	// so the emit path is a lock-free map read; an unexpected label combination
+	// falls back to CounterVec.WithLabelValues. A Reporter is safe for concurrent
+	// use.
+	Reporter struct {
+		decisions *prometheus.CounterVec
+		errors    *prometheus.CounterVec
+		decHandle map[decisionKey]prometheus.Counter
+		errHandle map[errorKey]prometheus.Counter
+	}
+
+	decisionKey struct {
+		upstream string
+		outcome  Outcome
+	}
+
+	errorKey struct {
+		upstream string
+		reason   string
+	}
+)
+
+// NewReporter builds the Prometheus-backed Reporter, registering its collectors
+// with the factory's registry and pre-resolving the meaningful label
+// combinations so every series starts at zero. upstreams is the configured
+// upstream name list.
+func NewReporter(f *metrics.Factory, upstreams []string) *Reporter {
+	decisions := f.NewCounter(prometheus.CounterOpts{
+		Name: "decisions_total",
+		Help: "Total routing decisions, labeled by chosen upstream and outcome.",
+	}, []string{"upstream", "outcome"})
+
+	errors := f.NewCounter(prometheus.CounterOpts{
+		Name: "forwarding_errors_total",
+		Help: "Total router-originated forwarding failures, labeled by upstream and reason.",
+	}, []string{"upstream", "reason"})
+
+	r := &Reporter{
+		decisions: decisions,
+		errors:    errors,
+		decHandle: make(map[decisionKey]prometheus.Counter),
+		errHandle: make(map[errorKey]prometheus.Counter),
+	}
+
+	outcomes := []Outcome{OutcomeMatch, OutcomeDefault, OutcomeSystem}
+	reasons := []string{reasonNoConnection, reasonStreamSetup}
+	for _, u := range upstreams {
+		for _, o := range outcomes {
+			r.decHandle[decisionKey{u, o}] = decisions.WithLabelValues(u, o.String())
+		}
+		for _, reason := range reasons {
+			r.errHandle[errorKey{u, reason}] = errors.WithLabelValues(u, reason)
+		}
+	}
+	r.decHandle[decisionKey{upstreamUnknown, OutcomeUnroutable}] = decisions.WithLabelValues(
+		upstreamUnknown,
+		OutcomeUnroutable.String(),
+	)
+
+	return r
+}
+
+// Decision increments the decision counter for the chosen upstream and outcome.
+func (r *Reporter) Decision(upstream string, outcome Outcome) {
+	if c, ok := r.decHandle[decisionKey{upstream, outcome}]; ok {
+		c.Inc()
+		return
+	}
+
+	r.decisions.WithLabelValues(upstream, outcome.String()).Inc()
+}
+
+// ForwardingError increments the forwarding-error counter for the upstream and
+// reason.
+func (r *Reporter) ForwardingError(upstream, reason string) {
+	if c, ok := r.errHandle[errorKey{upstream, reason}]; ok {
+		c.Inc()
+		return
+	}
+
+	r.errors.WithLabelValues(upstream, reason).Inc()
+}

--- a/internal/router/reporter_test.go
+++ b/internal/router/reporter_test.go
@@ -1,0 +1,99 @@
+package router_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+
+	"github.com/temporalio/temporal-proxy/internal/router"
+)
+
+func TestReporter(t *testing.T) {
+	t.Parallel()
+
+	t.Run("pre-resolves meaningful series to zero", func(t *testing.T) {
+		t.Parallel()
+
+		_, reg := newTestReporter(t, "primary")
+
+		const wantDecisions = `
+# HELP tmprl_proxy_router_decisions_total Total routing decisions, labeled by chosen upstream and outcome.
+# TYPE tmprl_proxy_router_decisions_total counter
+tmprl_proxy_router_decisions_total{outcome="default",upstream="primary"} 0
+tmprl_proxy_router_decisions_total{outcome="match",upstream="primary"} 0
+tmprl_proxy_router_decisions_total{outcome="system",upstream="primary"} 0
+tmprl_proxy_router_decisions_total{outcome="unroutable",upstream="unknown"} 0
+`
+		require.NoError(t, testutil.GatherAndCompare(
+			reg, strings.NewReader(wantDecisions), "tmprl_proxy_router_decisions_total",
+		))
+
+		const wantErrors = `
+# HELP tmprl_proxy_router_forwarding_errors_total Total router-originated forwarding failures, labeled by upstream and reason.
+# TYPE tmprl_proxy_router_forwarding_errors_total counter
+tmprl_proxy_router_forwarding_errors_total{reason="no_connection",upstream="primary"} 0
+tmprl_proxy_router_forwarding_errors_total{reason="stream_setup",upstream="primary"} 0
+`
+		require.NoError(t, testutil.GatherAndCompare(
+			reg, strings.NewReader(wantErrors), "tmprl_proxy_router_forwarding_errors_total",
+		))
+	})
+
+	t.Run("records decisions and forwarding errors", func(t *testing.T) {
+		t.Parallel()
+
+		m, reg := newTestReporter(t, "primary")
+
+		m.Decision("primary", router.OutcomeMatch)
+		m.Decision("primary", router.OutcomeMatch)
+		m.Decision("unknown", router.OutcomeUnroutable)
+		m.ForwardingError("primary", "no_connection")
+
+		const wantDecisions = `
+# HELP tmprl_proxy_router_decisions_total Total routing decisions, labeled by chosen upstream and outcome.
+# TYPE tmprl_proxy_router_decisions_total counter
+tmprl_proxy_router_decisions_total{outcome="default",upstream="primary"} 0
+tmprl_proxy_router_decisions_total{outcome="match",upstream="primary"} 2
+tmprl_proxy_router_decisions_total{outcome="system",upstream="primary"} 0
+tmprl_proxy_router_decisions_total{outcome="unroutable",upstream="unknown"} 1
+`
+		require.NoError(t, testutil.GatherAndCompare(
+			reg, strings.NewReader(wantDecisions), "tmprl_proxy_router_decisions_total",
+		))
+
+		const wantErrors = `
+# HELP tmprl_proxy_router_forwarding_errors_total Total router-originated forwarding failures, labeled by upstream and reason.
+# TYPE tmprl_proxy_router_forwarding_errors_total counter
+tmprl_proxy_router_forwarding_errors_total{reason="no_connection",upstream="primary"} 1
+tmprl_proxy_router_forwarding_errors_total{reason="stream_setup",upstream="primary"} 0
+`
+		require.NoError(t, testutil.GatherAndCompare(
+			reg, strings.NewReader(wantErrors), "tmprl_proxy_router_forwarding_errors_total",
+		))
+	})
+
+	t.Run("falls back for an unknown upstream", func(t *testing.T) {
+		t.Parallel()
+
+		m, reg := newTestReporter(t, "primary")
+
+		// "secondary" was not pre-resolved; the defensive WithLabelValues path must
+		// still create and increment the series.
+		m.Decision("secondary", router.OutcomeMatch)
+
+		const want = `
+# HELP tmprl_proxy_router_decisions_total Total routing decisions, labeled by chosen upstream and outcome.
+# TYPE tmprl_proxy_router_decisions_total counter
+tmprl_proxy_router_decisions_total{outcome="default",upstream="primary"} 0
+tmprl_proxy_router_decisions_total{outcome="match",upstream="primary"} 0
+tmprl_proxy_router_decisions_total{outcome="match",upstream="secondary"} 1
+tmprl_proxy_router_decisions_total{outcome="system",upstream="primary"} 0
+tmprl_proxy_router_decisions_total{outcome="unroutable",upstream="unknown"} 0
+`
+		require.NoError(t, testutil.GatherAndCompare(
+			reg, strings.NewReader(want), "tmprl_proxy_router_decisions_total",
+		))
+	})
+}


### PR DESCRIPTION
The router forwards streams transparently but emitted no telemetry, so there was no way to see where traffic is being routed or why forwarding fails.

Add two low-cardinality counters.

`tmprl_proxy_router_decisions_total{upstream,outcome}` counts every routing decision, where outcome is match, default, system, or unroutable (unroutable uses upstream="unknown").

`tmprl_proxy_router_forwarding_errors_total{upstream,reason}` counts failures the router itself originates, where reason is no_connection or stream_setup. namespace is deliberately never a label because a deployment may have many namespaces which could make the cardinality untenable.

Relayed non-OK upstream statuses are intentionally not counted; a non-EOF response is the upstream's own status faithfully relayed, not a proxy failure, and belongs to a future server-layer status-code interceptor (not done here).
