### PR TITLE
[auth]: Add outbound upstream credentials

### DIFF
--- a/e2e/doc.go
+++ b/e2e/doc.go
@@ -1,0 +1,4 @@
+// Package e2e contains black-box, full-stack integration tests that drive the
+// proxy the way production does: a client through the inbound server, router,
+// per-upstream proxy, and out to a fake upstream.
+package e2e

--- a/e2e/harness_test.go
+++ b/e2e/harness_test.go
@@ -1,0 +1,240 @@
+package e2e
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.uber.org/fx"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+
+	"github.com/temporalio/temporal-proxy/internal/auth"
+	"github.com/temporalio/temporal-proxy/internal/config"
+	"github.com/temporalio/temporal-proxy/internal/metrics"
+	"github.com/temporalio/temporal-proxy/internal/protoutil"
+	"github.com/temporalio/temporal-proxy/internal/proxy"
+	"github.com/temporalio/temporal-proxy/internal/router"
+	"github.com/temporalio/temporal-proxy/internal/server"
+	"github.com/temporalio/temporal-proxy/internal/transport/connect"
+	"github.com/temporalio/temporal-proxy/internal/transport/socket"
+	"github.com/temporalio/temporal-proxy/pkg/logger"
+	"github.com/temporalio/temporal-proxy/pkg/testutil"
+)
+
+type (
+	// capturingWorkflowService is a fake upstream Temporal frontend that records
+	// the incoming metadata on GetSystemInfo, the smallest WorkflowService method
+	// that needs no namespace argument.
+	capturingWorkflowService struct {
+		workflowservice.UnimplementedWorkflowServiceServer
+
+		mu sync.Mutex
+		md metadata.MD
+	}
+
+	// fakeTLSUpstream is a running fake WorkflowService frontend over TLS together
+	// with the CA and client-identity cert/key files needed to build a matching
+	// upstream [config.TLSConfig]. It exposes the raw file paths (rather than an
+	// assembled TLSConfig) so callers can vary other TLS fields, or the rest of the
+	// upstream config, per case.
+	fakeTLSUpstream struct {
+		svc            *capturingWorkflowService
+		addr           string
+		caFile         string
+		clientCertFile string
+		clientKeyFile  string
+	}
+)
+
+func (s *capturingWorkflowService) GetSystemInfo(
+	ctx context.Context, _ *workflowservice.GetSystemInfoRequest,
+) (*workflowservice.GetSystemInfoResponse, error) {
+	md, _ := metadata.FromIncomingContext(ctx)
+
+	s.mu.Lock()
+	s.md = md
+	s.mu.Unlock()
+
+	return &workflowservice.GetSystemInfoResponse{}, nil
+}
+
+// received returns the metadata observed by the most recent GetSystemInfo
+// call, or nil if none has arrived yet.
+func (s *capturingWorkflowService) received() metadata.MD {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.md
+}
+
+// newFullApp builds an fx.App wiring every module the production app wires
+// (see cmd/proxy/serve.go), so tests can drive the full stack -- inbound
+// server, router, and per-upstream proxy -- rather than any single module in
+// isolation. Each call gets a fresh Prometheus registry (avoiding
+// duplicate-registration panics across parallel tests) and an ephemeral
+// metrics listener address, since these tests only care about the proxy path.
+func newFullApp(t *testing.T, cfg *config.Config) *fx.App {
+	t.Helper()
+
+	reg := prometheus.NewRegistry()
+
+	return fx.New(
+		fx.Supply(fx.Annotate(t.Context(), fx.As(new(context.Context)))),
+		fx.Supply(cfg),
+		fx.Supply(fx.Annotate("127.0.0.1:0", metrics.AddrTag)),
+		fx.Supply(fx.Annotate("test", metrics.NamespaceTag)),
+		fx.Provide(
+			func() logger.Logger { return logger.NewNoopLogger() },
+			func() prometheus.Gatherer { return reg },
+			func() prometheus.Registerer { return reg },
+		),
+		auth.Module,
+		connect.Module,
+		metrics.Module,
+		protoutil.Module,
+		proxy.Module,
+		router.Module,
+		server.Module,
+		fx.NopLogger,
+	)
+}
+
+// newProxyApp is a minimal, proxy.Module-only fx app for the socket-level
+// test in this package. internal/proxy/fx_test.go has its own copy (with
+// support for extra fx.Options) that its unit tests still depend on; this is
+// a deliberate small duplication rather than an exported helper, so the two
+// packages stay decoupled.
+func newProxyApp(t *testing.T, cfg *config.Config) *fx.App {
+	t.Helper()
+
+	return fx.New(
+		fx.Supply(fx.Annotate(t.Context(), fx.As(new(context.Context)))),
+		fx.Supply(cfg),
+		proxy.Module,
+		fx.NopLogger,
+	)
+}
+
+// newFakeTLSUpstream stands up a fake WorkflowService frontend over TLS and
+// returns it along with the cert files needed to dial it.
+func newFakeTLSUpstream(t *testing.T) fakeTLSUpstream {
+	t.Helper()
+
+	caFile, serverCertFile, serverKeyFile := testutil.GenerateMTLSCerts(t)
+	serverCert, err := tls.LoadX509KeyPair(serverCertFile, serverKeyFile)
+	require.NoError(t, err)
+
+	svc := &capturingWorkflowService{}
+	fakeUpstream := grpc.NewServer(grpc.Creds(credentials.NewTLS(&tls.Config{
+		Certificates: []tls.Certificate{serverCert},
+	})))
+	workflowservice.RegisterWorkflowServiceServer(fakeUpstream, svc)
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	go func() { _ = fakeUpstream.Serve(lis) }()
+	t.Cleanup(fakeUpstream.Stop)
+
+	clientCertFile, clientKeyFile := generateMatchingRSAKeyPair(t)
+
+	return fakeTLSUpstream{
+		svc:            svc,
+		addr:           lis.Addr().String(),
+		caFile:         caFile,
+		clientCertFile: clientCertFile,
+		clientKeyFile:  clientKeyFile,
+	}
+}
+
+// freeTCPAddr reserves an ephemeral localhost TCP port and returns its
+// address. The listener is closed before returning so the caller (here, the
+// inbound server started by newFullApp) can bind it; the small race window is
+// acceptable in tests. Mirrors the identically named helper in
+// internal/server/fx_test.go, which package e2e cannot see.
+func freeTCPAddr(t *testing.T) string {
+	t.Helper()
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	addr := lis.Addr().String()
+	require.NoError(t, lis.Close())
+	return addr
+}
+
+// dialInbound dials the top-level server's inbound address the way a real
+// client would: plaintext, since the full-stack cases here never configure
+// inbound TLS.
+func dialInbound(t *testing.T, addr string) *grpc.ClientConn {
+	t.Helper()
+
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	return conn
+}
+
+// dialUnix returns a client connection to the proxy's unix socket for the
+// given upstream host. The socket path matches what proxy.Start binds.
+// internal/proxy/server_test.go has its own copy that its unit tests still
+// depend on; this is a deliberate small duplication for the socket-level test
+// in this package.
+func dialUnix(t *testing.T, upstream string) *grpc.ClientConn {
+	t.Helper()
+
+	path, err := socket.UnixPath(upstream)
+	require.NoError(t, err)
+
+	conn, err := grpc.NewClient(
+		"unix://"+path,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	return conn
+}
+
+// generateMatchingRSAKeyPair writes a self-signed RSA-2048 certificate and its
+// matching private key to a fresh [testing.T.TempDir] and returns the paths.
+// Unlike [testutil.RSACert], the private key is retained and written out, so
+// the pair loads via [tls.LoadX509KeyPair] for use as a real TLS client
+// identity.
+func generateMatchingRSAKeyPair(t *testing.T) (certFile, keyFile string) {
+	t.Helper()
+
+	dir := t.TempDir()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "proxy-client"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	certFile = testutil.WriteFile(t, dir, "client-cert.pem", pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
+	keyFile = testutil.WriteFile(t, dir, "client-key.pem",
+		pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)}))
+
+	return certFile, keyFile
+}

