### PR TITLE
[docs]: Rework README and standardize on "gateway"

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -98,9 +98,9 @@ mise run grpc DescribeNamespace '{"namespace":"test2"}'
 The differing results confirm the metadata rule selected the upstream. Metadata keys are matched case-insensitively
 (gRPC lowercases them).
 
-### Checking the front door (not proxied)
+### Checking the gateway (not proxied)
 
-The health service is answered locally by the inbound server, so it verifies the front door is up but does not prove
+The health service is answered locally by the inbound server, so it verifies the gateway is up but does not prove
 forwarding. It uses a different schema, so call `buf curl` directly:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -5,22 +5,68 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/temporalio/temporal-proxy.svg)](https://pkg.go.dev/github.com/temporalio/temporal-proxy)
 [![license](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-A gRPC proxy that sits between Temporal SDK clients, workers, and the Temporal UI on one side and one or more upstream
-Temporal clusters on the other. It handles namespace translation and TLS termination so applications can target a single
-local endpoint while the proxy fans requests out to the right upstream (a local dev cluster, a self-hosted deployment,
-Temporal Cloud, or some mix).
+A gRPC proxy that sits between Temporal SDK Clients, Workers, and the Temporal UI on one side and one or more upstream
+Temporal Services on the other. It handles Namespace translation and TLS termination so applications can target a single
+local endpoint while the proxy fans requests out to the right upstream (a local dev Temporal Service, a self-hosted
+deployment, Temporal Cloud, or some mix).
 
 > [!NOTE]
 >
 > **Pre-release:** This project is under active development and evolving quickly. It is not ready for production use.
 > Open a GitHub issue if you have questions or want to follow along.
 
-## Installation
+## Why
 
-> [!NOTE]
->
-> Releases are currently pre-release (alpha), so most tooling will not select them without opting in. The examples below
-> show how.
+Connection details leak into application code. Every Worker and Client has to know the upstream's host, TLS material,
+credentials, and the exact Namespace name the upstream expects. That couples your code to an environment and makes
+moving between a local Temporal Service, a self-hosted deployment, and Temporal Cloud a code change.
+
+The proxy pulls that concern out. Workers talk plaintext to a single local endpoint using a short Namespace name; the
+proxy owns TLS, credentials, and Namespace translation on the way out. Point a Worker at a different Namespace and it
+reaches a different upstream with no change to the Worker.
+
+## How
+
+```mermaid
+flowchart LR
+    Worker[Worker]
+    Client[SDK Client]
+    UI[Web UI]
+
+    subgraph Proxy[Temporal Proxy]
+        direction LR
+        Gateway[Gateway]
+        ProxyA[Per-upstream proxy A]
+        ProxyB[Per-upstream proxy B]
+        Gateway -->|unix socket| ProxyA
+        Gateway -->|unix socket| ProxyB
+    end
+
+    Cloud[Temporal Cloud]
+    SelfHosted[Self-hosted Temporal Service]
+
+    Worker --> Gateway
+    Client --> Gateway
+    UI --> Gateway
+    ProxyA --> Cloud
+    ProxyB --> SelfHosted
+
+```
+
+## Features
+
+- **Rule-based routing.** Route requests to different upstreams by Namespace and/or request metadata, with a system
+  upstream for Namespace-less calls and a default fallback.
+- **Namespace translation.** Rewrite local Namespace names to the names an upstream expects (prefix, suffix, or explicit
+  overrides) in both requests and responses.
+- **TLS termination and outbound credentials.** Terminate inbound TLS/mTLS and attach the upstream's own TLS and
+  credentials (API key or mTLS), so client code carries none of it.
+- **Inbound authentication.** Optional static-token or JWKS validation on the gateway; off by default.
+- **Codec-transparent.** The gateway never parses payloads. It peeks the Namespace, picks an upstream, and relays raw
+  frames in both directions.
+- **Multiple deployment options.** Ship as a Go binary, a container image, or a Helm chart.
+
+## Installation
 
 ### Go
 
@@ -30,10 +76,10 @@ Install the `proxy` binary into your `$GOBIN` with `go install`:
 go install github.com/temporalio/temporal-proxy/cmd/proxy@latest
 ```
 
-Since only pre-release tags exist today, `@latest` resolves to the current alpha. Pin an explicit version if you prefer:
+`@latest` resolves to the newest stable release. Pin an explicit version if you prefer:
 
 ```bash
-go install github.com/temporalio/temporal-proxy/cmd/proxy@v0.1.0-alpha.20260716
+go install github.com/temporalio/temporal-proxy/cmd/proxy@v0.1.0
 ```
 
 ### Container image
@@ -46,130 +92,58 @@ docker pull temporalio/temporal-proxy:latest
 
 ### Helm
 
-A chart is published to the Temporal Helm repo at `https://go.temporal.io/helm-charts`. Because the chart is a
-pre-release, opt in with `--devel` or pin an explicit `--version`:
+A chart is published to the Temporal Helm repo at `https://go.temporal.io/helm-charts`:
 
 ```bash
-# Latest pre-release
+# Latest stable release
+helm install temporal-proxy temporal-proxy \
+  --repo https://go.temporal.io/helm-charts
+
+# Or pin a specific proxy version
 helm install temporal-proxy temporal-proxy \
   --repo https://go.temporal.io/helm-charts \
-  --devel
-
-# Or pin a specific version
-helm install temporal-proxy temporal-proxy \
-  --repo https://go.temporal.io/helm-charts \
-  --version 0.1.0-alpha1
+  --set image.tag=v0.1.0
 ```
 
-The chart deploys the proxy as a single Deployment fronted by a ClusterIP Service, with its runtime configuration
-supplied through a ConfigMap (mounted at `/etc/temporal-proxy/config.yaml`). Set that config under `config` in your
-values. See the [chart README](https://github.com/temporalio/helm-charts/tree/main/charts/temporal-proxy) for the full
-set of options.
+Each chart release deploys a proxy version by default; `--set image.tag` overrides it to pin a specific one.
 
-## How It Works
-
-The proxy is really **two gRPC servers connected by a unix socket**:
-
-- A single **front door** (`internal/server`) that every worker, SDK client, and the UI connect to. It is
-  codec-transparent: it never parses payloads. It peeks the namespace off the first frame, picks an upstream, and relays
-  raw frames in both directions.
-- One **per-upstream proxy** (`internal/proxy`) for each configured upstream, each listening on its own unix socket.
-  This hop hosts a real `WorkflowService` proxy, applies namespace translation and outbound credentials, and dials the
-  actual upstream frontend.
-
-Routing happens at the front door; namespace translation and outbound auth happen in the per-upstream proxy. Whether an
-upstream is a local dev cluster, a self-hosted deployment, or Temporal Cloud is purely a matter of that upstream's
-config (TLS, credentials, translation rules). There is no first-class "local vs Cloud" concept.
-
-```mermaid
-flowchart TB
-    W["SDK clients / workers / UI"]
-
-    subgraph FD["Front door (internal/server, one instance)"]
-        direction TB
-        M["metrics interceptor"]
-        A["auth interceptor"]
-        H["router handler: peek namespace"]
-        M --> A --> H
-    end
-
-    SW["Mux.Switch: rules, then system, then default"]
-
-    subgraph PX["Per-upstream proxy (internal/proxy, one per upstream)"]
-        direction TB
-        P["WorkflowService proxy"]
-        T["namespace translate + creds interceptors"]
-        P --> T
-    end
-
-    U["Upstream frontend: local / self-hosted / Cloud"]
-
-    W -->|"gRPC (TLS)"| M
-    H --> SW
-    SW -->|"raw frames over unix socket"| P
-    T -->|"gRPC (TLS + credentials)"| U
-```
-
-### The request path
-
-1. **Connect.** A worker dials the front door over gRPC (TLS, mTLS, or insecure, per the `listen` config).
-2. **Metrics.** A stream interceptor starts timing and will record request duration and final gRPC status code, labeled
-   by method (never by namespace).
-3. **Authenticate.** The inbound authenticator validates the configured credential (static token or JWKS). On success it
-   strips the consumed credential header so it never leaks upstream; on failure it returns a client-safe status and logs
-   the detail server-side. Auth is opt-in: with no `auth` block, every request is admitted.
-4. **Peek and route.** The router buffers the first client frame, reads the namespace via protoreflect, and `Mux.Switch`
-   picks an upstream. The first matching rule wins, then the system upstream (empty namespace), then the default.
-5. **Forward.** The front door opens a stream to the chosen upstream's unix socket, replays the buffered frame, and
-   pumps frames in both directions using a pass-through codec. Headers, trailers, and status are relayed verbatim.
-6. **Translate and authenticate outbound.** In the per-upstream proxy, client interceptors rewrite the local namespace
-   to the remote one (`prefix + namespace + suffix`, or an explicit override) on the way out and back to the local name
-   on the way in, and attach the upstream's credential (which requires TLS).
-7. **Upstream.** The proxy dials the real Temporal frontend. The response retraces the same path in reverse.
-
-### Namespace translation
-
-Workers address namespaces by their local name, but an upstream may know them by a different name (for example, Temporal
-Cloud registers `payments` as `payments.<account>`). Each upstream configures translation rules (a `prefix`, a `suffix`,
-and/or explicit `overrides`), and the proxy rewrites namespace fields in both requests and responses. Rewriting is
-driven by protoreflect: any string field whose name ends in `namespace` is translated (plus a few explicit fields such
-as `NamespaceInfo.name`), and a per-type plan is cached so the descriptor walk happens once per message type.
-
-### Configuration
-
-Config is a single YAML file (passed via `--config` or `PROXY_CONFIG`) with `${VAR}` environment expansion. The shape,
-abbreviated:
+Supply the proxy config under the `config:` key in a values file and pass it with `-f`:
 
 ```yaml
-hostPort: 0.0.0.0:7233 # front-door listener
-tls: { ca, cert, key, serverName }
-
-auth: # inbound, optional
-  staticToken: { token, header, scheme } # or jwks: { url, audiences, issuer, ... }
-
-routing:
-  default: local # fallback upstream
-  system: local # used for namespace-less requests
-  rules:
-    - upstream: cloud
-      match: { namespace: "payments*" }
-
-upstreams:
-  - name: local
-    hostPort: localhost:7234
-  - name: cloud
-    hostPort: my-ns.acct.tmprl.cloud:7233
-    tls: { serverName: my-ns.acct.tmprl.cloud }
-    namespaces:
-      rules: { suffix: ".acct" }
-    credentials:
-      static: { apiKey: "${TEMPORAL_API_KEY}" }
+# values.yaml
+config:
+  hostPort: :7233
+  upstreams:
+    - name: local
+      hostPort: localhost:7234
+  routing:
+    default: local
 ```
 
-> [!NOTE]
->
-> The front door serves all traffic through a catch-all handler and labels metrics by gRPC method, which is effectively
-> unbounded. The proxy assumes trusted callers; do not expose it to untrusted clients without additional protection.
+```bash
+helm install temporal-proxy temporal-proxy \
+  --repo https://go.temporal.io/helm-charts \
+  -f values.yaml
+```
+
+See the [chart README] for the full set of options.
+
+[chart README]: https://github.com/temporalio/helm-charts/tree/main/charts/temporal-proxy
+
+## Get started
+
+The [Temporal Cloud example](examples/cloud) is the quickest way to see the proxy in action: a Worker and starter that
+carry no Cloud configuration talk plaintext to `localhost:7233`, and the proxy adds TLS, the API key, and the Namespace
+rewrite on the way to Cloud. Follow its README to run it end to end.
+
+## Terms
+
+| Term             | Meaning                                                                                                                                                                                        |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| gateway          | The single inbound gRPC endpoint that every SDK Client, Worker, and the UI connects to. It routes each request to an upstream by Namespace and/or request metadata, and never parses payloads. |
+| upstream         | A configured destination the proxy forwards to: a Temporal Service (local dev, self-hosted, or Temporal Cloud), or another Temporal Proxy.                                                     |
+| system upstream  | The upstream that handles Namespace-less requests, such as the SDK's `GetSystemInfo` call on connect.                                                                                          |
+| Temporal Service | A Temporal frontend the proxy connects to.                                                                                                                                                     |
 
 ## Development
 

--- a/examples/cloud/README.md
+++ b/examples/cloud/README.md
@@ -7,7 +7,7 @@ rewrite on the way to Cloud.
 ```mermaid
 flowchart LR
     client["worker / starter<br/>plaintext gRPC<br/>no TLS, no creds"]
-    proxy["proxy (local)<br/>front door :7233"]
+    proxy["proxy (local)<br/>gateway :7233"]
     cloud["Temporal Cloud<br/>quickstart.&lt;account&gt;.tmprl.cloud:7233"]
 
     client -->|"namespace: quickstart"| proxy
@@ -44,7 +44,7 @@ command changes to the repo root and runs it from source:
 cd ../../ && go run ./cmd/proxy serve -c examples/cloud/config.yaml
 ```
 
-The proxy logs `Running with insecure credentials` for the local front door and its internal sockets. That is expected:
+The proxy logs `Running with insecure credentials` for the local gateway and its internal sockets. That is expected:
 those are local hops. The connection to Temporal Cloud is TLS.
 
 Start the worker:

--- a/examples/cloud/config.yaml
+++ b/examples/cloud/config.yaml
@@ -13,7 +13,7 @@
 #                       fully-qualified namespace, e.g. "a1b2c")
 #   TEMPORAL_API_KEY    a Temporal Cloud API key
 #
-# Workers connect to the local front door in plaintext with no credentials; the
+# Workers connect to the local gateway in plaintext with no credentials; the
 # proxy adds TLS, the API key, and the namespace rewrite on the way to Cloud.
 hostPort: 127.0.0.1:7233
 


### PR DESCRIPTION
The README carried stale pre-release framing (claiming only alpha tags existed) and a lot of detail - diagrams, request-path walkthrough, full config schema - that obscured what the proxy is and how to start using it.

Restructure around Why / Features / Terms and trim the deep internals. Update the install paths to reflect the stable v0.1.0 release: go install @latest now resolves to stable, and the Helm section pins the proxy version via --set image.tag (the chart appVersion) rather than conflating it with the chart version, plus shows supplying config through a values file.