### PR TITLE
[proxy]: Apply namespace translation between workers and upstreams

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -53,17 +53,19 @@ mise run grpc GetSystemInfo
 
 A response with the upstream's capabilities means the call traversed the proxy and reached the frontend.
 
-To exercise a namespace-scoped call, use `DescribeNamespace`:
+To exercise a namespace-scoped call, use `DescribeNamespace`. Send the local
+alias; the proxy rewrites it to the upstream name before forwarding, per the matched upstream's
+`upstream.namespaces.rules` in `dev/config.yaml`:
 
 ```sh
-mise run grpc DescribeNamespace '{"namespace":"ns1.remote"}'
+mise run grpc DescribeNamespace '{"namespace":"ns1"}'
 ```
 
-> [!IMPORTANT]
+> [!NOTE]
 >
-> namespace names are currently forwarded verbatim - the `upstream.namespaces.rules` in `dev/config.yaml` are parsed and
-> validated but not yet applied. Until translation is wired up, you must send the real upstream name (`ns1.remote`), not
-> the local alias (`ns1`). Sending `ns1` returns `NotFound`.
+> The default upstream applies `suffix: .remote`, so the local alias `ns1` reaches the frontend as `ns1.remote`, and the
+> name in the response is translated back to `ns1`. The `ns3 -> ns2.remote` override maps the local alias `ns3` to
+> `ns2.remote` upstream. `cluster-3` configures no rules, so calls routed there are forwarded verbatim.
 
 ### Confirming per-request routing
 

--- a/cmd/proxy/serve.go
+++ b/cmd/proxy/serve.go
@@ -7,6 +7,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/urfave/cli/v3"
 	"go.uber.org/fx"
+	"google.golang.org/protobuf/reflect/protoreflect"
 
 	"github.com/temporalio/temporal-proxy/internal/auth"
 	"github.com/temporalio/temporal-proxy/internal/config"
@@ -61,6 +62,9 @@ func serve() *cli.Command {
 					fx.Annotate(cmd.String("config"), config.ConfigFileTag),
 					fx.Annotate(cmd.String("metrics-addr"), metrics.AddrTag),
 					fx.Annotate(cmd.String("metrics-namespace"), metrics.NamespaceTag),
+					// Services whose request and response types have their namespace
+					// translation plans warmed at startup.
+					[]protoreflect.FullName{"temporal.api.workflowservice.v1.WorkflowService"},
 				),
 				fx.Provide(
 					func() logger.Logger { return log },

--- a/e2e/harness_test.go
+++ b/e2e/harness_test.go
@@ -114,10 +114,11 @@ func newFullApp(t *testing.T, cfg *config.Config) *fx.App {
 	)
 }
 
-// newProxyApp is a minimal, proxy.Module-only fx app for the socket-level
-// test in this package. internal/proxy/fx_test.go has its own copy (with
-// support for extra fx.Options) that its unit tests still depend on; this is
-// a deliberate small duplication rather than an exported helper, so the two
+// newProxyApp is a minimal fx app for the socket-level test in this package: it
+// wires proxy.Module plus protoutil.Module (which provides the Translator
+// proxy.Module requires). internal/proxy/fx_test.go has its own copy (with
+// support for extra fx.Options) that its unit tests still depend on; this is a
+// deliberate small duplication rather than an exported helper, so the two
 // packages stay decoupled.
 func newProxyApp(t *testing.T, cfg *config.Config) *fx.App {
 	t.Helper()
@@ -125,6 +126,7 @@ func newProxyApp(t *testing.T, cfg *config.Config) *fx.App {
 	return fx.New(
 		fx.Supply(fx.Annotate(t.Context(), fx.As(new(context.Context)))),
 		fx.Supply(cfg),
+		protoutil.Module,
 		proxy.Module,
 		fx.NopLogger,
 	)

--- a/internal/config/upstream.go
+++ b/internal/config/upstream.go
@@ -156,6 +156,13 @@ func (r *NamespaceRules) Validate() error {
 	return validation.Validate("", rules...)
 }
 
+// Configured reports whether the rules translate anything. When false the
+// prefix, suffix, and overrides are all empty and Remote and Local are identity,
+// so callers can skip installing translation entirely.
+func (r *NamespaceRules) Configured() bool {
+	return r.Prefix != "" || r.Suffix != "" || len(r.Overrides) > 0
+}
+
 // Validate requires both the local and remote namespace names.
 func (m *NamespaceMapping) Validate() error {
 	return validation.Validate(

--- a/internal/config/upstream_test.go
+++ b/internal/config/upstream_test.go
@@ -526,3 +526,25 @@ func TestUpstreamCredentialsRequireTLS(t *testing.T) {
 		require.NoError(t, u.Validate())
 	})
 }
+
+func TestNamespaceRulesConfigured(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		rules config.NamespaceRules
+		want  bool
+	}{
+		{"empty", config.NamespaceRules{}, false},
+		{"prefix set", config.NamespaceRules{Prefix: "acme-"}, true},
+		{"suffix set", config.NamespaceRules{Suffix: "-prod"}, true},
+		{"override set", config.NamespaceRules{Overrides: []config.NamespaceMapping{{Local: "a", Remote: "b"}}}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, tt.rules.Configured())
+		})
+	}
+}