--- a/e2e/inbound_auth_strip_test.go
+++ b/e2e/inbound_auth_strip_test.go
@@ -1,0 +1,86 @@
+package e2e
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/api/workflowservice/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+
+	"github.com/temporalio/temporal-proxy/internal/config"
+)
+
+// TestEndToEndInboundAuthStrippedOutboundCredentialAttached drives a request
+// through the full stack (client -> inbound server with StaticToken auth ->
+// router -> per-upstream proxy -> fake TLS upstream) and proves the inbound and
+// outbound header strips compose: the caller's worker token authenticates at
+// the inbound server but never reaches the upstream, and the upstream sees
+// exactly one authorization value, the configured static API key.
+//
+// TestProxyAttachesUpstreamCredential (in upstream_credential_socket_test.go)
+// dials the per-upstream proxy's socket directly and so cannot exercise the
+// inbound server or router at all; this test is the only one that proves both
+// strips hold together end to end.
+func TestEndToEndInboundAuthStrippedOutboundCredentialAttached(t *testing.T) {
+	t.Parallel()
+
+	up := newFakeTLSUpstream(t)
+
+	inboundAddr := freeTCPAddr(t)
+	app := newFullApp(t, &config.Config{
+		Listen:  config.ListenConfig{HostPort: inboundAddr},
+		Auth:    &config.AuthConfig{StaticToken: &config.StaticTokenConfig{Token: "worker-secret"}},
+		Routing: config.Routing{DefaultUpstream: "workers"},
+		Upstreams: []config.Upstream{{
+			Name: "workers",
+			Listen: config.ListenConfig{
+				HostPort: up.addr,
+				TLS: &config.TLSConfig{
+					CA:         up.caFile,
+					Cert:       up.clientCertFile,
+					Key:        up.clientKeyFile,
+					ServerName: "localhost",
+				},
+			},
+			Credentials: &config.CredentialConfig{Static: &config.StaticCredentialConfig{APIKey: "k3y"}},
+		}},
+	})
+	require.NoError(t, app.Err())
+
+	startCtx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	require.NoError(t, app.Start(startCtx))
+	t.Cleanup(func() {
+		stopCtx, stopCancel := context.WithTimeout(t.Context(), 5*time.Second)
+		defer stopCancel()
+		_ = app.Stop(stopCtx)
+	})
+
+	conn := dialInbound(t, inboundAddr)
+	defer func() { _ = conn.Close() }()
+
+	// The client presents the worker's own token. The inbound authenticator
+	// consumes it (proving inbound auth is wired end to end); the router then
+	// forwards to the "workers" upstream, whose static credential provider
+	// replaces whatever authorization header survives forwarding.
+	ctx := metadata.AppendToOutgoingContext(startCtx, "authorization", "Bearer worker-secret")
+	_, err := workflowservice.NewWorkflowServiceClient(conn).GetSystemInfo(
+		ctx, &workflowservice.GetSystemInfoRequest{}, grpc.WaitForReady(true),
+	)
+	require.NoError(t, err, "inbound auth must accept the correct worker token")
+
+	got := up.svc.received().Get("authorization")
+	require.Equal(t, []string{"Bearer k3y"}, got,
+		"upstream must see only the API key; the worker token must be stripped, not forwarded or duplicated")
+
+	// Negative check: a wrong worker token never gets past the inbound
+	// authenticator, so it never reaches the router or upstream at all.
+	badCtx := metadata.AppendToOutgoingContext(startCtx, "authorization", "Bearer wrong")
+	_, err = workflowservice.NewWorkflowServiceClient(conn).GetSystemInfo(badCtx, &workflowservice.GetSystemInfoRequest{})
+	require.Equal(t, codes.Unauthenticated, status.Code(err))
+}

