### PR TITLE
[proxy]: Support client-side outbound TLS for upstreams

### DIFF
--- a/internal/config/listen.go
+++ b/internal/config/listen.go
@@ -24,6 +24,14 @@ type (
 		Key        string `yaml:"key"`        // PEM-encoded private key
 		ServerName string `yaml:"serverName"` // Optional SNI override
 	}
+
+	// caTrustAnchor validates a certificate used as an outbound trust anchor
+	// (client-side TLS with no client certificate presented). The anchor may be
+	// either a CA or a pinned self-signed leaf. It is checked for expiry, a secure
+	// signature algorithm, and sufficient key size.
+	caTrustAnchor struct {
+		caFile string
+	}
 )
 
 // Validate checks the host:port and, when present, the TLS configuration.
@@ -45,15 +53,57 @@ func (t *TLSConfig) Validate() error {
 		"",
 		validation.WhenRules(
 			func() bool { return t.CA != "" },
-			validation.Nested(
-				"", creds.NewMTLS(t.CA, t.Cert, t.Key, creds.MTLSOptions{
-					ServerName: t.ServerName,
-				}),
-			),
+			validation.Nested("", t.mtlsCreds()),
 		),
 		validation.WhenRules(
 			func() bool { return t.CA == "" },
 			validation.Nested("", creds.NewServerTLS(t.Cert, t.Key)),
 		),
+	)
+}
+
+// mtlsCreds builds the mutual-TLS credential described by the config: the CA
+// verifies the peer and the client key pair is the presented certificate. It is
+// shared by the inbound listener validation and the outbound upstream validation
+// so the construction lives in one place.
+func (t *TLSConfig) mtlsCreds() *creds.MTLS {
+	return creds.NewMTLS(t.CA, t.Cert, t.Key, creds.MTLSOptions{ServerName: t.ServerName})
+}
+
+// validateOutbound validates the config as client-side TLS used to dial an
+// upstream. A client certificate (cert+key) selects mutual TLS and requires a
+// CA; a CA alone verifies the upstream against a private trust anchor while
+// presenting no client certificate; neither means client TLS against the system
+// root pool. Callers must invoke this only when the receiver is non-nil.
+func (t *TLSConfig) validateOutbound() validation.Errors {
+	hasCert := t.Cert != "" || t.Key != ""
+
+	switch {
+	case (t.Cert == "") != (t.Key == ""):
+		return validation.Errors{{Subject: "tls", Message: "cert and key must be set together"}}
+	case hasCert && t.CA == "":
+		return validation.Errors{{Subject: "tls", Field: "ca", Message: "is required when a client certificate is set"}}
+	case hasCert:
+		return validation.Nested("tls", t.mtlsCreds())()
+	case t.CA != "":
+		return validation.Nested("tls", caTrustAnchor{caFile: t.CA})()
+	default:
+		return nil
+	}
+}
+
+// Validate checks that the trust anchor is not expired and is signed with a
+// strong algorithm and a sufficiently large key.
+func (c caTrustAnchor) Validate() error {
+	return validation.Validate(
+		"",
+		validation.Field("ca", c.caFile, func(path string) error {
+			return creds.ValidatePEMFile(
+				path,
+				creds.CertificateNotExpired(),
+				creds.UsesSecureCertificateAlgorithm(),
+				creds.HasSufficientKeySize(),
+			)
+		}),
 	)
 }

