### PR TITLE
[server]: Add request latency and status-code metrics

### DIFF
--- a/internal/metrics/factory.go
+++ b/internal/metrics/factory.go
@@ -47,3 +47,16 @@ func (f *Factory) NewCounter(opts prometheus.CounterOpts, labelNames []string) *
 
 	return f.factory.NewCounterVec(opts, labelNames)
 }
+
+// NewHistogram creates and registers a HistogramVec. It forces the bound
+// namespace (and subsystem, when set) onto opts, overriding any the caller set,
+// so every histogram shares the same prefix. labelNames are the histogram's
+// variable label dimensions.
+func (f *Factory) NewHistogram(opts prometheus.HistogramOpts, labelNames []string) *prometheus.HistogramVec {
+	opts.Namespace = f.namespace
+	if f.subsystem != "" {
+		opts.Subsystem = f.subsystem
+	}
+
+	return f.factory.NewHistogramVec(opts, labelNames)
+}

--- a/internal/metrics/factory_test.go
+++ b/internal/metrics/factory_test.go
@@ -95,6 +95,55 @@ app_starts_total 1
 	})
 }
 
+func TestFactoryNewHistogram(t *testing.T) {
+	t.Parallel()
+
+	t.Run("prefixes the bound namespace/subsystem and registers", func(t *testing.T) {
+		t.Parallel()
+
+		reg := goprom.NewRegistry()
+		m := metrics.New("myns", promauto.With(reg)).ForSubsystem("sub")
+
+		m.NewHistogram(goprom.HistogramOpts{
+			Name:    "wait_seconds",
+			Help:    "Waits.",
+			Buckets: []float64{0.5, 1},
+		}, []string{"kind"}).WithLabelValues("a").Observe(0.75)
+
+		require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+# HELP myns_sub_wait_seconds Waits.
+# TYPE myns_sub_wait_seconds histogram
+myns_sub_wait_seconds_bucket{kind="a",le="0.5"} 0
+myns_sub_wait_seconds_bucket{kind="a",le="1"} 1
+myns_sub_wait_seconds_bucket{kind="a",le="+Inf"} 1
+myns_sub_wait_seconds_sum{kind="a"} 0.75
+myns_sub_wait_seconds_count{kind="a"} 1
+`), "myns_sub_wait_seconds"))
+	})
+
+	t.Run("overrides a caller-set namespace", func(t *testing.T) {
+		t.Parallel()
+
+		reg := goprom.NewRegistry()
+		m := metrics.New("bound", promauto.With(reg))
+
+		m.NewHistogram(goprom.HistogramOpts{
+			Namespace: "ignored",
+			Name:      "d_seconds",
+			Help:      "D.",
+			Buckets:   []float64{1},
+		}, nil).WithLabelValues().Observe(0.5)
+
+		n, err := testutil.GatherAndCount(reg, "ignored_d_seconds")
+		require.NoError(t, err)
+		require.Zero(t, n, "caller-set namespace must not leak into the metric name")
+
+		n, err = testutil.GatherAndCount(reg, "bound_d_seconds")
+		require.NoError(t, err)
+		require.Equal(t, 1, n)
+	})
+}
+
 func TestModuleProvidesNamespacedMetrics(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/fx.go
+++ b/internal/server/fx.go
@@ -10,83 +10,92 @@ import (
 	"google.golang.org/grpc/encoding"
 
 	"github.com/temporalio/temporal-proxy/internal/config"
+	"github.com/temporalio/temporal-proxy/internal/metrics"
 	"github.com/temporalio/temporal-proxy/internal/transport/creds"
 	"github.com/temporalio/temporal-proxy/pkg/logger"
 )
 
 // Module is the fx module that constructs a [Server] from [ServerParams] and
 // binds its lifecycle to the application.
-var Module = fx.Option(fx.Invoke(func(p ServerParams) error {
-	if err := p.Config.Validate(); err != nil {
-		return fmt.Errorf("invalid configuration: %w", err)
-	}
+var Module = fx.Options(
+	fx.Provide(func(f *metrics.Factory) *Reporter {
+		return NewReporter(f.ForSubsystem("server"))
+	}),
+	fx.Invoke(func(p ServerParams) error {
+		if err := p.Config.Validate(); err != nil {
+			return fmt.Errorf("invalid configuration: %w", err)
+		}
 
-	opts := make([]Option, 0, 5)
-	opts = append(
-		opts,
-		WithCredentials(p.creds()),
-		WithUnknownServiceHandler(p.Handler),
-		WithServerCodec(p.Codec),
-	)
+		opts := make([]Option, 0, 6)
+		opts = append(
+			opts,
+			WithCredentials(p.creds()),
+			WithServerCodec(p.Codec),
+			WithStreamInterceptor(p.Reporter.StreamInterceptor()),
+			WithUnknownServiceHandler(p.Handler),
+		)
 
-	if p.Logger != nil {
-		opts = append(opts, WithLogger(p.Logger))
-	}
+		if p.Logger != nil {
+			opts = append(opts, WithLogger(p.Logger))
+		}
 
-	if p.HealthCheck != nil {
-		opts = append(opts, WithHealthCheck(p.HealthCheck))
-	}
+		if p.HealthCheck != nil {
+			opts = append(opts, WithHealthCheck(p.HealthCheck))
+		}
 
-	svr, err := New(opts...)
-	if err != nil {
-		return fmt.Errorf("failed to create server: %w", err)
-	}
+		svr, err := New(opts...)
+		if err != nil {
+			return fmt.Errorf("failed to create server: %w", err)
+		}
 
-	p.Lifecycle.Append(fx.Hook{
-		OnStart: func(context.Context) error {
-			lis, err := (&net.ListenConfig{}).Listen(
-				p.Context,
-				"tcp",
-				p.Config.Listen.HostPort,
-			)
-			if err != nil {
-				return fmt.Errorf("failed to create listener: %w", err)
-			}
-
-			go func() {
-				defer func() { _ = lis.Close() }()
-
-				if err := svr.Start(p.Context, lis); err != nil {
-					// The server stopped serving unexpectedly. Bring the app
-					// down rather than linger in a non-serving state; Start has
-					// already logged the cause.
-					_ = p.Shutdowner.Shutdown(fx.ExitCode(1))
+		p.Lifecycle.Append(fx.Hook{
+			OnStart: func(context.Context) error {
+				lis, err := (&net.ListenConfig{}).Listen(
+					p.Context,
+					"tcp",
+					p.Config.Listen.HostPort,
+				)
+				if err != nil {
+					return fmt.Errorf("failed to create listener: %w", err)
 				}
-			}()
 
-			return nil
-		},
-		OnStop: svr.Stop,
-	})
+				go func() {
+					defer func() { _ = lis.Close() }()
 
-	return nil
-}))
+					if err := svr.Start(p.Context, lis); err != nil {
+						// The server stopped serving unexpectedly. Bring the app
+						// down rather than linger in a non-serving state; Start has
+						// already logged the cause.
+						_ = p.Shutdowner.Shutdown(fx.ExitCode(1))
+					}
+				}()
+
+				return nil
+			},
+			OnStop: svr.Stop,
+		})
+
+		return nil
+	}),
+)
 
 // ServerParams collects the fx-provided dependencies needed to construct and
-// run a [Server]. Context, Config, Codec, and Handler are required; the Codec
-// and Handler are the transparent-forwarding pieces supplied by the router
-// module. HealthCheck and Logger are optional and fall back to the defaults
-// used by [New] when not supplied.
+// run a [Server]. Context, Config, Codec, Handler, and Reporter are required;
+// the Codec and Handler are the transparent-forwarding pieces supplied by the
+// router module, and the Reporter is provided by this module's own
+// [fx.Provide]. HealthCheck and Logger are optional and fall back to the
+// defaults used by [New] when not supplied.
 type ServerParams struct {
 	fx.In
 	Lifecycle  fx.Lifecycle
 	Shutdowner fx.Shutdowner
 
 	// Required values
-	Context context.Context
-	Config  *config.Config
-	Codec   encoding.CodecV2
-	Handler grpc.StreamHandler
+	Context  context.Context
+	Config   *config.Config
+	Codec    encoding.CodecV2
+	Handler  grpc.StreamHandler
+	Reporter *Reporter
 
 	// Optional values
 	HealthCheck HealthCheck   `optional:"true"`

--- a/internal/server/fx_test.go
+++ b/internal/server/fx_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
 	"google.golang.org/grpc"
@@ -141,6 +142,7 @@ func TestModuleWiresInjectedCodecAndHandler(t *testing.T) {
 		return status.Error(codes.Unimplemented, "injected-handler-reached")
 	})
 
+	f, _ := newTestFactory(t)
 	addr := freeTCPAddr(t)
 	app := fx.New(
 		fx.Supply(fx.Annotate(t.Context(), fx.As(new(context.Context)))),
@@ -148,6 +150,7 @@ func TestModuleWiresInjectedCodecAndHandler(t *testing.T) {
 			Listen:    config.ListenConfig{HostPort: addr},
 			Upstreams: []config.Upstream{{Name: "primary", Listen: config.ListenConfig{HostPort: "127.0.0.1:7233"}}},
 		}),
+		fx.Supply(f),
 		fx.Provide(
 			func() encoding.CodecV2 { return rec },
 			func() grpc.StreamHandler { return handler },
@@ -195,11 +198,71 @@ func TestModuleWiresInjectedCodecAndHandler(t *testing.T) {
 	require.NoError(t, app.Stop(stopCtx))
 }
 
+func TestModuleWiresMetricsInterceptor(t *testing.T) {
+	t.Parallel()
+
+	factory, reg := newTestFactory(t)
+
+	handler := grpc.StreamHandler(func(any, grpc.ServerStream) error {
+		return status.Error(codes.Unimplemented, "stub")
+	})
+
+	addr := freeTCPAddr(t)
+	app := fx.New(
+		fx.Supply(fx.Annotate(t.Context(), fx.As(new(context.Context)))),
+		fx.Supply(&config.Config{
+			Listen:    config.ListenConfig{HostPort: addr},
+			Upstreams: []config.Upstream{{Name: "primary", Listen: config.ListenConfig{HostPort: "127.0.0.1:7233"}}},
+		}),
+		fx.Supply(factory),
+		fx.Provide(
+			func() encoding.CodecV2 { return encoding.GetCodecV2("proto") },
+			func() grpc.StreamHandler { return handler },
+		),
+		server.Module,
+		fx.NopLogger,
+	)
+
+	startCtx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	require.NoError(t, app.Start(startCtx))
+
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	defer func() { _ = conn.Close() }()
+
+	callCtx, callCancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer callCancel()
+
+	err = conn.Invoke(
+		callCtx,
+		"/temporal.api.workflowservice.v1.WorkflowService/GetSystemInfo",
+		&grpc_health_v1.HealthCheckRequest{},
+		new(grpc_health_v1.HealthCheckResponse),
+		grpc.WaitForReady(true),
+	)
+	require.Error(t, err)
+	require.Equal(t, codes.Unimplemented, status.Code(err))
+
+	stopCtx, stopCancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer stopCancel()
+	require.NoError(t, app.Stop(stopCtx))
+
+	// This test proves Module installs the interceptor, so one recorded series is
+	// enough; the exact labels are asserted by the reporter tests that own that
+	// check.
+	n, err := testutil.GatherAndCount(reg, "tmprl_proxy_server_requests_total")
+	require.NoError(t, err)
+	require.Equal(t, 1, n)
+}
+
 func newTestApp(t *testing.T, opts ...fx.Option) *fx.App {
 	t.Helper()
 
+	f, _ := newTestFactory(t)
 	base := []fx.Option{
 		fx.Supply(fx.Annotate(t.Context(), fx.As(new(context.Context)))),
+		fx.Supply(f),
 		// Stand-in transparent-forwarding dependencies; the router module
 		// provides the real ones in production.
 		fx.Provide(

--- a/internal/server/reporter.go
+++ b/internal/server/reporter.go
@@ -1,0 +1,79 @@
+package server
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/temporalio/temporal-proxy/internal/metrics"
+)
+
+// durationBuckets covers both sub-second unary calls and long-poll methods
+// (PollWorkflowTaskQueue, PollActivityTaskQueue, long-poll history) that block
+// 60s+ server-side; the default prometheus buckets top out at 10s.
+var durationBuckets = []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 30, 60, 120}
+
+// Reporter records server-layer telemetry to Prometheus: per-RPC latency and
+// completed-request counts by gRPC status code, both labeled by method. The
+// method label set is not known at startup, so handles are resolved per call
+// via WithLabelValues rather than pre-resolved. A Reporter is safe for
+// concurrent use.
+//
+// Cardinality assumption: method comes from the request line, and the proxy
+// serves every request through a catch-all handler, so any distinct method
+// string a client sends becomes a new series. This is bounded only for trusted
+// callers (real Temporal SDK clients use a fixed method set); a client sending
+// arbitrary method paths can grow the series set without bound. The proxy
+// therefore assumes trusted callers and must not be exposed directly to
+// untrusted clients without first bounding this label. namespace is never a
+// label for the same reason.
+type Reporter struct {
+	duration *prometheus.HistogramVec
+	requests *prometheus.CounterVec
+}
+
+// NewReporter builds the Prometheus-backed Reporter. f must already be scoped to
+// the "server" subsystem by the caller.
+func NewReporter(f *metrics.Factory) *Reporter {
+	return &Reporter{
+		duration: f.NewHistogram(prometheus.HistogramOpts{
+			Name:    "request_duration_seconds",
+			Help:    "Time spent serving an RPC end to end, labeled by method.",
+			Buckets: durationBuckets,
+		}, []string{"method"}),
+		requests: f.NewCounter(prometheus.CounterOpts{
+			Name: "requests_total",
+			Help: "Total RPCs served, labeled by method and gRPC status code.",
+		}, []string{"method", "code"}),
+	}
+}
+
+// Observe records one completed RPC: its duration on the method histogram and a
+// count on the (method, code) counter.
+func (r *Reporter) Observe(method string, code codes.Code, d time.Duration) {
+	r.duration.WithLabelValues(method).Observe(d.Seconds())
+	r.requests.WithLabelValues(method, code.String()).Inc()
+}
+
+// StreamInterceptor returns a stream server interceptor that times the handler
+// and records the RPC's duration and final gRPC status code. It covers all
+// forwarded traffic, which grpc-go serves through the unknown-service handler as
+// streams. The local health service's unary Check is not metered, since unary
+// calls do not pass through a stream interceptor; its streaming Watch, if a
+// client uses it, would be metered under its own method name.
+func (r *Reporter) StreamInterceptor() grpc.StreamServerInterceptor {
+	return func(
+		srv any,
+		ss grpc.ServerStream,
+		info *grpc.StreamServerInfo,
+		handler grpc.StreamHandler,
+	) error {
+		start := time.Now()
+		err := handler(srv, ss)
+		r.Observe(info.FullMethod, status.Code(err), time.Since(start))
+		return err
+	}
+}

--- a/internal/server/reporter_test.go
+++ b/internal/server/reporter_test.go
@@ -1,0 +1,179 @@
+package server_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	goprom "github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+
+	"github.com/temporalio/temporal-proxy/internal/metrics"
+	"github.com/temporalio/temporal-proxy/internal/server"
+)
+
+func TestReporterObserve(t *testing.T) {
+	t.Parallel()
+
+	t.Run("counts requests by method and code", func(t *testing.T) {
+		t.Parallel()
+
+		r, reg := newTestReporter(t)
+
+		r.Observe("/svc/Method", codes.OK, 750*time.Millisecond)
+		r.Observe("/svc/Method", codes.OK, 250*time.Millisecond)
+		r.Observe("/svc/Other", codes.NotFound, 2*time.Second)
+
+		require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+# HELP tmprl_proxy_server_requests_total Total RPCs served, labeled by method and gRPC status code.
+# TYPE tmprl_proxy_server_requests_total counter
+tmprl_proxy_server_requests_total{code="OK",method="/svc/Method"} 2
+tmprl_proxy_server_requests_total{code="NotFound",method="/svc/Other"} 1
+`), "tmprl_proxy_server_requests_total"))
+	})
+
+	t.Run("buckets durations by method", func(t *testing.T) {
+		t.Parallel()
+
+		r, reg := newTestReporter(t)
+
+		r.Observe("/svc/Method", codes.OK, 750*time.Millisecond)
+		r.Observe("/svc/Method", codes.OK, 250*time.Millisecond)
+
+		require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+# HELP tmprl_proxy_server_request_duration_seconds Time spent serving an RPC end to end, labeled by method.
+# TYPE tmprl_proxy_server_request_duration_seconds histogram
+tmprl_proxy_server_request_duration_seconds_bucket{method="/svc/Method",le="0.005"} 0
+tmprl_proxy_server_request_duration_seconds_bucket{method="/svc/Method",le="0.01"} 0
+tmprl_proxy_server_request_duration_seconds_bucket{method="/svc/Method",le="0.025"} 0
+tmprl_proxy_server_request_duration_seconds_bucket{method="/svc/Method",le="0.05"} 0
+tmprl_proxy_server_request_duration_seconds_bucket{method="/svc/Method",le="0.1"} 0
+tmprl_proxy_server_request_duration_seconds_bucket{method="/svc/Method",le="0.25"} 1
+tmprl_proxy_server_request_duration_seconds_bucket{method="/svc/Method",le="0.5"} 1
+tmprl_proxy_server_request_duration_seconds_bucket{method="/svc/Method",le="1"} 2
+tmprl_proxy_server_request_duration_seconds_bucket{method="/svc/Method",le="2.5"} 2
+tmprl_proxy_server_request_duration_seconds_bucket{method="/svc/Method",le="5"} 2
+tmprl_proxy_server_request_duration_seconds_bucket{method="/svc/Method",le="10"} 2
+tmprl_proxy_server_request_duration_seconds_bucket{method="/svc/Method",le="30"} 2
+tmprl_proxy_server_request_duration_seconds_bucket{method="/svc/Method",le="60"} 2
+tmprl_proxy_server_request_duration_seconds_bucket{method="/svc/Method",le="120"} 2
+tmprl_proxy_server_request_duration_seconds_bucket{method="/svc/Method",le="+Inf"} 2
+tmprl_proxy_server_request_duration_seconds_sum{method="/svc/Method"} 1
+tmprl_proxy_server_request_duration_seconds_count{method="/svc/Method"} 2
+`), "tmprl_proxy_server_request_duration_seconds"))
+	})
+}
+
+func TestReporterStreamInterceptor(t *testing.T) {
+	t.Parallel()
+
+	t.Run("records the returned status code", func(t *testing.T) {
+		t.Parallel()
+
+		r, reg := newTestReporter(t)
+		interceptor := r.StreamInterceptor()
+
+		info := &grpc.StreamServerInfo{FullMethod: "/svc/Fail"}
+		handler := func(any, grpc.ServerStream) error {
+			return status.Error(codes.PermissionDenied, "nope")
+		}
+
+		err := interceptor(nil, nil, info, handler)
+		require.Error(t, err)
+		require.Equal(t, codes.PermissionDenied, status.Code(err))
+
+		require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+# HELP tmprl_proxy_server_requests_total Total RPCs served, labeled by method and gRPC status code.
+# TYPE tmprl_proxy_server_requests_total counter
+tmprl_proxy_server_requests_total{code="PermissionDenied",method="/svc/Fail"} 1
+`), "tmprl_proxy_server_requests_total"))
+	})
+
+	t.Run("maps a nil error to OK", func(t *testing.T) {
+		t.Parallel()
+
+		r, reg := newTestReporter(t)
+		interceptor := r.StreamInterceptor()
+
+		info := &grpc.StreamServerInfo{FullMethod: "/svc/Ok"}
+		handler := func(any, grpc.ServerStream) error { return nil }
+
+		require.NoError(t, interceptor(nil, nil, info, handler))
+
+		require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+# HELP tmprl_proxy_server_requests_total Total RPCs served, labeled by method and gRPC status code.
+# TYPE tmprl_proxy_server_requests_total counter
+tmprl_proxy_server_requests_total{code="OK",method="/svc/Ok"} 1
+`), "tmprl_proxy_server_requests_total"))
+	})
+}
+
+func TestReporterInterceptorMetersForwardedTraffic(t *testing.T) {
+	t.Parallel()
+
+	r, reg := newTestReporter(t)
+
+	handler := func(_ any, _ grpc.ServerStream) error {
+		return status.Error(codes.Unimplemented, "unknown")
+	}
+
+	svr, err := server.New(
+		server.WithStreamInterceptor(r.StreamInterceptor()),
+		server.WithUnknownServiceHandler(handler),
+	)
+	require.NoError(t, err)
+
+	lis := bufconn.Listen(1024 * 1024)
+	defer func() { _ = lis.Close() }()
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- svr.Start(t.Context(), lis) }()
+
+	conn := newBufConnClient(t, lis)
+	defer func() { _ = conn.Close() }()
+
+	// A "unary" call to an unregistered method is served as a stream through the
+	// unknown-service handler, so the stream interceptor meters it.
+	err = conn.Invoke(
+		t.Context(),
+		"/temporal.api.workflowservice.v1.WorkflowService/GetSystemInfo",
+		&grpc_health_v1.HealthCheckRequest{},
+		&grpc_health_v1.HealthCheckResponse{},
+	)
+	require.Error(t, err)
+	require.Equal(t, codes.Unimplemented, status.Code(err))
+
+	require.NoError(t, svr.Stop(t.Context()))
+	require.NoError(t, <-errCh)
+
+	n, err := testutil.GatherAndCount(reg, "tmprl_proxy_server_requests_total")
+	require.NoError(t, err)
+	require.Equal(t, 1, n)
+	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+# HELP tmprl_proxy_server_requests_total Total RPCs served, labeled by method and gRPC status code.
+# TYPE tmprl_proxy_server_requests_total counter
+tmprl_proxy_server_requests_total{code="Unimplemented",method="/temporal.api.workflowservice.v1.WorkflowService/GetSystemInfo"} 1
+`), "tmprl_proxy_server_requests_total"))
+}
+
+func newTestReporter(t *testing.T) (*server.Reporter, *goprom.Registry) {
+	t.Helper()
+	f, reg := newTestFactory(t)
+	return server.NewReporter(f.ForSubsystem("server")), reg
+}
+
+// newTestFactory builds a namespace-scoped metrics Factory backed by a fresh,
+// isolated registry, returning both so callers can gather what the Factory's
+// collectors record.
+func newTestFactory(t *testing.T) (*metrics.Factory, *goprom.Registry) {
+	t.Helper()
+	reg := goprom.NewRegistry()
+	return metrics.New("tmprl_proxy", promauto.With(reg)), reg
+}


### PR DESCRIPTION
The server layer accepted and held every RPC but emitted no telemetry, so there was no signal for request latency or the gRPC status codes clients ultimately receive.

Add a stream server interceptor in internal/server that records each RPC's duration and final gRPC status. A Reporter owns a method-labeled latency histogram (buckets extended to 120s so long-poll methods are not all lumped into +Inf) and a method+code counter, both under the `server` Prometheus subsystem. It is installed through the existing WithStreamInterceptor option.

The interceptor is stream-only by design as the proxy forwards all traffic through the unknown-service handler, which gRPC serves as streams, so a stream interceptor meters everything a client sends (including unary-looking RPCs such as GetSystemInfo).

> [!NOTE]
Namespace is never a label, matching the router's cardinality rule. The method label is bounded only for trusted callers, since the catch-all handler records whatever method string the client sends; this assumption is documented on Reporter and accepted for the proxy's trusted-caller deployment model.