--- a/e2e/inbound_credential_no_leak_test.go
+++ b/e2e/inbound_credential_no_leak_test.go
@@ -1,0 +1,74 @@
+package e2e
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/api/workflowservice/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+
+	"github.com/temporalio/temporal-proxy/internal/config"
+)
+
+// TestEndToEndInboundHeaderStrippedNotLeakedUpstream isolates the inbound
+// strip's independent contribution. Here the inbound authenticator consumes a
+// worker credential on its own header (x-worker-auth), distinct from the
+// outbound credential's authorization header, so the outbound strip (which
+// only ever touches authorization) has nothing to do with x-worker-auth: if
+// it reaches the upstream at all, only the inbound strip could have failed to
+// remove it. TestEndToEndInboundAuthStrippedOutboundCredentialAttached
+// exercises both strips on the same header, which cannot distinguish "the
+// inbound strip removed it" from "the outbound strip's replacement happened
+// to overwrite it".
+func TestEndToEndInboundHeaderStrippedNotLeakedUpstream(t *testing.T) {
+	t.Parallel()
+
+	up := newFakeTLSUpstream(t)
+	inboundAddr := freeTCPAddr(t)
+
+	cfg := &config.Config{
+		Listen: config.ListenConfig{HostPort: inboundAddr},
+		// Inbound auth consumes a custom header, distinct from the outbound credential's.
+		Auth:    &config.AuthConfig{StaticToken: &config.StaticTokenConfig{Token: "worker-secret", Header: "x-worker-auth"}},
+		Routing: config.Routing{DefaultUpstream: "workers"},
+		Upstreams: []config.Upstream{{
+			Name: "workers",
+			Listen: config.ListenConfig{
+				HostPort: up.addr,
+				TLS: &config.TLSConfig{
+					CA:         up.caFile,
+					Cert:       up.clientCertFile,
+					Key:        up.clientKeyFile,
+					ServerName: "localhost",
+				},
+			},
+			Credentials: &config.CredentialConfig{Static: &config.StaticCredentialConfig{APIKey: "k3y"}}, // header defaults to authorization
+		}},
+	}
+
+	app := newFullApp(t, cfg)
+	require.NoError(t, app.Err())
+
+	startCtx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	require.NoError(t, app.Start(startCtx))
+	t.Cleanup(func() {
+		stopCtx, stopCancel := context.WithTimeout(t.Context(), 5*time.Second)
+		defer stopCancel()
+		_ = app.Stop(stopCtx)
+	})
+
+	conn := dialInbound(t, inboundAddr)
+	defer func() { _ = conn.Close() }()
+
+	ctx := metadata.AppendToOutgoingContext(startCtx, "x-worker-auth", "Bearer worker-secret")
+	_, err := workflowservice.NewWorkflowServiceClient(conn).GetSystemInfo(ctx, &workflowservice.GetSystemInfoRequest{}, grpc.WaitForReady(true))
+	require.NoError(t, err)
+
+	got := up.svc.received()
+	require.Empty(t, got.Get("x-worker-auth"), "the worker credential (on its own header) must not leak upstream")
+	require.Equal(t, []string{"Bearer k3y"}, got.Get("authorization"), "the upstream must see exactly the API key")
+}

--- a/e2e/outbound_credential_override_test.go
+++ b/e2e/outbound_credential_override_test.go
@@ -1,0 +1,67 @@
+package e2e
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/api/workflowservice/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+
+	"github.com/temporalio/temporal-proxy/internal/config"
+)
+
+// TestEndToEndOutboundCredentialOverridesForwardedHeader proves the outbound
+// strip holds even with no inbound auth configured: a caller-supplied
+// authorization header has nothing to authenticate against at the inbound
+// server (so the call succeeds regardless), but the outbound static credential
+// provider must still strip that forwarded header and replace it with the
+// configured API key rather than let both reach the upstream.
+func TestEndToEndOutboundCredentialOverridesForwardedHeader(t *testing.T) {
+	t.Parallel()
+
+	up := newFakeTLSUpstream(t)
+
+	inboundAddr := freeTCPAddr(t)
+	app := newFullApp(t, &config.Config{
+		Listen:  config.ListenConfig{HostPort: inboundAddr},
+		Routing: config.Routing{DefaultUpstream: "workers"},
+		Upstreams: []config.Upstream{{
+			Name: "workers",
+			Listen: config.ListenConfig{
+				HostPort: up.addr,
+				TLS: &config.TLSConfig{
+					CA:         up.caFile,
+					Cert:       up.clientCertFile,
+					Key:        up.clientKeyFile,
+					ServerName: "localhost",
+				},
+			},
+			Credentials: &config.CredentialConfig{Static: &config.StaticCredentialConfig{APIKey: "k3y"}},
+		}},
+	})
+	require.NoError(t, app.Err())
+
+	startCtx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	require.NoError(t, app.Start(startCtx))
+	t.Cleanup(func() {
+		stopCtx, stopCancel := context.WithTimeout(t.Context(), 5*time.Second)
+		defer stopCancel()
+		_ = app.Stop(stopCtx)
+	})
+
+	conn := dialInbound(t, inboundAddr)
+	defer func() { _ = conn.Close() }()
+
+	ctx := metadata.AppendToOutgoingContext(startCtx, "authorization", "Bearer stray")
+	_, err := workflowservice.NewWorkflowServiceClient(conn).GetSystemInfo(
+		ctx, &workflowservice.GetSystemInfoRequest{}, grpc.WaitForReady(true),
+	)
+	require.NoError(t, err, "with no inbound auth configured, the stray header alone must not block the call")
+
+	require.Equal(t, []string{"Bearer k3y"}, up.svc.received().Get("authorization"),
+		"the outbound credential must override the forwarded header, not add to it")
+}

--- a/e2e/upstream_credential_socket_test.go
+++ b/e2e/upstream_credential_socket_test.go
@@ -1,0 +1,69 @@
+package e2e
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/api/workflowservice/v1"
+	"google.golang.org/grpc"
+
+	"github.com/temporalio/temporal-proxy/internal/config"
+)
+
+// TestProxyAttachesUpstreamCredential proves the static credential configured
+// on an upstream actually reaches that upstream: it stands up a fake
+// WorkflowService server over TLS, points a real [proxy.Server] (built via
+// [proxy.Module]) at it with a static credential configured, drives a
+// request through the proxy's local socket, and asserts the fake upstream
+// observed the "authorization: Bearer <key>" header. The static provider
+// requires transport security, so this exercises the same TLS + per-RPC
+// credential dial path production traffic takes; fx.go wiring in isolation
+// cannot prove the header actually arrives on the wire.
+func TestProxyAttachesUpstreamCredential(t *testing.T) {
+	t.Parallel()
+
+	up := newFakeTLSUpstream(t)
+
+	app := newProxyApp(t, &config.Config{
+		Upstreams: []config.Upstream{{
+			Name: "workers",
+			Listen: config.ListenConfig{
+				HostPort: up.addr,
+				TLS: &config.TLSConfig{
+					CA:   up.caFile,
+					Cert: up.clientCertFile,
+					Key:  up.clientKeyFile,
+					// The fake upstream's leaf certificate (from
+					// GenerateMTLSCerts) advertises CN/DNSNames "localhost",
+					// which does not match the 127.0.0.1 dial address.
+					ServerName: "localhost",
+				},
+			},
+			Credentials: &config.CredentialConfig{Static: &config.StaticCredentialConfig{APIKey: "k3y"}},
+		}},
+	})
+	require.NoError(t, app.Err())
+
+	startCtx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	require.NoError(t, app.Start(startCtx))
+	t.Cleanup(func() {
+		stopCtx, stopCancel := context.WithTimeout(t.Context(), 5*time.Second)
+		defer stopCancel()
+		_ = app.Stop(stopCtx)
+	})
+
+	conn := dialUnix(t, up.addr)
+	defer func() { _ = conn.Close() }()
+
+	_, err := workflowservice.NewWorkflowServiceClient(conn).GetSystemInfo(
+		startCtx, &workflowservice.GetSystemInfoRequest{}, grpc.WaitForReady(true),
+	)
+	require.NoError(t, err)
+
+	got := up.svc.received()
+	require.Equal(t, []string{"Bearer k3y"}, got.Get("authorization"),
+		"expected the configured static credential to reach the upstream")
+}