--- a/internal/protoutil/completeness_test.go
+++ b/internal/protoutil/completeness_test.go
@@ -1,0 +1,84 @@
+package protoutil
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	_ "go.temporal.io/api/workflowservice/v1"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+)
+
+// completenessServices lists the gRPC services the guard checks. It should
+// cover every service the proxy translates (see cmd/proxy). Each service's
+// package must be blank-imported above so its descriptors resolve.
+var completenessServices = []protoreflect.FullName{
+	"temporal.api.workflowservice.v1.WorkflowService",
+}
+
+func TestRuleSetCoversServices(t *testing.T) {
+	t.Parallel()
+
+	seen := map[protoreflect.FullName]bool{}
+	var offenders []string
+
+	var walk func(md protoreflect.MessageDescriptor)
+	walk = func(md protoreflect.MessageDescriptor) {
+		if seen[md.FullName()] {
+			return
+		}
+		seen[md.FullName()] = true
+
+		fields := md.Fields()
+		for i := 0; i < fields.Len(); i++ {
+			fd := fields.Get(i)
+			if suspiciousButUnclassified(md, fd) {
+				offenders = append(offenders, string(md.FullName())+"."+string(fd.Name()))
+			}
+
+			if sub := childMessage(fd); sub != nil {
+				walk(sub)
+			}
+		}
+	}
+
+	for _, name := range completenessServices {
+		d, err := protoregistry.GlobalFiles.FindDescriptorByName(name)
+		require.NoError(t, err, "service %q not registered; add a blank import for its package", name)
+
+		sd, ok := d.(protoreflect.ServiceDescriptor)
+		require.True(t, ok, "%q resolved to a non-service descriptor", name)
+
+		methods := sd.Methods()
+		for i := 0; i < methods.Len(); i++ {
+			m := methods.Get(i)
+			walk(m.Input())
+			walk(m.Output())
+		}
+	}
+
+	require.Empty(t, offenders,
+		"these string fields look like namespace names but the rule set does not classify them; "+
+			"either extend the suffix rule / namespaceNameOverrides, or confirm they are not namespaces:\n%s",
+		strings.Join(offenders, "\n"))
+}
+
+// suspiciousButUnclassified reports whether fd looks like it could carry a
+// namespace name yet isNamespaceName does not translate it. A string field is
+// suspicious when its name mentions "namespace" (but is not a "*namespace_id"
+// UUID) or when it is named "name" on a message type whose own name mentions
+// "Namespace". Any such field must be either translated by the rule set or added
+// to an explicit, reviewed exclusion.
+func suspiciousButUnclassified(md protoreflect.MessageDescriptor, fd protoreflect.FieldDescriptor) bool {
+	if fd.Kind() != protoreflect.StringKind || isNamespaceName(md, fd) {
+		return false
+	}
+
+	name := string(fd.Name())
+	if strings.Contains(name, "namespace") && !strings.HasSuffix(name, "namespace_id") {
+		return true
+	}
+
+	return name == "name" && strings.Contains(strings.ToLower(string(md.Name())), "namespace")
+}

--- a/internal/protoutil/doc.go
+++ b/internal/protoutil/doc.go
@@ -3,9 +3,17 @@
 // concrete message type for a given method.
 //
 // [Extractor] reads the namespace from an encoded request by resolving its
-// message type from a descriptor registry and a type registry. [Module] wires
-// an Extractor into an fx application, defaulting those registries to
+// message type from a descriptor registry and a type registry.
+//
+// [Translator] rewrites namespace names inside decoded messages, driven by a
+// direction function, using a per-message-type plan cache that WarmService
+// pre-populates. The package is free of any gRPC dependency; callers apply a
+// Translator on a connection themselves.
+//
+// [Module] wires both an Extractor and a Translator into an fx application,
+// defaulting the descriptor and type registries to
 // [google.golang.org/protobuf/reflect/protoregistry.GlobalFiles] and
 // [google.golang.org/protobuf/reflect/protoregistry.GlobalTypes] when they are
-// not supplied.
+// not supplied, and warming the translator for the services the application
+// lists in ExtractorParams.TranslatorServices.
 package protoutil

--- a/internal/protoutil/fx.go
+++ b/internal/protoutil/fx.go
@@ -1,34 +1,65 @@
 package protoutil
 
 import (
+	"fmt"
+
 	"go.uber.org/fx"
+	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/reflect/protoregistry"
 )
 
-// Module provides an [*Extractor]. Files and Types default to the global
-// protobuf registries when the application supplies neither, so most consumers
-// wire this module with no extra dependencies; supplying either (for example in
-// tests) overrides the corresponding default.
-var Module = fx.Options(fx.Provide(
-	func(p ExtractorParams) *Extractor {
-		if p.Files == nil {
-			p.Files = protoregistry.GlobalFiles
+// Module provides an [*Extractor] and a [*Translator], and warms the
+// translator's plan cache for every service in TranslatorServices at startup.
+// Files and Types default to the global protobuf registries when the
+// application supplies neither. TranslatorServices is optional: when empty, no
+// plans are pre-populated and the translator builds them lazily on first use.
+var Module = fx.Options(
+	fx.Provide(
+		func(p ExtractorParams) *Translator {
+			return NewTranslator(filesOrGlobal(p.Files))
+		},
+		func(p ExtractorParams) *Extractor {
+			return NewExtractor(filesOrGlobal(p.Files), typesOrGlobal(p.Types))
+		},
+	),
+	fx.Invoke(func(t *Translator, p ExtractorParams) error {
+		for _, svc := range p.TranslatorServices {
+			if err := t.WarmService(svc); err != nil {
+				return fmt.Errorf("failed to set up translations for %s: %w", svc, err)
+			}
 		}
 
-		if p.Types == nil {
-			p.Types = protoregistry.GlobalTypes
-		}
+		return nil
+	}),
+)
 
-		return NewExtractor(p.Files, p.Types)
-	},
-))
-
-// ExtractorParams collects the dependencies used to build the [*Extractor].
-// Both are optional: when absent, Module falls back to the global protobuf
-// registries.
+// ExtractorParams collects the dependencies used to build the [*Extractor] and
+// the [Translator]. Files and Types are optional: when absent, Module falls back
+// to the global protobuf registries. TranslatorServices is optional and lists
+// the gRPC services whose request and response types are pre-warmed at startup.
 type ExtractorParams struct {
 	fx.In
 
-	Files Files `optional:"true"`
-	Types Types `optional:"true"`
+	Files              Files                   `optional:"true"`
+	Types              Types                   `optional:"true"`
+	TranslatorServices []protoreflect.FullName `optional:"true"`
+}
+
+// filesOrGlobal returns files, or the global descriptor registry when files is
+// nil.
+func filesOrGlobal(files Files) Files {
+	if files == nil {
+		return protoregistry.GlobalFiles
+	}
+
+	return files
+}
+
+// typesOrGlobal returns types, or the global type registry when types is nil.
+func typesOrGlobal(types Types) Types {
+	if types == nil {
+		return protoregistry.GlobalTypes
+	}
+
+	return types
 }

--- a/internal/protoutil/fx_test.go
+++ b/internal/protoutil/fx_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.uber.org/fx"
+	"google.golang.org/protobuf/reflect/protoreflect"
 
 	"github.com/temporalio/temporal-proxy/internal/protoutil"
 )