--- a/internal/config/upstream.go
+++ b/internal/config/upstream.go
@@ -63,7 +63,7 @@ func (u *Upstream) Validate() error {
 		),
 		validation.WhenRules(
 			func() bool { return u.Listen.TLS != nil },
-			validation.Nested("tls", u.Listen.TLS),
+			func() validation.Errors { return u.Listen.TLS.validateOutbound() },
 		),
 		validation.Nested("namespaces", &u.Namespaces),
 		validation.WhenRules(

--- a/internal/config/upstream_test.go
+++ b/internal/config/upstream_test.go
@@ -1,13 +1,9 @@
 package config_test
 
 import (
-	"crypto/x509"
-	"crypto/x509/pkix"
 	"errors"
-	"math/big"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -512,19 +508,91 @@ func TestUpstreamCredentialsRequireTLS(t *testing.T) {
 	t.Run("credentials with tls is accepted", func(t *testing.T) {
 		t.Parallel()
 		u := base()
-		// RSA certs are required for TLS validation (ECDSA certs are incompatible
-		// with the RSA-only cipher suites). Generate an RSA cert and a key.
-		certPEM := testutil.RSACert(t, &x509.Certificate{
-			SerialNumber: big.NewInt(1),
-			Subject:      pkix.Name{CommonName: "test"},
-			NotBefore:    time.Now().Add(-time.Hour),
-			NotAfter:     time.Now().Add(time.Hour),
-		})
-		certFile := testutil.WriteFile(t, t.TempDir(), "cert.pem", certPEM)
-		_, keyFile := testutil.GenerateSelfSignedCert(t)
-		u.Listen.TLS = &config.TLSConfig{Cert: certFile, Key: keyFile}
+		u.Listen.TLS = &config.TLSConfig{ServerName: "my-ns.acct.tmprl.cloud"}
 		require.NoError(t, u.Validate())
 	})
+}
+
+func TestUpstreamOutboundTLS(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		tls     func(t *testing.T) *config.TLSConfig
+		wantErr string
+	}{
+		{
+			name: "server name only is valid (cloud + api key)",
+			tls: func(*testing.T) *config.TLSConfig {
+				return &config.TLSConfig{ServerName: "my-ns.acct.tmprl.cloud"}
+			},
+		},
+		{
+			name: "CA only is valid (self-signed + api key)",
+			tls: func(t *testing.T) *config.TLSConfig {
+				caFile, _, _ := testutil.GenerateMTLSCerts(t)
+				return &config.TLSConfig{CA: caFile, ServerName: "localhost"}
+			},
+		},
+		{
+			name: "CA plus client key pair is valid (mutual TLS)",
+			tls: func(t *testing.T) *config.TLSConfig {
+				caFile, certFile, keyFile := testutil.GenerateMTLSCerts(t)
+				return &config.TLSConfig{CA: caFile, Cert: certFile, Key: keyFile, ServerName: "localhost"}
+			},
+		},
+		{
+			name: "self-signed leaf cert is accepted as a trust anchor (pinning)",
+			// A peer proxy may present a plain self-signed leaf (IsCA=false).
+			// Pinning it as the trust anchor is valid TLS, so it must validate.
+			tls: func(t *testing.T) *config.TLSConfig {
+				leafCert, _ := testutil.GenerateSelfSignedCert(t)
+				return &config.TLSConfig{CA: leafCert, ServerName: "localhost"}
+			},
+		},
+		{
+			name: "cert without key is rejected",
+			tls: func(t *testing.T) *config.TLSConfig {
+				_, certFile, _ := testutil.GenerateMTLSCerts(t)
+				return &config.TLSConfig{Cert: certFile}
+			},
+			wantErr: "cert and key must be set together",
+		},
+		{
+			name: "key without cert is rejected",
+			tls: func(t *testing.T) *config.TLSConfig {
+				_, _, keyFile := testutil.GenerateMTLSCerts(t)
+				return &config.TLSConfig{Key: keyFile}
+			},
+			wantErr: "cert and key must be set together",
+		},
+		{
+			name: "client cert without CA is rejected",
+			tls: func(t *testing.T) *config.TLSConfig {
+				_, certFile, keyFile := testutil.GenerateMTLSCerts(t)
+				return &config.TLSConfig{Cert: certFile, Key: keyFile}
+			},
+			wantErr: "required when a client certificate is set",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			u := config.Upstream{
+				Name:   "u",
+				Listen: config.ListenConfig{HostPort: "host:7233", TLS: tt.tls(t)},
+			}
+
+			err := u.Validate()
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
 }
 
 func TestNamespaceRulesConfigured(t *testing.T) {

--- a/internal/proxy/fx.go
+++ b/internal/proxy/fx.go
@@ -125,20 +125,30 @@ func upstreamResolver(upstream *config.Upstream, opts []grpc.DialOption) (connec
 			translator = upstream.Namespaces.Rules.Remote
 		}
 
-		// Share one loader across the per-request credentials so templated mTLS
-		// routing reads and parses the certificate and CA files once rather than
-		// on every request. Only ServerName varies per request. nil for non-mTLS
-		// upstreams, which have no files to load.
-		var loader *creds.CertLoader
-		if tls := upstream.Listen.TLS; tls != nil && tls.CA != "" {
-			loader = creds.NewCertLoader(tls.CA, tls.Cert, tls.Key)
+		// Share one loader across the per-request credentials so a templated
+		// upstream reads and parses its TLS material once rather than on every
+		// request. Mutual TLS (a configured client certificate) uses a CertLoader
+		// for the client key pair and CA; CA-only client TLS uses a CAPoolLoader
+		// for the trust anchor. The system-root client-TLS and insecure paths have
+		// no files to load, so both loaders stay nil.
+		var (
+			loader   *creds.CertLoader
+			caLoader *creds.CAPoolLoader
+		)
+		if tls := upstream.Listen.TLS; tls != nil {
+			switch {
+			case tls.Cert != "" || tls.Key != "":
+				loader = creds.NewCertLoader(tls.CA, tls.Cert, tls.Key)
+			case tls.CA != "":
+				caLoader = creds.NewCAPoolLoader(tls.CA)
+			}
 		}
 
 		return NewDynamicResolver(
 			upstream,
 			WithRemoteNamespacer(translator),
 			WithOptionsFactory(func(data RouteData) ([]grpc.DialOption, error) {
-				creds, err := upstreamCreds(upstream, data.ResolvedServerName, loader).DialOption()
+				creds, err := upstreamCreds(upstream, data.ResolvedServerName, loader, caLoader).DialOption()
 				if err != nil {
 					return nil, err
 				}
@@ -153,7 +163,7 @@ func upstreamResolver(upstream *config.Upstream, opts []grpc.DialOption) (connec
 		serverName = upstream.Listen.TLS.ServerName
 	}
 
-	creds, err := upstreamCreds(upstream, serverName, nil).DialOption()
+	creds, err := upstreamCreds(upstream, serverName, nil, nil).DialOption()
 	if err != nil {
 		return nil, fmt.Errorf("failed to build credentials for upstream %q: %w", upstream.Name, err)
 	}
@@ -162,25 +172,33 @@ func upstreamResolver(upstream *config.Upstream, opts []grpc.DialOption) (connec
 }
 
 // upstreamCreds derives the credentials used to dial the upstream frontend from
-// the upstream TLS configuration: mutual TLS when a CA is set, server-verified
-// client TLS when TLS is configured without one, and insecure otherwise.
-// serverName overrides the SNI/certificate-verification name; it is the
-// upstream's static configured ServerName, or a per-request value rendered
-// from a templated ServerName. loader, when non-nil, supplies the mTLS
-// certificate material so it is loaded once and reused across the per-request
-// credentials of a templated upstream; pass nil for a fixed-address upstream,
-// whose credentials are built once.
-func upstreamCreds(upstream *config.Upstream, serverName string, loader *creds.CertLoader) Credentials {
+// the upstream TLS configuration. A configured client certificate (cert+key)
+// selects mutual TLS, which verifies the upstream against the configured CA.
+// Without a client certificate the proxy uses client-side TLS: a custom root
+// pool when a CA is set, otherwise the system root pool. No TLS at all is
+// insecure. serverName overrides the SNI/certificate-verification name; it is
+// the upstream's static configured ServerName, or a per-request value rendered
+// from a templated ServerName. loader and caLoader, when non-nil, supply the
+// pre-parsed TLS material (mutual-TLS key pair plus CA, and CA-only trust
+// anchor respectively) so it is loaded once and reused across the per-request
+// credentials of a templated upstream; pass nil for both on a fixed-address
+// upstream. At most one is used, selected by the same TLS mode as the returned
+// credential.
+func upstreamCreds(upstream *config.Upstream, serverName string, loader *creds.CertLoader, caLoader *creds.CAPoolLoader) Credentials {
 	tls := upstream.Listen.TLS
 	if tls == nil {
 		return creds.NewInsecure()
 	}
 
-	if tls.CA != "" {
+	if tls.Cert != "" || tls.Key != "" {
 		return creds.NewMTLS(tls.CA, tls.Cert, tls.Key, creds.MTLSOptions{
 			ServerName: serverName,
 			Loader:     loader,
 		})
+	}
+
+	if tls.CA != "" {
+		return creds.NewClientTLSWithCA(tls.CA, serverName, caLoader)
 	}
 
 	return creds.NewClientTLS(serverName)

--- a/internal/proxy/fx_test.go
+++ b/internal/proxy/fx_test.go
@@ -2,9 +2,6 @@ package proxy_test
 
 import (
 	"context"
-	"crypto/x509"
-	"crypto/x509/pkix"
-	"math/big"
 	"testing"
 	"time"
 
@@ -123,33 +120,45 @@ func TestModuleMultipleUpstreams(t *testing.T) {
 	}
 }
 
-// TestModuleWithUpstreamCredentials is construction-only: proxy.New dials
-// lazily, so this asserts the Module accepts a credentialed+TLS upstream without
-// erroring, not that the credential is actually attached. See
-// TestProxyAttachesUpstreamCredential (e2e/upstream_credential_socket_test.go)
-// for proof the key reaches the upstream.
 func TestModuleWithUpstreamCredentials(t *testing.T) {
 	t.Parallel()
 
 	const upstream = "127.0.0.1:47236"
 
-	// The upstream TLS validation path requires an RSA cert (it checks
-	// compatibility with the RSA-only cipher suites in creds.TLS); the key file
-	// only needs to be a validly formatted PEM key, since New never dials
-	// (construction, not a live handshake, is what this test exercises).
-	certPEM := testutil.RSACert(t, &x509.Certificate{
-		SerialNumber: big.NewInt(1),
-		Subject:      pkix.Name{CommonName: "test"},
-		NotBefore:    time.Now().Add(-time.Hour),
-		NotAfter:     time.Now().Add(time.Hour),
-	})
-	certFile := testutil.WriteFile(t, t.TempDir(), "cert.pem", certPEM)
-	_, keyFile := testutil.GenerateSelfSignedCert(t)
+	// A client certificate selects mutual TLS, which verifies the upstream
+	// against the configured CA. Construction (not a live handshake) is what
+	// this test exercises.
+	caFile, certFile, keyFile := testutil.GenerateMTLSCerts(t)
 
 	app := newProxyApp(t, &config.Config{
 		Upstreams: []config.Upstream{{
-			Name:        "workers",
-			Listen:      config.ListenConfig{HostPort: upstream, TLS: &config.TLSConfig{Cert: certFile, Key: keyFile}},
+			Name: "workers",
+			Listen: config.ListenConfig{
+				HostPort: upstream,
+				TLS:      &config.TLSConfig{CA: caFile, Cert: certFile, Key: keyFile, ServerName: "localhost"},
+			},
+			Credentials: &config.CredentialConfig{Static: &config.StaticCredentialConfig{APIKey: "k3y"}},
+		}},
+	})
+	require.NoError(t, app.Err())
+}
+
+func TestModuleWithCAOnlyClientTLS(t *testing.T) {
+	t.Parallel()
+
+	const upstream = "127.0.0.1:47237"
+
+	// A CA with no client certificate is client-side TLS: verify the upstream
+	// against the CA, present no client cert. Construction must succeed.
+	caFile, _, _ := testutil.GenerateMTLSCerts(t)
+
+	app := newProxyApp(t, &config.Config{
+		Upstreams: []config.Upstream{{
+			Name: "workers",
+			Listen: config.ListenConfig{
+				HostPort: upstream,
+				TLS:      &config.TLSConfig{CA: caFile, ServerName: "localhost"},
+			},
 			Credentials: &config.CredentialConfig{Static: &config.StaticCredentialConfig{APIKey: "k3y"}},
 		}},
 	})

--- a/internal/transport/creds/mtls.go
+++ b/internal/transport/creds/mtls.go
@@ -110,14 +110,9 @@ func (c *MTLS) ServerOption() (grpc.ServerOption, error) {
 		return nil, fmt.Errorf("failed to load server key pair: %w", err)
 	}
 
-	ca := x509.NewCertPool()
-	caBytes, err := os.ReadFile(c.caFile)
+	ca, err := loadCAPool(c.caFile)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load CA certificate: %w", err)
-	}
-
-	if ok := ca.AppendCertsFromPEM(caBytes); !ok {
-		return nil, fmt.Errorf("failed to parse CA file: %s", c.caFile)
+		return nil, err
 	}
 
 	return grpc.Creds(credentials.NewTLS(&tls.Config{
@@ -167,6 +162,22 @@ func (c *MTLS) Encrypted() bool {
 	return true
 }
 
+// loadCAPool reads a PEM-encoded CA certificate file and returns a cert pool
+// containing it.
+func loadCAPool(path string) (*x509.CertPool, error) {
+	caBytes, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load CA certificate: %w", err)
+	}
+
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(caBytes) {
+		return nil, fmt.Errorf("failed to parse CA file: %s", path)
+	}
+
+	return pool, nil
+}
+
 // load reads and parses the client certificate/key pair and CA pool on the first
 // call, caching the result (or the error) for every subsequent call. The
 // returned certificate and CA pool are immutable and safe to share across dial
@@ -179,15 +190,9 @@ func (l *CertLoader) load() (tls.Certificate, *x509.CertPool, error) {
 			return
 		}
 
-		ca := x509.NewCertPool()
-		caBytes, err := os.ReadFile(l.caFile)
+		ca, err := loadCAPool(l.caFile)
 		if err != nil {
-			l.err = fmt.Errorf("failed to load CA certificate: %w", err)
-			return
-		}
-
-		if ok := ca.AppendCertsFromPEM(caBytes); !ok {
-			l.err = fmt.Errorf("failed to parse CA file: %s", l.caFile)
+			l.err = err
 			return
 		}
 

--- a/internal/transport/creds/tls.go
+++ b/internal/transport/creds/tls.go
@@ -2,7 +2,9 @@ package creds
 
 import (
 	"crypto/tls"
+	"crypto/x509"
 	"fmt"
+	"sync"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -24,14 +26,34 @@ var preferredCipherSuites = []uint16{
 	tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
 }
 
-// TLS enables one-way (server-side) TLS on gRPC connections. The server
-// presents a certificate to the client; the client is not required to present
-// one. Minimum TLS version is 1.2.
-type TLS struct {
-	certFile   string
-	keyFile    string
-	serverName string
-}
+type (
+	// TLS enables one-way (server-side) TLS on gRPC connections. The server
+	// presents a certificate to the client; the client is not required to present
+	// one. Minimum TLS version is 1.2.
+	TLS struct {
+		certFile   string
+		keyFile    string
+		serverName string
+		caFile     string
+		caLoader   *CAPoolLoader
+	}
+
+	// CAPoolLoader reads and parses a CA certificate pool once, caching the result
+	// for reuse across the [TLS] values built per request for a templated
+	// upstream. It is safe for concurrent use: the parsed pool is immutable after
+	// the first load, so it may be shared by many dial options. A rotated CA on
+	// disk is not picked up until the process restarts, matching how a
+	// fixed-address upstream loads its material once at startup. This is the
+	// CA-only analogue of [CertLoader], which also caches a client key pair for
+	// mutual TLS.
+	CAPoolLoader struct {
+		caFile string
+
+		once sync.Once
+		pool *x509.CertPool
+		err  error
+	}
+)
 
 // NewClientTLS returns a [TLS] credential suitable for outbound (client-side)
 // connections. The server's certificate is verified against the system root CA
@@ -40,6 +62,25 @@ type TLS struct {
 // certificate verification; when empty it defaults to the dial target's host.
 func NewClientTLS(serverName string) *TLS {
 	return &TLS{serverName: serverName}
+}
+
+// NewClientTLSWithCA returns a [TLS] credential for outbound (client-side)
+// connections that verifies the server's certificate against the CA loaded from
+// caFile instead of the system root pool. No client certificate is presented;
+// use [NewMTLS] when the upstream requires mutual authentication. serverName
+// overrides the name used for SNI and verification; when empty it defaults to
+// the dial target's host.
+//
+// loader, when non-nil, supplies the CA pool so it is read and parsed once and
+// reused across the per-request credentials of a templated upstream; pass nil
+// for a fixed-address upstream, in which case the credential loads (and caches)
+// its own pool on first use.
+func NewClientTLSWithCA(caFile, serverName string, loader *CAPoolLoader) *TLS {
+	if loader == nil {
+		loader = NewCAPoolLoader(caFile)
+	}
+
+	return &TLS{caFile: caFile, serverName: serverName, caLoader: loader}
 }
 
 // NewServerTLS returns a [TLS] credential that loads the server certificate and
@@ -51,13 +92,35 @@ func NewServerTLS(certFile, keyFile string) *TLS {
 	}
 }
 
+// NewCAPoolLoader returns a [CAPoolLoader] that reads and parses the CA
+// certificate pool from caFile on first use.
+func NewCAPoolLoader(caFile string) *CAPoolLoader {
+	return &CAPoolLoader{caFile: caFile}
+}
+
 // DialOption returns a [grpc.DialOption] that configures the outbound
-// connection with TLS, verifying the server's certificate against the system
-// root CA pool. The configured server name (when non-empty) is used for SNI and
-// verification; otherwise the dial target's host is used. No client certificate
-// is presented; use [MTLS] when mutual authentication is required.
+// connection with TLS. When no custom CA is configured, the server's certificate
+// is verified against the system root CA pool. When a custom CA was configured
+// via [NewClientTLSWithCA], the server's certificate is verified against that
+// custom CA pool instead. The configured server name (when non-empty) is used for
+// SNI and verification; otherwise the dial target's host is used. No client
+// certificate is presented; use [MTLS] when mutual authentication is required.
 func (c *TLS) DialOption() (grpc.DialOption, error) {
-	return grpc.WithTransportCredentials(credentials.NewClientTLSFromCert(nil, c.serverName)), nil
+	cfg := &tls.Config{
+		ServerName: c.serverName,
+		MinVersion: minTLSVersion,
+	}
+
+	if c.caFile != "" {
+		pool, err := c.caLoader.load()
+		if err != nil {
+			return nil, err
+		}
+
+		cfg.RootCAs = pool
+	}
+
+	return grpc.WithTransportCredentials(credentials.NewTLS(cfg)), nil
 }
 
 // ServerOption returns a [grpc.ServerOption] that configures the server with
@@ -104,4 +167,15 @@ func (c *TLS) Validate() error {
 // transport, so it returns true.
 func (c *TLS) Encrypted() bool {
 	return true
+}
+
+// load reads and parses the CA pool on the first call, caching the result (or
+// the error) for every subsequent call. The returned pool is immutable and safe
+// to share across dial options and goroutines.
+func (l *CAPoolLoader) load() (*x509.CertPool, error) {
+	l.once.Do(func() {
+		l.pool, l.err = loadCAPool(l.caFile)
+	})
+
+	return l.pool, l.err
 }

--- a/internal/transport/creds/tls_test.go
+++ b/internal/transport/creds/tls_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"math/big"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -153,10 +154,85 @@ func TestTLS_Validate(t *testing.T) {
 	})
 }
 
+func TestTLS_DialOption_WithCA(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid CA builds a dial option", func(t *testing.T) {
+		t.Parallel()
+
+		caFile, _, _ := testutil.GenerateMTLSCerts(t)
+
+		opt, err := creds.NewClientTLSWithCA(caFile, "localhost", nil).DialOption()
+		require.NoError(t, err)
+		require.NotNil(t, opt)
+	})
+
+	t.Run("missing CA file is an error", func(t *testing.T) {
+		t.Parallel()
+
+		missing := filepath.Join(t.TempDir(), "nope.pem")
+
+		_, err := creds.NewClientTLSWithCA(missing, "localhost", nil).DialOption()
+		require.ErrorContains(t, err, "failed to load CA certificate")
+	})
+
+	t.Run("unparseable CA file is an error", func(t *testing.T) {
+		t.Parallel()
+
+		bad := testutil.WriteFile(t, t.TempDir(), "ca.pem", []byte("not a pem"))
+
+		_, err := creds.NewClientTLSWithCA(bad, "localhost", nil).DialOption()
+		require.ErrorContains(t, err, "failed to parse CA file")
+	})
+}
+
 func TestTLS_Encrypted(t *testing.T) {
 	t.Parallel()
 
 	// TLS encrypts the transport in both client and server modes.
 	require.True(t, creds.NewClientTLS("").Encrypted())
 	require.True(t, creds.NewServerTLS("", "").Encrypted())
+}
+
+func TestCAPoolLoader(t *testing.T) {
+	t.Parallel()
+
+	t.Run("shared loader reads the CA once", func(t *testing.T) {
+		t.Parallel()
+
+		caFile, _, _ := testutil.GenerateMTLSCerts(t)
+		loader := creds.NewCAPoolLoader(caFile)
+
+		// Simulate two per-request credentials for the same templated upstream
+		// sharing the loader; only ServerName differs.
+		opt, err := creds.NewClientTLSWithCA(caFile, "first.example.com", loader).DialOption()
+		require.NoError(t, err)
+		require.NotNil(t, opt)
+
+		// Remove the CA file. A re-read would fail, so a successful second
+		// DialOption proves the loader cached the parsed pool.
+		require.NoError(t, os.Remove(caFile))
+
+		opt, err = creds.NewClientTLSWithCA(caFile, "second.example.com", loader).DialOption()
+		require.NoError(t, err)
+		require.NotNil(t, opt)
+	})
+
+	t.Run("load error is cached", func(t *testing.T) {
+		t.Parallel()
+
+		missing := filepath.Join(t.TempDir(), "missing.pem")
+		loader := creds.NewCAPoolLoader(missing)
+
+		c := creds.NewClientTLSWithCA(missing, "localhost", loader)
+
+		opt, err := c.DialOption()
+		require.ErrorContains(t, err, "failed to load CA certificate")
+		require.Nil(t, opt)
+
+		// The cached error is returned again without another disk read.
+		opt, err = c.DialOption()
+		require.ErrorContains(t, err, "failed to load CA certificate")
+		require.Nil(t, opt)
+	})
 }

--- a/pkg/testutil/certs.go
+++ b/pkg/testutil/certs.go
@@ -83,11 +83,14 @@ func GenerateSelfSignedCert(t *testing.T) (certFile, keyFile string) {
 	return certFile, keyFile
 }
 
-// GenerateMTLSCerts writes a self-signed ECDSA P-256 CA certificate plus a
-// leaf certificate signed by that CA (with its matching key) to a fresh
-// [testing.T.TempDir] and returns the three paths. The leaf advertises CN
-// "localhost" with DNSNames=["localhost"]; both certificates are valid for
-// one hour. Use this when a test needs the leaf to verify against the CA.
+// GenerateMTLSCerts writes a self-signed ECDSA P-256 CA certificate plus an
+// RSA-2048 leaf certificate signed by that CA (with its matching key) to a
+// fresh [testing.T.TempDir] and returns the three paths. The leaf is RSA
+// because creds.MTLS.Validate checks the leaf's key type against an RSA-only
+// cipher suite allowlist; an ECDSA leaf fails that check even though it
+// verifies fine against the CA. The leaf advertises CN "localhost" with
+// DNSNames=["localhost"]; both certificates are valid for one hour. Use this
+// when a test needs the leaf to verify against the CA.
 func GenerateMTLSCerts(t *testing.T) (caFile, certFile, keyFile string) {
 	t.Helper()
 
@@ -115,7 +118,7 @@ func GenerateMTLSCerts(t *testing.T) (caFile, certFile, keyFile string) {
 	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})
 	caFile = WriteFile(t, dir, "ca.pem", caPEM)
 
-	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	leafKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err)
 
 	leafTmpl := &x509.Certificate{
@@ -134,10 +137,9 @@ func GenerateMTLSCerts(t *testing.T) (caFile, certFile, keyFile string) {
 	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: leafDER})
 	certFile = WriteFile(t, dir, "cert.pem", certPEM)
 
-	leafKeyDER, err := x509.MarshalECPrivateKey(leafKey)
-	require.NoError(t, err)
+	leafKeyDER := x509.MarshalPKCS1PrivateKey(leafKey)
 
-	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: leafKeyDER})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: leafKeyDER})
 	keyFile = WriteFile(t, dir, "key.pem", keyPEM)
 
 	return caFile, certFile, keyFile


### PR DESCRIPTION
An upstream configured for client-side TLS could not be expressed. Outbound TLS was inferred entirely from the CA field: a set CA forced mutual TLS (requiring a client key pair), and an empty CA meant system-root verification only. So a Temporal Cloud upstream (serverName + API key, no client cert) failed the mandatory startup validation, and a self-signed or private-CA upstream with API-key auth could not be configured at all.

Validation now runs on Upstream.Validate instead of reusing the server-side listener rules: cert and key must be set together; a client certificate requires a CA; a CA-only trust anchor is checked for expiry, algorithm, and key size but need not be a CA, so a peer's self-signed leaf can be pinned. Inbound front-door TLS validation is unchanged.

Supported upstream TLS configurations (serverName is an optional SNI / verification override in every case; with no tls block the upstream is dialed insecure and no credentials may be set):

| cert + key | CA     | Outbound behavior                                | Example                                  |
| ---------- | ------ | ------------------------------------------------ | ---------------------------------------- |
| absent     | absent | client TLS, system roots, no client cert         | Temporal Cloud + API key                 |
| absent     | set    | client TLS, custom CA or pinned self-signed leaf | self-signed / private-CA peer + API key  |
| present    | set    | mutual TLS                                       | self-hosted mutual TLS                   |
| present    | absent | rejected at validation                           | a client cert requires a CA              |