--- a/internal/auth/authenticator.go
+++ b/internal/auth/authenticator.go
@@ -19,10 +19,14 @@ const (
 )
 
 type (
-	// Authenticator authenticates an inbound request from its metadata. It returns
-	// nil to allow the request, or a gRPC status error to reject it.
+	// Authenticator authenticates an inbound request from its metadata. It
+	// returns nil to allow the request, or a gRPC status error to reject it.
+	// Header reports the metadata header the authenticator consumes, so the
+	// proxy can strip the caller's credential before forwarding upstream; it
+	// returns "" when the authenticator consumes no header.
 	Authenticator interface {
 		Authenticate(ctx context.Context, md metadata.MD) error
+		Header() string
 	}
 
 	// rejection is an authentication failure that reports a generic, client-safe
@@ -34,6 +38,13 @@ type (
 	}
 
 	defaultAuthenticator struct{}
+
+	// strippedStream overrides Context so a downstream handler sees metadata with a
+	// consumed credential header removed.
+	strippedStream struct {
+		grpc.ServerStream
+		ctx context.Context
+	}
 )
 
 // StreamServerInterceptor adapts an Authenticator to a gRPC stream server
@@ -59,6 +70,19 @@ func StreamServerInterceptor(a Authenticator, log logger.Logger) grpc.StreamServ
 			return err
 		}
 
+		// The proxy terminates inbound auth, so strip the header it consumed:
+		// the caller's credential must not be forwarded upstream, where it would
+		// otherwise collide with (or leak alongside) an outbound credential on
+		// the same header.
+		if header := a.Header(); header != "" {
+			stripped := md.Copy()
+			stripped.Delete(header)
+			ss = &strippedStream{
+				ServerStream: ss,
+				ctx:          metadata.NewIncomingContext(ss.Context(), stripped),
+			}
+		}
+
 		return handler(srv, ss)
 	}
 }
@@ -75,10 +99,30 @@ func (a *defaultAuthenticator) Authenticate(_ context.Context, _ metadata.MD) er
 	return nil
 }
 
+// Header reports that the admit-all default consumes no header, so
+// StreamServerInterceptor strips nothing and the transparent relay is
+// preserved.
+func (a *defaultAuthenticator) Header() string { return "" }
+
+// Context returns the context carrying the stripped incoming metadata.
+func (s *strippedStream) Context() context.Context { return s.ctx }
+
 // reject builds a rejection carrying a client-safe code+message and a
 // server-side detail for logging.
 func reject(code codes.Code, clientMsg, detail string) error {
 	return &rejection{st: status.New(code, clientMsg), detail: detail}
+}
+
+// canonicalHeader returns the metadata header to use for a credential: the
+// default when h is blank, otherwise h lowercased. gRPC canonicalizes metadata
+// keys to lowercase, so normalizing here keeps a mixed-case configured header
+// matching what md lookups, strips, and per-RPC credentials actually send.
+func canonicalHeader(h string) string {
+	if h == "" {
+		return defaultHeader
+	}
+
+	return strings.ToLower(h)
 }
 
 // extractToken returns the credential carried in md under header, stripping the

--- a/internal/auth/authenticator_test.go
+++ b/internal/auth/authenticator_test.go
@@ -25,6 +25,7 @@ func (f *fakeStream) Context() context.Context { return f.ctx }
 type fakeAuthenticator struct{ err error }
 
 func (f fakeAuthenticator) Authenticate(context.Context, metadata.MD) error { return f.err }
+func (fakeAuthenticator) Header() string                                    { return "" }
 
 func TestStreamServerInterceptor(t *testing.T) {
 	t.Parallel()
@@ -53,6 +54,43 @@ func TestStreamServerInterceptor(t *testing.T) {
 		require.False(t, called)
 		require.Equal(t, codes.Unauthenticated, status.Code(err))
 	})