@@ -43,5 +44,31 @@ func TestModule(t *testing.T) {
 		require.NoError(t, app.Err())
 		require.NotNil(t, ex)
 		require.Equal(t, "", ex.Namespace(startMethod, start))
+	})
+
+	t.Run("provides a translator warmed for the supplied services", func(t *testing.T) {
+		t.Parallel()
+
+		var tr *protoutil.Translator
+		app := fx.New(
+			fx.Supply([]protoreflect.FullName{wfService}),
+			protoutil.Module,
+			fx.Populate(&tr),
+			fx.NopLogger,
+		)
+		require.NoError(t, app.Err())
+		require.NotNil(t, tr)
+		require.True(t, tr.IsWarm("temporal.api.workflowservice.v1.StartWorkflowExecutionRequest"))
+	})
+
+	t.Run("warming an unknown service fails startup", func(t *testing.T) {
+		t.Parallel()
+
+		app := fx.New(
+			fx.Supply([]protoreflect.FullName{"does.not.Exist"}),
+			protoutil.Module,
+			fx.NopLogger,
+		)
+		require.Error(t, app.Err())
 	})
 }

--- a/internal/protoutil/plan.go
+++ b/internal/protoutil/plan.go
@@ -1,0 +1,197 @@
+package protoutil
+
+import (
+	"strings"
+
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+// namespaceNameOverrides lists namespace-name string fields whose names do not
+// end in "namespace" and so are missed by the suffix rule. Keyed by the fully
+// qualified message type, then by field name. NamespaceInfo.name carries the
+// namespace name returned by DescribeNamespace and ListNamespaces, both of which
+// are WorkflowService methods that flow through the proxy.
+var namespaceNameOverrides = map[protoreflect.FullName]map[protoreflect.Name]bool{
+	"temporal.api.namespace.v1.NamespaceInfo": {"name": true},
+}
+
+type (
+	// nsPlan is the pre-computed set of namespace-name locations in a single
+	// message type: direct string fields to translate, and message-typed fields
+	// whose own plan is non-empty. A plan with neither is empty, marking a type
+	// that carries no namespace anywhere and can be skipped entirely.
+	nsPlan struct {
+		names    []protoreflect.FieldDescriptor
+		children []nsChild
+	}
+
+	// nsChild is a message-, repeated-message-, or map-valued field whose value
+	// type carries a namespace somewhere, paired with the plan for that value type.
+	nsChild struct {
+		field protoreflect.FieldDescriptor
+		plan  *nsPlan
+	}
+)
+
+// empty reports whether the plan has no namespace locations at all.
+func (p *nsPlan) empty() bool {
+	return len(p.names) == 0 && len(p.children) == 0
+}
+
+// apply walks m following the plan and rewrites every namespace-name value with
+// fn. Empty string values are left untouched so an unset namespace is not
+// wrapped. Fields absent from m are skipped.
+func (p *nsPlan) apply(m protoreflect.Message, fn func(string) string) {
+	for _, fd := range p.names {
+		if fd.IsList() {
+			list := m.Get(fd).List()
+			for i := 0; i < list.Len(); i++ {
+				if s := list.Get(i).String(); s != "" {
+					list.Set(i, protoreflect.ValueOfString(fn(s)))
+				}
+			}
+			continue
+		}
+
+		if !m.Has(fd) {
+			continue
+		}
+		if s := m.Get(fd).String(); s != "" {
+			m.Set(fd, protoreflect.ValueOfString(fn(s)))
+		}
+	}
+
+	for _, c := range p.children {
+		if !m.Has(c.field) {
+			continue
+		}
+
+		v := m.Get(c.field)
+		switch {
+		case c.field.IsMap():
+			v.Map().Range(func(_ protoreflect.MapKey, val protoreflect.Value) bool {
+				c.plan.apply(val.Message(), fn)
+				return true
+			})
+		case c.field.IsList():
+			list := v.List()
+			for i := 0; i < list.Len(); i++ {
+				c.plan.apply(list.Get(i).Message(), fn)
+			}
+		default:
+			c.plan.apply(v.Message(), fn)
+		}
+	}
+}
+
+// buildPlan computes the plan for md. memo breaks recursive type graphs and is
+// shared across the whole build; callers pass a fresh memo per top-level build.
+// It links every message child first, then prunes edges that carry no namespace.
+func buildPlan(md protoreflect.MessageDescriptor, memo map[protoreflect.FullName]*nsPlan) *nsPlan {
+	root := buildNode(md, memo)
+	pruneDead(memo)
+	return root
+}
+
+// buildNode builds the raw plan graph, recording md's plan in memo before its
+// fields are walked so a type that transitively contains itself references the
+// same plan instead of recursing forever. Every message-typed field is linked
+// unconditionally here; pruneDead removes the ones that carry no namespace.
+func buildNode(md protoreflect.MessageDescriptor, memo map[protoreflect.FullName]*nsPlan) *nsPlan {
+	if p, ok := memo[md.FullName()]; ok {
+		return p
+	}
+
+	p := &nsPlan{}
+	memo[md.FullName()] = p
+
+	fields := md.Fields()
+	for i := 0; i < fields.Len(); i++ {
+		fd := fields.Get(i)
+
+		if fd.Kind() == protoreflect.StringKind && isNamespaceName(md, fd) {
+			p.names = append(p.names, fd)
+			continue
+		}
+
+		if sub := childMessage(fd); sub != nil {
+			p.children = append(p.children, nsChild{field: fd, plan: buildNode(sub, memo)})
+		}
+	}
+
+	return p
+}
+
+// pruneDead removes child edges that lead to no namespace, computed as a
+// fixpoint so cyclic type graphs converge: a plan is live when it has a name
+// field or a live child. Dead nodes are left empty, so apply skips them and the
+// zero-cost fast path is preserved.
+func pruneDead(memo map[protoreflect.FullName]*nsPlan) {
+	live := make(map[*nsPlan]bool, len(memo))
+	for _, p := range memo {
+		if len(p.names) > 0 {
+			live[p] = true
+		}
+	}
+
+	for changed := true; changed; {
+		changed = false
+		for _, p := range memo {
+			if live[p] {
+				continue
+			}
+			for _, c := range p.children {
+				if live[c.plan] {
+					live[p] = true
+					changed = true
+					break
+				}
+			}
+		}
+	}
+
+	for _, p := range memo {
+		kept := p.children[:0]
+		for _, c := range p.children {
+			if live[c.plan] {
+				kept = append(kept, c)
+			}
+		}
+		p.children = kept
+	}
+}
+
+// childMessage returns the message descriptor a field recurses into: the element
+// type for a repeated message, the value type for a map with a message value, or
+// the message type for a singular message field. It returns nil for scalar
+// fields and for maps whose values are not messages.
+func childMessage(fd protoreflect.FieldDescriptor) protoreflect.MessageDescriptor {
+	if fd.IsMap() {
+		if v := fd.MapValue(); v.Kind() == protoreflect.MessageKind {
+			return v.Message()
+		}
+		return nil
+	}
+
+	if fd.Kind() == protoreflect.MessageKind {
+		return fd.Message()
+	}
+
+	return nil
+}
+
+// isNamespaceName reports whether fd (declared on md) is a string field that
+// carries a namespace name. A field carries a namespace name when its proto name
+// ends in "namespace" (which excludes "*namespace_id", since those end in "_id"),
+// or when an explicit override lists it. Only string fields qualify.
+func isNamespaceName(md protoreflect.MessageDescriptor, fd protoreflect.FieldDescriptor) bool {
+	if fd.Kind() != protoreflect.StringKind {
+		return false
+	}
+
+	if strings.HasSuffix(string(fd.Name()), "namespace") {
+		return true
+	}
+
+	return namespaceNameOverrides[md.FullName()][fd.Name()]
+}

--- a/internal/protoutil/translate.go
+++ b/internal/protoutil/translate.go
@@ -1,0 +1,84 @@
+package protoutil
+
+import (
+	"fmt"
+	"sync"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+// Translator rewrites namespace names inside decoded protobuf messages. It
+// caches a translation plan per message type, so repeat translations of the
+// same type skip descriptor traversal. Plans may be pre-populated with
+// WarmService or built lazily on first use. A Translator is safe for concurrent
+// use.
+type Translator struct {
+	files Files
+	plans sync.Map // protoreflect.FullName -> *nsPlan
+}
+
+// NewTranslator returns a Translator that resolves service descriptors for
+// warming through files. Production callers pass protoregistry.GlobalFiles.
+func NewTranslator(files Files) *Translator {
+	return &Translator{files: files}
+}
+
+// WarmService pre-computes and caches the plan for every method input and output
+// type of the named gRPC service, so no request pays first-touch plan
+// construction. It fails when the name does not resolve to a service.
+func (t *Translator) WarmService(name protoreflect.FullName) error {
+	d, err := t.files.FindDescriptorByName(name)
+	if err != nil {
+		return fmt.Errorf("protoutil: resolve service %q: %w", name, err)
+	}
+
+	sd, ok := d.(protoreflect.ServiceDescriptor)
+	if !ok {
+		return fmt.Errorf("protoutil: %q is not a service", name)
+	}
+
+	methods := sd.Methods()
+	for i := 0; i < methods.Len(); i++ {
+		m := methods.Get(i)
+		t.planFor(m.Input())
+		t.planFor(m.Output())
+	}
+
+	return nil
+}
+
+// Translate rewrites every namespace name in m using fn. It is a no-op when m is
+// nil, invalid, or carries no namespace field. fn maps a namespace name to its
+// translated form (local to remote, or remote to local).
+func (t *Translator) Translate(m proto.Message, fn func(string) string) {
+	if m == nil || fn == nil {
+		return
+	}
+
+	msg := m.ProtoReflect()
+	if !msg.IsValid() {
+		return
+	}
+
+	if p := t.planFor(msg.Descriptor()); !p.empty() {
+		p.apply(msg, fn)
+	}
+}
+
+// IsWarm reports whether a plan for the named message type is already cached.
+func (t *Translator) IsWarm(name protoreflect.FullName) bool {
+	_, ok := t.plans.Load(name)
+	return ok
+}
+
+// planFor returns the cached plan for md, building and caching it on a miss.
+func (t *Translator) planFor(md protoreflect.MessageDescriptor) *nsPlan {
+	if v, ok := t.plans.Load(md.FullName()); ok {
+		return v.(*nsPlan)
+	}
+
+	p := buildPlan(md, map[protoreflect.FullName]*nsPlan{})
+	actual, _ := t.plans.LoadOrStore(md.FullName(), p)
+	return actual.(*nsPlan)
+}

--- a/internal/protoutil/translate_test.go
+++ b/internal/protoutil/translate_test.go
@@ -1,0 +1,113 @@
+package protoutil_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	failurepb "go.temporal.io/api/failure/v1"
+	historypb "go.temporal.io/api/history/v1"
+	namespacepb "go.temporal.io/api/namespace/v1"
+	"go.temporal.io/api/workflowservice/v1"
+	"google.golang.org/protobuf/reflect/protoregistry"
+
+	"github.com/temporalio/temporal-proxy/internal/protoutil"
+)
+
+func TestTranslatorTranslate(t *testing.T) {
+	t.Parallel()
+
+	tr := protoutil.NewTranslator(protoregistry.GlobalFiles)
+	req := &workflowservice.StartWorkflowExecutionRequest{Namespace: "local"}
+	tr.Translate(req, remote)
+	require.Equal(t, "remote-local", req.Namespace)
+}
+
+func TestTranslatorNilMessageIsNoop(t *testing.T) {
+	t.Parallel()
+
+	tr := protoutil.NewTranslator(protoregistry.GlobalFiles)
+	var req *workflowservice.StartWorkflowExecutionRequest
+	require.NotPanics(t, func() { tr.Translate(req, remote) })
+}
+
+func TestTranslatorWarmServicePopulatesCache(t *testing.T) {
+	t.Parallel()
+
+	tr := protoutil.NewTranslator(protoregistry.GlobalFiles)
+	require.NoError(t, tr.WarmService("temporal.api.workflowservice.v1.WorkflowService"))
+
+	// After warming, translating a request message must not need to build a plan;
+	// IsWarm reports whether the type's plan is already cached.
+	req := &workflowservice.StartWorkflowExecutionRequest{}
+	require.True(t, tr.IsWarm(req.ProtoReflect().Descriptor().FullName()))
+}
+
+func TestTranslatorWarmServiceUnknownName(t *testing.T) {
+	t.Parallel()
+
+	tr := protoutil.NewTranslator(protoregistry.GlobalFiles)
+	require.Error(t, tr.WarmService("does.not.Exist"))
+}
+
+func TestTranslateLeavesEmptyNamespace(t *testing.T) {
+	t.Parallel()
+
+	tr := protoutil.NewTranslator(protoregistry.GlobalFiles)
+	req := &workflowservice.StartWorkflowExecutionRequest{}
+	tr.Translate(req, remote)
+	require.Equal(t, "", req.Namespace, "an unset namespace must not be wrapped")
+}
+
+func TestTranslateNestedOverrideAndRepeated(t *testing.T) {
+	t.Parallel()
+
+	tr := protoutil.NewTranslator(protoregistry.GlobalFiles)
+	resp := &workflowservice.ListNamespacesResponse{
+		Namespaces: []*workflowservice.DescribeNamespaceResponse{
+			{NamespaceInfo: &namespacepb.NamespaceInfo{Name: "one", Id: "id-1"}},
+			{NamespaceInfo: &namespacepb.NamespaceInfo{Name: "two"}},
+		},
+	}
+	tr.Translate(resp, remote)
+	require.Equal(t, "remote-one", resp.Namespaces[0].NamespaceInfo.Name)
+	require.Equal(t, "id-1", resp.Namespaces[0].NamespaceInfo.Id, "namespace id must not change")
+	require.Equal(t, "remote-two", resp.Namespaces[1].NamespaceInfo.Name)
+}
+
+func TestTranslateDeepHistoryEventLeavesNamespaceId(t *testing.T) {
+	t.Parallel()
+
+	tr := protoutil.NewTranslator(protoregistry.GlobalFiles)
+	evt := &historypb.HistoryEvent{
+		Attributes: &historypb.HistoryEvent_StartChildWorkflowExecutionInitiatedEventAttributes{
+			StartChildWorkflowExecutionInitiatedEventAttributes: &historypb.StartChildWorkflowExecutionInitiatedEventAttributes{
+				Namespace:   "child-local",
+				NamespaceId: "uuid-keep",
+			},
+		},
+	}
+	tr.Translate(evt, remote)
+	attrs := evt.GetStartChildWorkflowExecutionInitiatedEventAttributes()
+	require.Equal(t, "remote-child-local", attrs.Namespace)
+	require.Equal(t, "uuid-keep", attrs.NamespaceId)
+}
+
+func TestTranslateRecursiveFailureCause(t *testing.T) {
+	t.Parallel()
+
+	tr := protoutil.NewTranslator(protoregistry.GlobalFiles)
+	f := &failurepb.Failure{
+		Message: "outer",
+		Cause: &failurepb.Failure{
+			FailureInfo: &failurepb.Failure_ChildWorkflowExecutionFailureInfo{
+				ChildWorkflowExecutionFailureInfo: &failurepb.ChildWorkflowExecutionFailureInfo{
+					Namespace: "child-local",
+				},
+			},
+		},
+	}
+	tr.Translate(f, remote)
+	require.Equal(t, "remote-child-local", f.Cause.GetChildWorkflowExecutionFailureInfo().Namespace)
+}
+
+func remote(s string) string { return "remote-" + s }

--- a/internal/proxy/fx.go
+++ b/internal/proxy/fx.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/temporalio/temporal-proxy/internal/auth"
 	"github.com/temporalio/temporal-proxy/internal/config"
+	"github.com/temporalio/temporal-proxy/internal/protoutil"
 	"github.com/temporalio/temporal-proxy/internal/transport/creds"
 	"github.com/temporalio/temporal-proxy/pkg/logger"
 )