+}
+
+func TestStreamServerInterceptorStripsConsumedHeader(t *testing.T) {
+	t.Parallel()
+
+	a, err := auth.NewStaticTokenAuthenticator("s3cret", "", "") // header defaults to "authorization"
+	require.NoError(t, err)
+
+	inMD := metadata.Pairs("authorization", "Bearer s3cret", "x-keep", "v")
+	ctx := metadata.NewIncomingContext(t.Context(), inMD)
+
+	var seen metadata.MD
+	ic := auth.StreamServerInterceptor(a, nil)
+	err = ic(nil, &fakeStream{ctx: ctx}, &grpc.StreamServerInfo{FullMethod: "/pkg.Svc/M"}, func(_ any, ss grpc.ServerStream) error {
+		seen, _ = metadata.FromIncomingContext(ss.Context())
+		return nil
+	})
+	require.NoError(t, err)
+
+	require.Empty(t, seen.Get("authorization"), "the consumed credential header must be stripped before forwarding")
+	require.Equal(t, []string{"v"}, seen.Get("x-keep"), "other headers must be forwarded unchanged")
+}
+
+func TestStreamServerInterceptorKeepsHeaderWhenNoneConsumed(t *testing.T) {
+	t.Parallel()
+
+	inMD := metadata.Pairs("authorization", "Bearer whatever")
+	ctx := metadata.NewIncomingContext(t.Context(), inMD)
+
+	var seen metadata.MD
+	ic := auth.StreamServerInterceptor(fakeAuthenticator{}, nil) // Header() == "" -> strips nothing
+	err := ic(nil, &fakeStream{ctx: ctx}, &grpc.StreamServerInfo{}, func(_ any, ss grpc.ServerStream) error {
+		seen, _ = metadata.FromIncomingContext(ss.Context())
+		return nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"Bearer whatever"}, seen.Get("authorization"))
 }
 
 func TestStreamServerInterceptorLogsReason(t *testing.T) {

--- a/internal/auth/doc.go
+++ b/internal/auth/doc.go
@@ -1,3 +1,4 @@
 // Package auth provides application-layer authentication for the proxy:
-// inbound request authentication (Authenticator).
+// authenticating inbound requests (Authenticator) and presenting credentials on
+// outbound requests to upstreams (CredentialProvider).
 package auth

--- a/internal/auth/jwks.go
+++ b/internal/auth/jwks.go
@@ -93,9 +93,6 @@ func NewJWKSAuthenticator(rawURL string, audiences []string, issuer, header, sch
 }
 
 func newJWKSAuthenticator(keyfn jwt.Keyfunc, audiences []string, issuer, header, scheme string) *JWKSAuthenticator {
-	if header == "" {
-		header = defaultHeader
-	}
 	if scheme == "" {
 		scheme = defaultScheme
 	}
@@ -104,7 +101,7 @@ func newJWKSAuthenticator(keyfn jwt.Keyfunc, audiences []string, issuer, header,
 		keyfn:     keyfn,
 		audiences: audiences,
 		issuer:    issuer,
-		header:    header,
+		header:    canonicalHeader(header),
 		scheme:    scheme,
 	}
 }
@@ -141,6 +138,10 @@ func (a *JWKSAuthenticator) Authenticate(_ context.Context, md metadata.MD) erro
 
 	return nil
 }
+
+// Header reports the metadata header this authenticator consumes, so
+// StreamServerInterceptor can strip it before forwarding upstream.
+func (a *JWKSAuthenticator) Header() string { return a.header }
 
 // audienceMatches reports whether the token's aud claim intersects allowed.
 func audienceMatches(claims jwt.MapClaims, allowed []string) bool {

--- a/internal/auth/provider.go
+++ b/internal/auth/provider.go
@@ -1,0 +1,82 @@
+package auth
+
+import (
+	"context"
+	"errors"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/metadata"
+
+	"github.com/temporalio/temporal-proxy/internal/config"
+)
+
+// CredentialProvider supplies per-RPC metadata for outbound calls to an
+// upstream. Header reports the metadata header it sets, so the proxy can strip
+// any forwarded value on that header before the credential adds its own.
+type CredentialProvider interface {
+	credentials.PerRPCCredentials
+	Header() string
+}
+
+// CredentialProviderFor maps configuration to the selected CredentialProvider.
+// It returns (nil, nil) only when cfg is nil (no credential configured); a
+// present-but-empty block fails closed with an error rather than silently
+// dialing the upstream without the configured credential.
+func CredentialProviderFor(cfg *config.CredentialConfig) (CredentialProvider, error) {
+	if cfg == nil {
+		return nil, nil
+	}
+
+	if cfg.Static != nil {
+		cp, err := NewStaticCredentialProvider(cfg.Static.APIKey, cfg.Static.Header, cfg.Static.Scheme)
+		if err != nil {
+			return nil, err
+		}
+		return cp, nil
+	}
+
+	return nil, errors.New("auth: a credentials block was configured but no provider (static) was selected")
+}
+
+// DialOptions returns the dial options that install cp on an outbound
+// connection: the per-RPC credential itself, plus client interceptors that
+// strip cp's header from each call's forwarded metadata so a forwarded value on
+// the same header cannot collide with the credential.
+func DialOptions(cp CredentialProvider) []grpc.DialOption {
+	opts := []grpc.DialOption{grpc.WithPerRPCCredentials(cp)}
+	if header := cp.Header(); header != "" {
+		opts = append(
+			opts,
+			grpc.WithChainUnaryInterceptor(stripOutgoingUnary(header)),
+			grpc.WithChainStreamInterceptor(stripOutgoingStream(header)),
+		)
+	}
+
+	return opts
+}
+
+// stripOutgoingHeader returns ctx with header removed from its outgoing
+// metadata (a copy; the caller's metadata is not mutated).
+func stripOutgoingHeader(ctx context.Context, header string) context.Context {
+	md, ok := metadata.FromOutgoingContext(ctx)
+	if !ok {
+		return ctx
+	}
+
+	md = md.Copy()
+	md.Delete(header)
+	return metadata.NewOutgoingContext(ctx, md)
+}
+
+func stripOutgoingUnary(header string) grpc.UnaryClientInterceptor {
+	return func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		return invoker(stripOutgoingHeader(ctx, header), method, req, reply, cc, opts...)
+	}
+}
+
+func stripOutgoingStream(header string) grpc.StreamClientInterceptor {
+	return func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+		return streamer(stripOutgoingHeader(ctx, header), desc, cc, method, opts...)
+	}
+}

--- a/internal/auth/provider_internal_test.go
+++ b/internal/auth/provider_internal_test.go
@@ -1,0 +1,29 @@
+package auth
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+func TestStripOutgoingUnary(t *testing.T) {
+	t.Parallel()
+
+	ctx := metadata.NewOutgoingContext(t.Context(), metadata.Pairs("authorization", "Bearer forwarded", "x-keep", "v"))
+
+	var gotCtx context.Context
+	invoker := func(ic context.Context, _ string, _, _ any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
+		gotCtx = ic
+		return nil
+	}
+
+	err := stripOutgoingUnary("authorization")(ctx, "/svc/M", nil, nil, nil, invoker)
+	require.NoError(t, err)
+
+	md, _ := metadata.FromOutgoingContext(gotCtx)
+	require.Empty(t, md.Get("authorization"), "the credential header must be stripped from forwarded metadata")
+	require.Equal(t, []string{"v"}, md.Get("x-keep"), "other forwarded headers must be preserved")
+}

--- a/internal/auth/provider_test.go
+++ b/internal/auth/provider_test.go
@@ -1,0 +1,54 @@
+package auth_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/temporalio/temporal-proxy/internal/auth"
+	"github.com/temporalio/temporal-proxy/internal/config"
+)
+
+func TestCredentialProviderFor(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil config yields nil provider", func(t *testing.T) {
+		t.Parallel()
+		cp, err := auth.CredentialProviderFor(nil)
+		require.NoError(t, err)
+		require.Nil(t, cp)
+	})
+
+	t.Run("static config yields a provider", func(t *testing.T) {
+		t.Parallel()
+		cp, err := auth.CredentialProviderFor(&config.CredentialConfig{
+			Static: &config.StaticCredentialConfig{APIKey: "k"},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, cp)
+		require.True(t, cp.RequireTransportSecurity())
+	})
+
+	t.Run("invalid static config errors", func(t *testing.T) {
+		t.Parallel()
+		cp, err := auth.CredentialProviderFor(&config.CredentialConfig{Static: &config.StaticCredentialConfig{}})
+		require.Error(t, err)
+		require.Nil(t, cp)
+	})
+
+	t.Run("present but empty block fails closed", func(t *testing.T) {
+		t.Parallel()
+		cp, err := auth.CredentialProviderFor(&config.CredentialConfig{})
+		require.Error(t, err)
+		require.Nil(t, cp)
+	})
+
+	t.Run("DialOptions returns the credential and strip interceptors", func(t *testing.T) {
+		t.Parallel()
+		cp, err := auth.CredentialProviderFor(&config.CredentialConfig{
+			Static: &config.StaticCredentialConfig{APIKey: "k"},
+		})
+		require.NoError(t, err)
+		require.Len(t, auth.DialOptions(cp), 3)
+	})
+}

--- a/internal/auth/static_provider.go
+++ b/internal/auth/static_provider.go
@@ -1,0 +1,42 @@
+package auth
+
+import (
+	"context"
+	"errors"
+)
+
+// StaticCredentialProvider attaches a fixed bearer header to every outbound
+// request to an upstream. It implements google.golang.org/grpc/credentials
+// PerRPCCredentials and requires transport security, so gRPC refuses to send
+// the credential over an insecure connection.
+type StaticCredentialProvider struct {
+	header string
+	value  string
+}
+
+// NewStaticCredentialProvider builds a StaticCredentialProvider. header and
+// scheme default to "authorization" and "Bearer" when blank. A blank apiKey is
+// an error.
+func NewStaticCredentialProvider(apiKey, header, scheme string) (*StaticCredentialProvider, error) {
+	if apiKey == "" {
+		return nil, errors.New("auth: api key is required")
+	}
+
+	if scheme == "" {
+		scheme = defaultScheme
+	}
+
+	return &StaticCredentialProvider{header: canonicalHeader(header), value: scheme + " " + apiKey}, nil
+}
+
+// GetRequestMetadata returns the fixed credential header for every call.
+func (p *StaticCredentialProvider) GetRequestMetadata(context.Context, ...string) (map[string]string, error) {
+	return map[string]string{p.header: p.value}, nil
+}
+
+// Header returns the metadata header this credential sets.
+func (p *StaticCredentialProvider) Header() string { return p.header }
+
+// RequireTransportSecurity reports that the credential must only travel over a
+// secure transport.
+func (p *StaticCredentialProvider) RequireTransportSecurity() bool { return true }

--- a/internal/auth/static_provider_test.go
+++ b/internal/auth/static_provider_test.go
@@ -1,0 +1,52 @@
+package auth_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/temporalio/temporal-proxy/internal/auth"
+)
+
+func TestStaticCredentialProvider(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty api key is rejected", func(t *testing.T) {
+		t.Parallel()
+		_, err := auth.NewStaticCredentialProvider("", "", "")
+		require.Error(t, err)
+	})
+
+	t.Run("defaults produce a bearer authorization header", func(t *testing.T) {
+		t.Parallel()
+		p, err := auth.NewStaticCredentialProvider("k3y", "", "")
+		require.NoError(t, err)
+
+		md, err := p.GetRequestMetadata(t.Context())
+		require.NoError(t, err)
+		require.Equal(t, map[string]string{"authorization": "Bearer k3y"}, md)
+		require.True(t, p.RequireTransportSecurity())
+	})
+
+	t.Run("custom header and scheme", func(t *testing.T) {
+		t.Parallel()
+		p, err := auth.NewStaticCredentialProvider("k3y", "x-api-key", "Token")
+		require.NoError(t, err)
+
+		md, err := p.GetRequestMetadata(t.Context())
+		require.NoError(t, err)
+		require.Equal(t, map[string]string{"x-api-key": "Token k3y"}, md)
+	})
+
+	t.Run("mixed-case header is lowercased to a canonical metadata key", func(t *testing.T) {
+		t.Parallel()
+		p, err := auth.NewStaticCredentialProvider("k3y", "Authorization", "")
+		require.NoError(t, err)
+
+		require.Equal(t, "authorization", p.Header())
+
+		md, err := p.GetRequestMetadata(t.Context())
+		require.NoError(t, err)
+		require.Equal(t, map[string]string{"authorization": "Bearer k3y"}, md)
+	})
+}

--- a/internal/auth/statictoken.go
+++ b/internal/auth/statictoken.go
@@ -25,15 +25,11 @@ func NewStaticTokenAuthenticator(token, header, scheme string) (*StaticTokenAuth
 		return nil, errors.New("auth: static token is required")
 	}
 
-	if header == "" {
-		header = defaultHeader
-	}
-
 	if scheme == "" {
 		scheme = defaultScheme
 	}
 
-	return &StaticTokenAuthenticator{token: token, header: header, scheme: scheme}, nil
+	return &StaticTokenAuthenticator{token: token, header: canonicalHeader(header), scheme: scheme}, nil
 }
 
 // Authenticate compares the extracted token against the configured value in
@@ -51,3 +47,7 @@ func (a *StaticTokenAuthenticator) Authenticate(_ context.Context, md metadata.M
 
 	return nil
 }
+
+// Header reports the metadata header this authenticator consumes, so
+// StreamServerInterceptor can strip it before forwarding upstream.
+func (a *StaticTokenAuthenticator) Header() string { return a.header }

--- a/internal/config/auth.go
+++ b/internal/config/auth.go
@@ -30,6 +30,20 @@ type (
 		Header    string   `yaml:"header"`
 		Scheme    string   `yaml:"scheme"`
 	}