@@ -31,6 +32,11 @@ var Module = fx.Options(fx.Invoke(func(p ProxyParams) error {
 		}
 
 		opts := []Option{WithCredentials(upstreamCreds(upstream))}
+
+		rules := &upstream.Namespaces.Rules
+		if rules.Configured() {
+			opts = append(opts, WithDialOptions(translationDialOptions(p.Translator, rules.Remote, rules.Local)...))
+		}
 
 		cp, err := auth.CredentialProviderFor(upstream.Credentials)
 		if err != nil {
@@ -70,16 +76,18 @@ var Module = fx.Options(fx.Invoke(func(p ProxyParams) error {
 }))
 
 // ProxyParams collects the fx-provided dependencies needed to construct and run
-// the proxy [Server]. Context and Config are required; Logger is optional and
-// falls back to the default used by [New] when not supplied.
+// the proxy [Server]. Context, Config, and Translator are required; Logger is
+// optional and falls back to the default used by [New] when not supplied.
+// [protoutil.Module] provides the Translator in the assembled application.
 type ProxyParams struct {
 	fx.In
 	Lifecycle  fx.Lifecycle
 	Shutdowner fx.Shutdowner
 
 	// Required values
-	Context context.Context
-	Config  *config.Config
+	Context    context.Context
+	Config     *config.Config
+	Translator *protoutil.Translator
 
 	// Optional values
 	Logger logger.Logger `optional:"true"`

--- a/internal/proxy/fx_test.go
+++ b/internal/proxy/fx_test.go
@@ -14,6 +14,7 @@ import (
 	"google.golang.org/grpc/health/grpc_health_v1"
 
 	"github.com/temporalio/temporal-proxy/internal/config"
+	"github.com/temporalio/temporal-proxy/internal/protoutil"
 	"github.com/temporalio/temporal-proxy/internal/proxy"
 	"github.com/temporalio/temporal-proxy/pkg/logger"
 	"github.com/temporalio/temporal-proxy/pkg/testutil"
@@ -167,12 +168,50 @@ func TestModuleRejectsTemplatedUpstream(t *testing.T) {
 	require.ErrorContains(t, app.Err(), "templated")
 }
 
+func TestModuleInstallsNamespaceTranslation(t *testing.T) {
+	t.Parallel()
+
+	const upstream = "127.0.0.1:47241"
+
+	// An upstream that configures namespace rules wires translation from the
+	// injected Translator and must still build and serve.
+	app := newProxyApp(t, &config.Config{
+		Upstreams: []config.Upstream{{
+			Name:       "primary",
+			Listen:     config.ListenConfig{HostPort: upstream},
+			Namespaces: config.NamespaceConfig{Rules: config.NamespaceRules{Suffix: ".remote"}},
+		}},
+	})
+	require.NoError(t, app.Err())
+
+	startServeStop(t, app, upstream)
+}
+
+func TestModuleRequiresTranslator(t *testing.T) {
+	t.Parallel()
+
+	// proxy.Module requires a *protoutil.Translator. Without protoutil.Module
+	// (or another provider) the app must fail to build rather than run without
+	// one.
+	app := fx.New(
+		fx.Supply(fx.Annotate(t.Context(), fx.As(new(context.Context)))),
+		fx.Supply(&config.Config{
+			Upstreams: []config.Upstream{{Name: "primary", Listen: config.ListenConfig{HostPort: "127.0.0.1:47242"}}},
+		}),
+		proxy.Module,
+		fx.NopLogger,
+	)
+
+	require.Error(t, app.Err())
+}
+
 func newProxyApp(t *testing.T, cfg *config.Config, opts ...fx.Option) *fx.App {
 	t.Helper()
 
 	base := []fx.Option{
 		fx.Supply(fx.Annotate(t.Context(), fx.As(new(context.Context)))),
 		fx.Supply(cfg),
+		protoutil.Module,
 		proxy.Module,
 		fx.NopLogger,
 	}

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -65,6 +65,7 @@ func New(hostPort string, opts ...Option) (*Server, error) {
 	}
 
 	dialOpts := append([]grpc.DialOption{upstreamCreds}, pops.dialOpts...)
+
 	conn, err := grpc.NewClient(hostPort, dialOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to dial: %s, %w", hostPort, err)
@@ -114,7 +115,8 @@ func WithLogger(log logger.Logger) Option {
 }
 
 // WithDialOptions appends gRPC dial options applied to the outbound connection
-// to the upstream frontend, in addition to the transport credentials.
+// to the upstream frontend, in addition to the transport credentials. Outbound
+// credentials and namespace translation are both wired this way.
 func WithDialOptions(opts ...grpc.DialOption) Option {
 	return Option(func(o *Options) { o.dialOpts = append(o.dialOpts, opts...) })
 }

--- a/internal/proxy/translation.go
+++ b/internal/proxy/translation.go
@@ -1,0 +1,159 @@
+package proxy
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+
+	"github.com/temporalio/temporal-proxy/internal/protoutil"
+)
+
+// translatingClientStream wraps a ClientStream to translate sent messages local
+// to remote and received messages remote to local.
+type translatingClientStream struct {
+	grpc.ClientStream
+
+	translator *protoutil.Translator
+	out        func(string) string
+	in         func(string) string
+}
+
+// SendMsg translates the outbound message local to remote before sending.
+func (s *translatingClientStream) SendMsg(m any) error {
+	if pm, ok := m.(proto.Message); ok {
+		s.translator.Translate(pm, s.out)
+	}
+
+	return s.ClientStream.SendMsg(m)
+}
+
+// RecvMsg translates the inbound message remote to local after receiving, and
+// translates typed status details on a terminal error.
+func (s *translatingClientStream) RecvMsg(m any) error {
+	if err := s.ClientStream.RecvMsg(m); err != nil {
+		return translateStatusError(s.translator, err, s.in)
+	}
+
+	if pm, ok := m.(proto.Message); ok {
+		s.translator.Translate(pm, s.in)
+	}
+
+	return nil
+}
+
+// translationDialOptions returns the dial options that install namespace
+// translation on the outbound connection: t rewrites message bodies and typed
+// error details, out maps local names to remote on the way out, and in maps
+// remote names to local on the way back.
+func translationDialOptions(t *protoutil.Translator, out, in func(string) string) []grpc.DialOption {
+	return []grpc.DialOption{
+		grpc.WithChainUnaryInterceptor(unaryClientInterceptor(t, out, in)),
+		grpc.WithChainStreamInterceptor(streamClientInterceptor(t, out, in)),
+	}
+}
+
+// unaryClientInterceptor translates the request local to remote before the call
+// and the reply remote to local after it. On error it translates the namespace
+// names in any typed status details remote to local. out maps local to remote;
+// in maps remote to local.
+func unaryClientInterceptor(t *protoutil.Translator, out, in func(string) string) grpc.UnaryClientInterceptor {
+	return func(
+		ctx context.Context,
+		method string,
+		req, reply any,
+		cc *grpc.ClientConn,
+		invoker grpc.UnaryInvoker,
+		opts ...grpc.CallOption,
+	) error {
+		if m, ok := req.(proto.Message); ok {
+			t.Translate(m, out)
+		}
+
+		if err := invoker(ctx, method, req, reply, cc, opts...); err != nil {
+			return translateStatusError(t, err, in)
+		}
+
+		if m, ok := reply.(proto.Message); ok {
+			t.Translate(m, in)
+		}
+
+		return nil
+	}
+}
+
+// streamClientInterceptor wraps the stream so each sent message is translated
+// local to remote and each received message remote to local. out maps local to
+// remote; in maps remote to local.
+func streamClientInterceptor(t *protoutil.Translator, out, in func(string) string) grpc.StreamClientInterceptor {
+	return func(
+		ctx context.Context,
+		desc *grpc.StreamDesc,
+		cc *grpc.ClientConn,
+		method string,
+		streamer grpc.Streamer,
+		opts ...grpc.CallOption,
+	) (grpc.ClientStream, error) {
+		cs, err := streamer(ctx, desc, cc, method, opts...)
+		if err != nil {
+			return nil, translateStatusError(t, err, in)
+		}
+
+		return &translatingClientStream{ClientStream: cs, translator: t, out: out, in: in}, nil
+	}
+}
+
+// translateStatusError rewrites namespace names carried in the typed status
+// details of a gRPC error using fn. Errors that do not carry a gRPC status, and
+// the status code and free-text message, are returned unchanged; only typed
+// details are translated. A nil error returns nil.
+func translateStatusError(t *protoutil.Translator, err error, fn func(string) string) error {
+	if err == nil {
+		return nil
+	}
+
+	st, ok := status.FromError(err)
+	if !ok {
+		return err
+	}
+
+	pb := st.Proto()
+	if pb == nil || len(pb.Details) == 0 {
+		return err
+	}
+
+	changed := false
+	for i, detail := range pb.Details {
+		msg, uerr := detail.UnmarshalNew()
+		if uerr != nil {
+			continue
+		}
+
+		original := proto.Clone(msg)
+		t.Translate(msg, fn)
+		if proto.Equal(original, msg) {
+			// This detail carried no namespace; leave the original Any in place.
+			continue
+		}
+
+		repacked, perr := anypb.New(msg)
+		if perr != nil {
+			continue
+		}
+
+		// Assign by index; do not struct-copy the Any (it embeds a sync.Mutex
+		// via MessageState, which go vet copylocks rejects).
+		pb.Details[i] = repacked
+		changed = true
+	}
+
+	if !changed {
+		// Nothing was translated; return the original error so its identity is
+		// preserved for callers that compare by pointer.
+		return err
+	}
+
+	return status.FromProto(pb).Err()
+}

--- a/internal/proxy/translation_test.go
+++ b/internal/proxy/translation_test.go
@@ -1,0 +1,201 @@
+package proxy
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/api/errordetails/v1"
+	namespacepb "go.temporal.io/api/namespace/v1"
+	workflowservice "go.temporal.io/api/workflowservice/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoregistry"
+
+	"github.com/temporalio/temporal-proxy/internal/protoutil"
+	"github.com/temporalio/temporal-proxy/internal/transport/socket"
+)
+
+type (
+	// namespaceCheckingService is a fake WorkflowService upstream that rejects
+	// any request whose namespace is not the expected translated value.
+	namespaceCheckingService struct {
+		workflowservice.UnimplementedWorkflowServiceServer
+		want string
+	}
+
+	// fakeClientStream is a ClientStream whose RecvMsg yields a fixed message.
+	fakeClientStream struct {
+		grpc.ClientStream
+		recv proto.Message
+	}
+)
+
+func TestUnaryClientInterceptorTranslatesBothDirections(t *testing.T) {
+	t.Parallel()
+
+	tr := protoutil.NewTranslator(protoregistry.GlobalFiles)
+	interceptor := unaryClientInterceptor(tr, remote, local)
+
+	req := &workflowservice.StartWorkflowExecutionRequest{Namespace: "ns"}
+	reply := &workflowservice.DescribeNamespaceResponse{}
+
+	invoker := func(_ context.Context, _ string, gotReq, gotReply any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
+		// The request was translated local to remote before invocation.
+		require.Equal(t, "remote-ns", gotReq.(*workflowservice.StartWorkflowExecutionRequest).Namespace)
+		// Simulate the upstream returning a remote namespace name in the reply.
+		gotReply.(*workflowservice.DescribeNamespaceResponse).NamespaceInfo = namespaceInfo("remote-back")
+		return nil
+	}
+
+	err := interceptor(t.Context(), "/svc/Method", req, reply, nil, invoker)
+	require.NoError(t, err)
+	require.Equal(t, "local-remote-back", reply.NamespaceInfo.Name)
+}
+
+func TestStreamClientInterceptorTranslatesSendAndRecv(t *testing.T) {
+	t.Parallel()
+
+	tr := protoutil.NewTranslator(protoregistry.GlobalFiles)
+	fake := &fakeClientStream{}
+	streamer := func(context.Context, *grpc.StreamDesc, *grpc.ClientConn, string, ...grpc.CallOption) (grpc.ClientStream, error) {
+		return fake, nil
+	}
+
+	cs, err := streamClientInterceptor(tr, remote, local)(
+		t.Context(), &grpc.StreamDesc{}, nil, "/svc/Stream", streamer,
+	)
+	require.NoError(t, err)
+
+	sent := &workflowservice.StartWorkflowExecutionRequest{Namespace: "ns"}
+	require.NoError(t, cs.SendMsg(sent))
+	require.Equal(t, "remote-ns", sent.Namespace)
+
+	fake.recv = &workflowservice.DescribeNamespaceResponse{NamespaceInfo: namespaceInfo("remote-back")}
+	got := &workflowservice.DescribeNamespaceResponse{}
+	require.NoError(t, cs.RecvMsg(got))
+	require.Equal(t, "local-remote-back", got.NamespaceInfo.Name)
+}
+
+func TestTranslateStatusErrorRewritesDetailNamespace(t *testing.T) {
+	t.Parallel()
+
+	st, err := status.New(codes.NotFound, "namespace not found").
+		WithDetails(&errordetails.NamespaceNotFoundFailure{Namespace: "remote-ns"})
+	require.NoError(t, err)
+
+	tr := protoutil.NewTranslator(protoregistry.GlobalFiles)
+	out := translateStatusError(tr, st.Err(), local)
+
+	outSt, ok := status.FromError(out)
+	require.True(t, ok)
+	require.Equal(t, "namespace not found", outSt.Message(), "free-text message is unchanged")
+	details := outSt.Details()
+	require.Len(t, details, 1)
+	failure, ok := details[0].(*errordetails.NamespaceNotFoundFailure)
+	require.True(t, ok)
+	require.Equal(t, "local-remote-ns", failure.Namespace)
+}
+
+func TestTranslateStatusErrorPassthroughForNonStatus(t *testing.T) {
+	t.Parallel()
+
+	tr := protoutil.NewTranslator(protoregistry.GlobalFiles)
+	plain := errors.New("boom")
+	require.Equal(t, plain, translateStatusError(tr, plain, local))
+}
+
+func TestTranslateStatusErrorNilIsNil(t *testing.T) {
+	t.Parallel()
+
+	tr := protoutil.NewTranslator(protoregistry.GlobalFiles)
+	require.NoError(t, translateStatusError(tr, nil, local))
+}
+
+func TestOutboundNamespaceTranslation(t *testing.T) {
+	t.Parallel()
+
+	// Fake upstream frontend on a TCP port. It rejects any request whose
+	// namespace is not the translated "remote-local", so a successful call is
+	// itself proof that translation happened, with no shared state read from the
+	// test goroutine.
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	upstream := grpc.NewServer()
+	workflowservice.RegisterWorkflowServiceServer(upstream, &namespaceCheckingService{want: "remote-local"})
+	go func() { _ = upstream.Serve(lis) }()
+	t.Cleanup(upstream.Stop)
+
+	// Proxy dials the fake upstream, wrapping "local" -> "remote-local".
+	translator := protoutil.NewTranslator(protoregistry.GlobalFiles)
+	svr, err := New(
+		lis.Addr().String(),
+		WithDialOptions(translationDialOptions(
+			translator,
+			func(s string) string { return "remote-" + s },
+			func(s string) string { return "local-" + s },
+		)...),
+	)
+	require.NoError(t, err)
+
+	ctx := t.Context()
+	go func() { _ = svr.Start(ctx) }()
+	t.Cleanup(func() { _ = svr.Stop(context.Background()) })
+
+	conn := dialUnixSocket(t, lis.Addr().String())
+	defer func() { _ = conn.Close() }()
+
+	client := workflowservice.NewWorkflowServiceClient(conn)
+
+	require.Eventually(t, func() bool {
+		_, err := client.StartWorkflowExecution(ctx, &workflowservice.StartWorkflowExecutionRequest{Namespace: "local"})
+		return err == nil
+	}, 3*time.Second, 20*time.Millisecond, "upstream should observe the translated namespace")
+}
+
+func (s *namespaceCheckingService) StartWorkflowExecution(
+	_ context.Context, req *workflowservice.StartWorkflowExecutionRequest,
+) (*workflowservice.StartWorkflowExecutionResponse, error) {
+	if req.Namespace != s.want {
+		return nil, status.Errorf(codes.InvalidArgument, "namespace = %q, want %q", req.Namespace, s.want)
+	}
+
+	return &workflowservice.StartWorkflowExecutionResponse{}, nil
+}
+
+func (f *fakeClientStream) SendMsg(any) error { return nil }
+
+func (f *fakeClientStream) RecvMsg(m any) error {
+	proto.Merge(m.(proto.Message), f.recv)
+	return nil
+}
+
+func remote(s string) string { return "remote-" + s }
+
+func local(s string) string { return "local-" + s }
+
+func namespaceInfo(name string) *namespacepb.NamespaceInfo {
+	return &namespacepb.NamespaceInfo{Name: name}
+}
+
+// dialUnixSocket returns a client connection to the proxy's unix socket for the
+// given upstream host. The socket path matches what proxy.Start binds.
+func dialUnixSocket(t *testing.T, upstream string) *grpc.ClientConn {
+	t.Helper()
+
+	path, err := socket.UnixPath(upstream)
+	require.NoError(t, err)
+
+	conn, err := grpc.NewClient(
+		"unix://"+path,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	return conn
+}


### PR DESCRIPTION
Upstreams could define namespace rules (prefix, suffix, overrides) in config, but the proxy only parsed and validated them; requests and responses were forwarded verbatim, so workers had to address namespaces by their real upstream names rather than a local alias.

This wires translation end to end. On each per-upstream outbound connection a client interceptor rewrites namespace names in both directions: local to remote on requests, and remote to local on responses and on the typed details of gRPC errors. Routing is unaffected because it still keys on the local namespace one hop upstream, before translation happens on the downstream hop. Translation is installed only for upstreams that configure rules, so single-cluster deployments keep the existing raw-forwarding fast path.

Field identification combines a suffix convention (a string field ending in "namespace" is a name; a "*namespace_id" field is a UUID and is never touched) with a type-qualified override for names under non-conventional fields, notably NamespaceInfo.name, which DescribeNamespace and ListNamespaces return. A completeness test walks the translated services' message graphs and fails when a suspicious field is left unclassified, turning an api bump that adds a namespace field into a red build rather than a silent leak.

Translation runs on a protoreflect plan cache in internal/protoutil, pre-warmed at startup for the services the application lists (see cmd/proxy) and built lazily otherwise; message types that carry no namespace stay on the zero-copy path. protoutil has no gRPC dependency: the proxy owns the interceptors and assembles them as dial options, the same mechanism used for outbound credentials.