+
+	// CredentialConfig configures the credential the proxy presents to an
+	// upstream. Static is the only variant today.
+	CredentialConfig struct {
+		Static *StaticCredentialConfig `yaml:"static"`
+	}
+
+	// StaticCredentialConfig injects a fixed API key as a bearer header on every
+	// outbound request to the upstream.
+	StaticCredentialConfig struct {
+		APIKey string `yaml:"apiKey"`
+		Header string `yaml:"header"`
+		Scheme string `yaml:"scheme"`
+	}
 )
 
 // Validate requires exactly one authenticator and checks the selected one.
@@ -79,5 +93,27 @@ func (c *JWKSConfig) Validate() error {
 
 			return nil
 		}),
+	)
+}
+
+// Validate requires the static credential and checks it.
+func (c *CredentialConfig) Validate() error {
+	return validation.Validate(
+		"",
+		func() validation.Errors {
+			if c.Static == nil {
+				return validation.Errors{{Field: "static", Message: "is required"}}
+			}
+			return nil
+		},
+		validation.WhenRules(func() bool { return c.Static != nil }, validation.Nested("static", c.Static)),
+	)
+}
+
+// Validate requires the API key.
+func (c *StaticCredentialConfig) Validate() error {
+	return validation.Validate(
+		"",
+		validation.Field("apiKey", c.APIKey, validation.Required[string]()),
 	)
 }

--- a/internal/config/auth_test.go
+++ b/internal/config/auth_test.go
@@ -71,3 +71,29 @@ func TestAuthConfigValidate(t *testing.T) {
 		})
 	}
 }
+
+func TestCredentialConfigValidate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		cfg     config.CredentialConfig
+		wantErr string
+	}{
+		{"valid static", config.CredentialConfig{Static: &config.StaticCredentialConfig{APIKey: "k"}}, ""},
+		{"missing static", config.CredentialConfig{}, "static"},
+		{"static missing apiKey", config.CredentialConfig{Static: &config.StaticCredentialConfig{}}, "apiKey"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := tt.cfg.Validate()
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}

--- a/internal/config/upstream.go
+++ b/internal/config/upstream.go
@@ -13,9 +13,10 @@ type (
 	// identifies the upstream so routing rules can refer to it; it must be
 	// unique within the config.
 	Upstream struct {
-		Name       string          `yaml:"name"`
-		Listen     ListenConfig    `yaml:",inline"`
-		Namespaces NamespaceConfig `yaml:"namespaces"`
+		Name        string            `yaml:"name"`
+		Listen      ListenConfig      `yaml:",inline"`
+		Namespaces  NamespaceConfig   `yaml:"namespaces"`
+		Credentials *CredentialConfig `yaml:"credentials"`
 	}
 
 	// NamespaceConfig groups the namespace translation rules for an upstream.
@@ -65,6 +66,16 @@ func (u *Upstream) Validate() error {
 			validation.Nested("tls", u.Listen.TLS),
 		),
 		validation.Nested("namespaces", &u.Namespaces),
+		validation.WhenRules(
+			func() bool { return u.Credentials != nil },
+			validation.Nested("credentials", u.Credentials),
+		),
+		validation.WhenRules(
+			func() bool { return u.Credentials != nil && u.Listen.TLS == nil },
+			func() validation.Errors {
+				return validation.Errors{{Field: "credentials", Message: "requires TLS to the upstream"}}
+			},
+		),
 	)
 }
 

--- a/internal/config/upstream_test.go
+++ b/internal/config/upstream_test.go
@@ -1,13 +1,18 @@
 package config_test
 
 import (
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"errors"
+	"math/big"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/temporalio/temporal-proxy/internal/config"
+	"github.com/temporalio/temporal-proxy/pkg/testutil"
 	"github.com/temporalio/temporal-proxy/pkg/validation"
 )
 
@@ -485,4 +490,39 @@ func TestUpstream_Validate(t *testing.T) {
 			require.ElementsMatch(t, tt.wantTuples, got)
 		})
 	}
+}
+
+func TestUpstreamCredentialsRequireTLS(t *testing.T) {
+	t.Parallel()
+
+	base := func() config.Upstream {
+		return config.Upstream{
+			Name:        "u",
+			Listen:      config.ListenConfig{HostPort: "host:7233"},
+			Credentials: &config.CredentialConfig{Static: &config.StaticCredentialConfig{APIKey: "k"}},
+		}
+	}
+
+	t.Run("credentials without tls is rejected", func(t *testing.T) {
+		t.Parallel()
+		u := base()
+		require.ErrorContains(t, u.Validate(), "requires TLS")
+	})
+
+	t.Run("credentials with tls is accepted", func(t *testing.T) {
+		t.Parallel()
+		u := base()
+		// RSA certs are required for TLS validation (ECDSA certs are incompatible
+		// with the RSA-only cipher suites). Generate an RSA cert and a key.
+		certPEM := testutil.RSACert(t, &x509.Certificate{
+			SerialNumber: big.NewInt(1),
+			Subject:      pkix.Name{CommonName: "test"},
+			NotBefore:    time.Now().Add(-time.Hour),
+			NotAfter:     time.Now().Add(time.Hour),
+		})
+		certFile := testutil.WriteFile(t, t.TempDir(), "cert.pem", certPEM)
+		_, keyFile := testutil.GenerateSelfSignedCert(t)
+		u.Listen.TLS = &config.TLSConfig{Cert: certFile, Key: keyFile}
+		require.NoError(t, u.Validate())
+	})
 }

--- a/internal/proxy/fx.go
+++ b/internal/proxy/fx.go
@@ -6,6 +6,7 @@ import (
 
 	"go.uber.org/fx"
 
+	"github.com/temporalio/temporal-proxy/internal/auth"
 	"github.com/temporalio/temporal-proxy/internal/config"
 	"github.com/temporalio/temporal-proxy/internal/transport/creds"
 	"github.com/temporalio/temporal-proxy/pkg/logger"
@@ -30,6 +31,15 @@ var Module = fx.Options(fx.Invoke(func(p ProxyParams) error {
 		}
 
 		opts := []Option{WithCredentials(upstreamCreds(upstream))}
+
+		cp, err := auth.CredentialProviderFor(upstream.Credentials)
+		if err != nil {
+			return fmt.Errorf("invalid credentials for upstream %q: %w", upstream.Name, err)
+		}
+		if cp != nil {
+			opts = append(opts, WithDialOptions(auth.DialOptions(cp)...))
+		}
+
 		if p.Logger != nil {
 			opts = append(opts, WithLogger(p.Logger))
 		}

--- a/internal/proxy/fx_test.go
+++ b/internal/proxy/fx_test.go
@@ -2,6 +2,9 @@ package proxy_test
 
 import (
 	"context"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
 	"testing"
 	"time"
 
@@ -13,6 +16,7 @@ import (
 	"github.com/temporalio/temporal-proxy/internal/config"
 	"github.com/temporalio/temporal-proxy/internal/proxy"
 	"github.com/temporalio/temporal-proxy/pkg/logger"
+	"github.com/temporalio/temporal-proxy/pkg/testutil"
 	"github.com/temporalio/temporal-proxy/pkg/validation"
 )
 
@@ -115,6 +119,39 @@ func TestModuleMultipleUpstreams(t *testing.T) {
 		require.Error(t, err, "upstream %s should not serve after stop", upstream)
 		require.NoError(t, conn.Close())
 	}
+}
+
+// TestModuleWithUpstreamCredentials is construction-only: proxy.New dials
+// lazily, so this asserts the Module accepts a credentialed+TLS upstream without
+// erroring, not that the credential is actually attached. See
+// TestProxyAttachesUpstreamCredential (e2e/upstream_credential_socket_test.go)
+// for proof the key reaches the upstream.
+func TestModuleWithUpstreamCredentials(t *testing.T) {
+	t.Parallel()
+
+	const upstream = "127.0.0.1:47236"
+
+	// The upstream TLS validation path requires an RSA cert (it checks
+	// compatibility with the RSA-only cipher suites in creds.TLS); the key file
+	// only needs to be a validly formatted PEM key, since New never dials
+	// (construction, not a live handshake, is what this test exercises).
+	certPEM := testutil.RSACert(t, &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	})
+	certFile := testutil.WriteFile(t, t.TempDir(), "cert.pem", certPEM)
+	_, keyFile := testutil.GenerateSelfSignedCert(t)
+
+	app := newProxyApp(t, &config.Config{
+		Upstreams: []config.Upstream{{
+			Name:        "workers",
+			Listen:      config.ListenConfig{HostPort: upstream, TLS: &config.TLSConfig{Cert: certFile, Key: keyFile}},
+			Credentials: &config.CredentialConfig{Static: &config.StaticCredentialConfig{APIKey: "k3y"}},
+		}},
+	})
+	require.NoError(t, app.Err())
 }
 
 func TestModuleRejectsTemplatedUpstream(t *testing.T) {

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -37,8 +37,9 @@ type (
 
 	// Options configures a [Server] at construction time.
 	Options struct {
-		creds  Credentials
-		logger logger.Logger
+		creds    Credentials
+		logger   logger.Logger
+		dialOpts []grpc.DialOption
 	}
 
 	// Option configures a [Server] via [New].
@@ -63,7 +64,8 @@ func New(hostPort string, opts ...Option) (*Server, error) {
 		return nil, fmt.Errorf("failed to generate outbound credentials: %w", err)
 	}
 
-	conn, err := grpc.NewClient(hostPort, upstreamCreds)
+	dialOpts := append([]grpc.DialOption{upstreamCreds}, pops.dialOpts...)
+	conn, err := grpc.NewClient(hostPort, dialOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to dial: %s, %w", hostPort, err)
 	}
@@ -109,6 +111,12 @@ func WithCredentials(creds Credentials) Option {
 // WithLogger sets the logger used by the proxy.
 func WithLogger(log logger.Logger) Option {
 	return Option(func(o *Options) { o.logger = log })
+}
+
+// WithDialOptions appends gRPC dial options applied to the outbound connection
+// to the upstream frontend, in addition to the transport credentials.
+func WithDialOptions(opts ...grpc.DialOption) Option {
+	return Option(func(o *Options) { o.dialOpts = append(o.dialOpts, opts...) })
 }
 
 // Start binds the local unix socket and serves until the proxy is stopped or

--- a/internal/proxy/server_test.go
+++ b/internal/proxy/server_test.go
@@ -13,7 +13,9 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/health/grpc_health_v1"
 
+	"github.com/temporalio/temporal-proxy/internal/auth"
 	"github.com/temporalio/temporal-proxy/internal/proxy"
+	"github.com/temporalio/temporal-proxy/internal/transport/creds"
 	"github.com/temporalio/temporal-proxy/internal/transport/socket"
 	"github.com/temporalio/temporal-proxy/pkg/logger"
 )
@@ -45,6 +47,21 @@ func TestNew(t *testing.T) {
 		require.ErrorContains(t, err, "outbound credentials")
 		require.ErrorContains(t, err, "boom")
 	})
+}
+
+func TestNewWithDialOptions(t *testing.T) {
+	t.Parallel()
+
+	cp, err := auth.NewStaticCredentialProvider("k", "", "")
+	require.NoError(t, err)
+
+	svr, err := proxy.New(
+		"127.0.0.1:7233",
+		proxy.WithCredentials(creds.NewClientTLS()),
+		proxy.WithDialOptions(auth.DialOptions(cp)...),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, svr)
 }
 
 func TestServerStartAndStop(t *testing.T) {

--- a/internal/server/fx_test.go
+++ b/internal/server/fx_test.go
@@ -385,6 +385,7 @@ func TestServerEndToEndAuth(t *testing.T) {
 }
 
 func (stubAuthenticator) Authenticate(context.Context, metadata.MD) error { return nil }
+func (stubAuthenticator) Header() string                                  { return "" }
 
 func newTestApp(t *testing.T, opts ...fx.Option) *fx.App {
 	t.Helper()


### PR DESCRIPTION
The proxy secured the connection to each upstream with TLS/mTLS but could not present an application-layer credential, so it could not authenticate itself to upstreams that require one, notably Temporal Cloud namespace endpoints that expect an API key.

Add a per-upstream credential the proxy attaches to every forwarded request. A CredentialProvider supplies gRPC per-RPC metadata; the Static provider sends a configured API key as a bearer header (upstreams[].credentials.static.apiKey) and requires transport security, so the key never travels over an insecure connection. An absent credentials block is fine; a present-but-empty one fails closed.

Inbound authentication and an outbound credential can share the authorization header, so the proxy makes the outbound credential authoritative: the inbound interceptor strips the header it consumed before forwarding, and the outbound dial strips the credential's header from forwarded metadata before adding its own. The upstream therefore sees exactly one value on that header, and a caller's token is never forwarded upstream. End-to-end tests in ./e2e drive the full stack and assert this across configurations.