### PR TITLE
[proxy]: Encrypt upstream payloads via a client interceptor

### DIFF
--- a/e2e/encryption_test.go
+++ b/e2e/encryption_test.go
@@ -1,0 +1,169 @@
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"net"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/api/common/v1"
+	"go.temporal.io/api/query/v1"
+	"go.temporal.io/api/workflowservice/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/temporalio/temporal-proxy/internal/config"
+)
+
+// These mirror the proxy's on-the-wire encryption metadata contract
+// (internal/proxy/encryption.go). They are duplicated here because e2e is an
+// external package and the constants are unexported; this test verifies the
+// observable wire format, so pinning the literals is intentional.
+const (
+	wireEncoding        = "encoding"
+	wireEncryptedMarker = "binary/encrypted"
+	wireKeyID           = "encryption-key-id"
+	wireDEK             = "encryption-dek"
+)
+
+// queryEchoService is a fake upstream WorkflowService frontend that records the
+// QueryArgs it receives and echoes them straight back as the QueryResult. The
+// echo lets a single QueryWorkflow call exercise both directions of the proxy's
+// encryption interceptor: the recorded args prove outbound sealing, and the
+// echoed result (still ciphertext on the wire) is what the proxy opens on the
+// way back.
+type queryEchoService struct {
+	workflowservice.UnimplementedWorkflowServiceServer
+
+	mu      sync.Mutex
+	gotArgs *common.Payloads
+}
+
+// TestEndToEndPayloadEncryption drives a QueryWorkflow call through the full
+// stack (client -> inbound server -> router -> per-upstream proxy -> fake
+// upstream) with encryption enabled via a local testing:// key, and proves the
+// interceptor is wired in both directions: the upstream receives sealed
+// QueryArgs (outbound encryption), and the client receives the original
+// plaintext QueryResult the upstream echoed back (inbound decryption).
+func TestEndToEndPayloadEncryption(t *testing.T) {
+	t.Parallel()
+
+	svc := &queryEchoService{}
+	upstreamAddr := newPlaintextUpstream(t, svc)
+
+	inboundAddr := freeTCPAddr(t)
+	app := newFullApp(t, &config.Config{
+		Listen:  config.ListenConfig{HostPort: inboundAddr},
+		Routing: config.Routing{DefaultUpstream: "workers"},
+		Encryption: config.Encryption{
+			Enabled: true,
+			Default: &config.KeyPolicy{URI: testingKeyURI(t), Duration: time.Hour},
+		},
+		Upstreams: []config.Upstream{{
+			Name:   "workers",
+			Listen: config.ListenConfig{HostPort: upstreamAddr},
+		}},
+	})
+	require.NoError(t, app.Err())
+
+	startCtx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	require.NoError(t, app.Start(startCtx))
+	t.Cleanup(func() {
+		stopCtx, stopCancel := context.WithTimeout(t.Context(), 5*time.Second)
+		defer stopCancel()
+		_ = app.Stop(stopCtx)
+	})
+
+	conn := dialInbound(t, inboundAddr)
+	defer func() { _ = conn.Close() }()
+
+	secret := &common.Payload{
+		Metadata: map[string][]byte{wireEncoding: []byte("json/plain")},
+		Data:     []byte(`"the-answer-is-42"`),
+	}
+
+	resp, err := workflowservice.NewWorkflowServiceClient(conn).QueryWorkflow(
+		startCtx,
+		&workflowservice.QueryWorkflowRequest{
+			Namespace: "ns1",
+			Execution: &common.WorkflowExecution{WorkflowId: "wf-1"},
+			Query: &query.WorkflowQuery{
+				QueryType: "state",
+				QueryArgs: &common.Payloads{Payloads: []*common.Payload{secret}},
+			},
+		},
+		grpc.WaitForReady(true),
+	)
+	require.NoError(t, err)
+
+	// Inbound: the echoed QueryResult was decrypted back to the original plaintext.
+	require.Len(t, resp.GetQueryResult().GetPayloads(), 1)
+	require.True(t, proto.Equal(secret, resp.GetQueryResult().GetPayloads()[0]),
+		"client must receive the original plaintext payload after inbound decryption")
+
+	// Outbound: the upstream saw ciphertext, not the plaintext the client sent.
+	got := svc.received()
+	require.Len(t, got.GetPayloads(), 1)
+	sealed := got.GetPayloads()[0]
+	require.Equal(t, wireEncryptedMarker, string(sealed.Metadata[wireEncoding]),
+		"upstream must see the encryption marker, proving outbound sealing ran")
+	require.NotEqual(t, secret.Data, sealed.Data, "upstream payload data must be ciphertext, not plaintext")
+	require.NotEmpty(t, sealed.Metadata[wireKeyID], "sealed payload must carry the wrapping key id")
+	require.NotEmpty(t, sealed.Metadata[wireDEK], "sealed payload must carry the wrapped DEK")
+}
+
+func (s *queryEchoService) QueryWorkflow(
+	_ context.Context, req *workflowservice.QueryWorkflowRequest,
+) (*workflowservice.QueryWorkflowResponse, error) {
+	args := req.GetQuery().GetQueryArgs()
+
+	s.mu.Lock()
+	s.gotArgs = args
+	s.mu.Unlock()
+
+	return &workflowservice.QueryWorkflowResponse{QueryResult: args}, nil
+}
+
+func (s *queryEchoService) received() *common.Payloads {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.gotArgs
+}
+
+// newPlaintextUpstream stands up a fake WorkflowService frontend over plaintext
+// TCP (this test exercises payload encryption, not transport TLS) and returns
+// its address.
+func newPlaintextUpstream(t *testing.T, svc workflowservice.WorkflowServiceServer) string {
+	t.Helper()
+
+	srv := grpc.NewServer()
+	workflowservice.RegisterWorkflowServiceServer(srv, svc)
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	go func() { _ = srv.Serve(lis) }()
+	t.Cleanup(srv.Stop)
+
+	return lis.Addr().String()
+}
+
+// testingKeyURI builds a local testing:// key URI with a fixed 32-byte key. The
+// kms module rewrites testing:// to gocloud's base64key:// local keeper, so no
+// cloud KMS is needed.
+func testingKeyURI(t *testing.T) url.URL {
+	t.Helper()
+
+	key := base64.StdEncoding.EncodeToString(bytes.Repeat([]byte{0x2a}, 32))
+	u, err := url.Parse("testing://" + key)
+	require.NoError(t, err)
+
+	return *u
+}

--- a/e2e/harness_test.go
+++ b/e2e/harness_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/temporalio/temporal-proxy/internal/auth"
 	"github.com/temporalio/temporal-proxy/internal/config"
+	"github.com/temporalio/temporal-proxy/internal/kms"
 	"github.com/temporalio/temporal-proxy/internal/metrics"
 	"github.com/temporalio/temporal-proxy/internal/protoutil"
 	"github.com/temporalio/temporal-proxy/internal/proxy"
@@ -32,6 +33,7 @@ import (
 	"github.com/temporalio/temporal-proxy/internal/server"
 	"github.com/temporalio/temporal-proxy/internal/transport/connect"
 	"github.com/temporalio/temporal-proxy/internal/transport/socket"
+	"github.com/temporalio/temporal-proxy/pkg/crypto"
 	"github.com/temporalio/temporal-proxy/pkg/logger"
 	"github.com/temporalio/temporal-proxy/pkg/testutil"
 )
@@ -105,6 +107,7 @@ func newFullApp(t *testing.T, cfg *config.Config) *fx.App {
 		),
 		auth.Module,
 		connect.Module,
+		kms.Module,
 		metrics.Module,
 		protoutil.Module,
 		proxy.Module,
@@ -127,6 +130,7 @@ func newProxyApp(t *testing.T, cfg *config.Config) *fx.App {
 	return fx.New(
 		fx.Supply(fx.Annotate(t.Context(), fx.As(new(context.Context)))),
 		fx.Supply(cfg),
+		fx.Provide(func() *crypto.Vault { return nil }),
 		connect.Module,
 		protoutil.Module,
 		proxy.Module,

--- a/internal/kms/fx.go
+++ b/internal/kms/fx.go
@@ -19,14 +19,17 @@ const (
 	rotationInterval = 10 * time.Second
 )
 
-// Module provides a *crypto.Vault built from the proxy's encryption
-// configuration and, when encryption is enabled, runs background key rotation
-// for the lifetime of the fx application. When encryption is disabled the
-// provided vault is nil and no rotation goroutine is started.
+// Module provides a *crypto.Vault whenever encryption keys are configured (a
+// Default key policy is present) and, only while encryption is Enabled, runs
+// background key rotation for the lifetime of the fx application. Building the
+// vault from key presence rather than the Enabled flag lets encryption be
+// turned off for new traffic while the vault stays available to open payloads
+// sealed earlier: the proxy interceptor gates sealing on Enabled but always
+// decrypts. With no key policy the vault is nil and no rotation runs.
 var Module = fx.Options(
 	fx.Provide(
 		func(p KMSParams) (*crypto.Vault, error) {
-			if !p.Config.Encryption.Enabled {
+			if p.Config.Encryption.Default == nil {
 				return nil, nil
 			}
 

--- a/internal/kms/fx_test.go
+++ b/internal/kms/fx_test.go
@@ -202,9 +202,11 @@ func TestCreateKEKRegistry(t *testing.T) {
 	lc.RequireStop()
 }
 
-func TestModule_Disabled_ProvidesNilVault(t *testing.T) {
+func TestModule_NoKeys_ProvidesNilVault(t *testing.T) {
 	t.Parallel()
 
+	// No key policy configured (and encryption disabled): there is nothing to
+	// seal or open, so the vault is nil.
 	var v *crypto.Vault
 	app := fx.New(
 		fx.Supply(fx.Annotate(t.Context(), fx.As(new(context.Context)))),
@@ -217,6 +219,33 @@ func TestModule_Disabled_ProvidesNilVault(t *testing.T) {
 
 	require.NoError(t, app.Err())
 	require.Nil(t, v)
+}
+
+func TestModule_DisabledWithKeys_ProvidesVault(t *testing.T) {
+	t.Parallel()
+
+	// Encryption is off for new traffic but keys remain configured, so the vault
+	// is still built to open payloads sealed earlier. The rotation goroutine is
+	// gated on Enabled, so a clean start/stop confirms none was scheduled.
+	var v *crypto.Vault
+	cfg := &config.Config{Encryption: config.Encryption{
+		Enabled:   false,
+		CacheSize: 10,
+		Default:   &config.KeyPolicy{URI: distinctKeyURL(t, 1), Duration: time.Hour, RenewBefore: time.Minute},
+	}}
+
+	app := fxtest.New(
+		t,
+		fx.Supply(fx.Annotate(t.Context(), fx.As(new(context.Context)))),
+		fx.Supply(cfg),
+		fx.Provide(func() logger.Logger { return logger.NewNoopLogger() }),
+		Module,
+		fx.Populate(&v),
+	)
+
+	app.RequireStart()
+	require.NotNil(t, v)
+	app.RequireStop()
 }
 
 func TestModule_Enabled_ProvidesVaultAndRunsCleanly(t *testing.T) {

--- a/internal/proxy/encryption.go
+++ b/internal/proxy/encryption.go
@@ -1,0 +1,137 @@
+package proxy
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+
+	"go.temporal.io/api/common/v1"
+	"go.temporal.io/api/proxy"
+	"google.golang.org/grpc"
+
+	"github.com/temporalio/temporal-proxy/internal/transport/meta"
+	"github.com/temporalio/temporal-proxy/pkg/crypto"
+)
+
+// These keys form the on-the-wire contract for an encrypted payload: the
+// encoding marker lets decryptPayloads recognize its own output, and the key-ID
+// and wrapped-DEK entries carry the material needed to open it. They live in the
+// payload metadata so the ciphertext travels with everything required to
+// decrypt it.
+const (
+	metadataEncoding        = "encoding" // Copied to avoid importing SDK just for this
+	metadataEncryptionKeyID = "encryption-key-id"
+	metadataEncryptionDEK   = "encryption-dek"
+	encryptionEncoding      = "binary/encrypted"
+)
+
+// Vault seals and opens payloads using envelope encryption scoped by namespace.
+// It is the subset of [crypto.Vault] the interceptor depends on.
+type Vault interface {
+	Seal(context.Context, string, []byte) (*crypto.Message, error)
+	Open(context.Context, *crypto.Message) ([]byte, error)
+}
+
+// EncryptionInterceptor returns a unary client interceptor that opens inbound
+// response payloads using v and, when enabled is true, seals outbound request
+// payloads as well. Sealing is gated so encryption can be turned off for new
+// traffic while still opening data sealed earlier: inbound decryption always
+// runs. Each payload is sealed under the DEK for the request's namespace, read
+// from the outgoing gRPC metadata via [meta.NamespaceFrom], so the upstream
+// never sees plaintext while local workers still exchange cleartext. On the way
+// back only payloads this interceptor sealed (identified by the
+// encryptionEncoding marker) are opened; anything else passes through
+// untouched. Search attributes are skipped so they stay queryable upstream. It
+// returns an error only if the underlying visitor interceptor cannot be
+// constructed.
+func EncryptionInterceptor(enabled bool, v Vault) (grpc.UnaryClientInterceptor, error) {
+	var outbound *proxy.VisitPayloadsOptions
+	if enabled {
+		outbound = &proxy.VisitPayloadsOptions{
+			ConcurrencyLimit:     runtime.NumCPU(),
+			SkipSearchAttributes: true,
+			Visitor:              encryptPayloads(v),
+		}
+	}
+
+	return proxy.NewPayloadVisitorInterceptor(proxy.PayloadVisitorInterceptorOptions{
+		Inbound: &proxy.VisitPayloadsOptions{
+			ConcurrencyLimit:     runtime.NumCPU(),
+			SkipSearchAttributes: true,
+			Visitor:              decryptPayloads(v),
+		},
+		Outbound: outbound,
+	})
+}
+
+// encryptPayloads returns a payload visitor that marshals each payload, seals
+// the bytes under v for the context's namespace, and replaces it with a payload
+// whose data is the ciphertext and whose metadata carries the wrapped DEK
+// needed to open it. The entire original payload (metadata included) is sealed,
+// so decryptPayloads can restore it exactly.
+func encryptPayloads(v Vault) func(*proxy.VisitPayloadsContext, []*common.Payload) ([]*common.Payload, error) {
+	return func(ctx *proxy.VisitPayloadsContext, payloads []*common.Payload) ([]*common.Payload, error) {
+		ns := meta.NamespaceFrom(ctx)
+
+		res := make([]*common.Payload, len(payloads))
+		for i, p := range payloads {
+			data, err := p.Marshal()
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal payload: %w", err)
+			}
+
+			msg, err := v.Seal(ctx, ns, data)
+			if err != nil {
+				return nil, fmt.Errorf("failed to encrypt payload: %w", err)
+			}
+
+			res[i] = &common.Payload{
+				Metadata: map[string][]byte{
+					metadataEncoding:        []byte(encryptionEncoding),
+					metadataEncryptionKeyID: []byte(msg.KeyMaterial.KEKID),
+					metadataEncryptionDEK:   []byte(msg.KeyMaterial.EncryptedDEK),
+				},
+				Data: msg.Ciphertext,
+			}
+		}
+
+		return res, nil
+	}
+}
+
+// decryptPayloads returns a payload visitor that reverses encryptPayloads:
+// payloads carrying the encryptionEncoding marker are opened and unmarshaled
+// back into their original form, while any others pass through unchanged so
+// payloads produced elsewhere survive the round trip.
+func decryptPayloads(v Vault) func(*proxy.VisitPayloadsContext, []*common.Payload) ([]*common.Payload, error) {
+	return func(ctx *proxy.VisitPayloadsContext, payloads []*common.Payload) ([]*common.Payload, error) {
+		res := make([]*common.Payload, len(payloads))
+		for i, p := range payloads {
+			// Only decrypt what we've encrypted
+			if enc := string(p.Metadata[metadataEncoding]); enc != encryptionEncoding {
+				res[i] = p
+				continue
+			}
+
+			pt, err := v.Open(ctx, &crypto.Message{
+				Ciphertext: p.Data,
+				KeyMaterial: &crypto.DEKMaterial{
+					KEKID:        string(p.Metadata[metadataEncryptionKeyID]),
+					EncryptedDEK: string(p.Metadata[metadataEncryptionDEK]),
+				},
+			})
+			if err != nil {
+				return nil, fmt.Errorf("failed to decrypt payload: %w", err)
+			}
+
+			og := new(common.Payload)
+			if err := og.Unmarshal(pt); err != nil {
+				return nil, fmt.Errorf("failed to unmarshal payload: %w", err)
+			}
+
+			res[i] = og
+		}
+
+		return res, nil
+	}
+}

--- a/internal/proxy/encryption_test.go
+++ b/internal/proxy/encryption_test.go
@@ -1,0 +1,302 @@
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/api/common/v1"
+	"go.temporal.io/api/proxy"
+	workflowservice "go.temporal.io/api/workflowservice/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/temporalio/temporal-proxy/internal/transport/meta"
+	"github.com/temporalio/temporal-proxy/pkg/crypto"
+)
+
+const (
+	testKEKID  = "test-kek"
+	sealPrefix = "sealed:"
+)
+
+// fakeVault is a reversible in-memory Vault. Seal prefixes the plaintext with
+// sealPrefix (so sealed data is observably distinct from cleartext) and records
+// the namespace it was called with; Open strips the prefix. Errors and a fixed
+// Open result can be injected to exercise the interceptor's failure paths. It is
+// safe for concurrent use because the payload visitor may seal/open payloads
+// from multiple goroutines within a single call.
+type fakeVault struct {
+	mu         sync.Mutex
+	namespaces []string // namespaces passed to Seal, in call order
+	opens      int      // number of Open calls
+	sealErr    error    // when set, Seal returns it
+	openErr    error    // when set, Open returns it
+	openReturn []byte   // when set, Open returns these bytes instead of the unsealed plaintext
+}
+
+func TestEncryptionInterceptorRoundtrip(t *testing.T) {
+	t.Parallel()
+
+	v := &fakeVault{}
+	interceptor, err := EncryptionInterceptor(true, v)
+	require.NoError(t, err)
+
+	input := &common.Payloads{Payloads: []*common.Payload{testPayload("json/plain", `"hi"`)}}
+	want := proto.Clone(input.Payloads[0]).(*common.Payload)
+
+	req := &workflowservice.StartWorkflowExecutionRequest{Namespace: "local", Input: input}
+	resp := &workflowservice.StartWorkflowExecutionRequest{}
+
+	invoker := func(_ context.Context, _ string, gotReq, gotResp any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
+		// Outbound: the request payload reached the upstream sealed.
+		sent := gotReq.(*workflowservice.StartWorkflowExecutionRequest).Input.Payloads[0]
+		require.Equal(t, encryptionEncoding, string(sent.Metadata[metadataEncoding]))
+		require.True(t, bytes.HasPrefix(sent.Data, []byte(sealPrefix)))
+
+		// Echo the sealed payload back so the inbound path can open it.
+		gotResp.(*workflowservice.StartWorkflowExecutionRequest).Input = &common.Payloads{
+			Payloads: []*common.Payload{sent},
+		}
+		return nil
+	}
+
+	ctx := meta.WithNamespace(t.Context(), "orders")
+	require.NoError(t, interceptor(ctx, "/svc/Start", req, resp, nil, invoker))
+
+	require.Len(t, resp.Input.Payloads, 1)
+	require.True(t, proto.Equal(want, resp.Input.Payloads[0]))
+	require.Equal(t, []string{"orders"}, v.namespaces)
+}
+
+func TestEncryptionInterceptorDisabledSkipsOutbound(t *testing.T) {
+	t.Parallel()
+
+	v := &fakeVault{}
+	interceptor, err := EncryptionInterceptor(false, v)
+	require.NoError(t, err)
+
+	// A response payload sealed exactly as fakeVault.Seal would produce it, so
+	// the inbound path can open it without the interceptor ever sealing.
+	orig := testPayload("json/plain", `"hi"`)
+	sealed := &common.Payload{
+		Metadata: map[string][]byte{
+			metadataEncoding:        []byte(encryptionEncoding),
+			metadataEncryptionKeyID: []byte(testKEKID),
+			metadataEncryptionDEK:   []byte("dek:orders"),
+		},
+		Data: append([]byte(sealPrefix), mustMarshal(t, orig)...),
+	}
+
+	req := &workflowservice.StartWorkflowExecutionRequest{
+		Namespace: "local",
+		Input:     &common.Payloads{Payloads: []*common.Payload{testPayload("json/plain", `"hi"`)}},
+	}
+	resp := &workflowservice.StartWorkflowExecutionRequest{}
+
+	invoker := func(_ context.Context, _ string, gotReq, gotResp any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
+		// Outbound sealing is disabled: the request payload reaches the upstream
+		// as cleartext with its original encoding.
+		sent := gotReq.(*workflowservice.StartWorkflowExecutionRequest).Input.Payloads[0]
+		require.Equal(t, "json/plain", string(sent.Metadata[metadataEncoding]))
+		require.False(t, bytes.HasPrefix(sent.Data, []byte(sealPrefix)))
+
+		gotResp.(*workflowservice.StartWorkflowExecutionRequest).Input = &common.Payloads{
+			Payloads: []*common.Payload{sealed},
+		}
+		return nil
+	}
+
+	ctx := meta.WithNamespace(t.Context(), "orders")
+	require.NoError(t, interceptor(ctx, "/svc/Start", req, resp, nil, invoker))
+
+	// Inbound decryption still runs even with sealing disabled.
+	require.Len(t, resp.Input.Payloads, 1)
+	require.True(t, proto.Equal(orig, resp.Input.Payloads[0]))
+	require.Equal(t, 1, v.opens, "inbound payload should be opened once")
+	require.Empty(t, v.namespaces, "interceptor must not seal when disabled")
+}
+
+func TestEncryptDecryptPayloadsRoundtrip(t *testing.T) {
+	t.Parallel()
+
+	v := &fakeVault{}
+	vc := visitCtx(meta.WithNamespace(t.Context(), "ns1"))
+
+	original := []*common.Payload{
+		testPayload("json/plain", `"first"`),
+		testPayload("json/plain", `"second"`),
+	}
+	want := []*common.Payload{
+		proto.Clone(original[0]).(*common.Payload),
+		proto.Clone(original[1]).(*common.Payload),
+	}
+
+	sealed, err := encryptPayloads(v)(vc, original)
+	require.NoError(t, err)
+	require.Len(t, sealed, len(original))
+
+	for _, p := range sealed {
+		require.Equal(t, encryptionEncoding, string(p.Metadata[metadataEncoding]))
+		require.Equal(t, testKEKID, string(p.Metadata[metadataEncryptionKeyID]))
+		require.NotEmpty(t, p.Metadata[metadataEncryptionDEK])
+		// The data on the wire is ciphertext, never the marshaled plaintext.
+		require.True(t, bytes.HasPrefix(p.Data, []byte(sealPrefix)))
+	}
+
+	require.Equal(t, []string{"ns1", "ns1"}, v.namespaces)
+
+	opened, err := decryptPayloads(v)(vc, sealed)
+	require.NoError(t, err)
+	require.Len(t, opened, len(want))
+
+	for i := range want {
+		require.True(t, proto.Equal(want[i], opened[i]), "payload %d did not round-trip", i)
+	}
+}
+
+func TestDecryptPayloadsPassesThroughUnencrypted(t *testing.T) {
+	t.Parallel()
+
+	v := &fakeVault{}
+	vc := visitCtx(meta.WithNamespace(t.Context(), "ns1"))
+
+	orig := testPayload("json/plain", `"secret"`)
+	sealed, err := encryptPayloads(v)(vc, []*common.Payload{orig})
+	require.NoError(t, err)
+
+	plain := testPayload("json/plain", `"visible"`)
+
+	out, err := decryptPayloads(v)(vc, []*common.Payload{sealed[0], plain})
+	require.NoError(t, err)
+	require.Len(t, out, 2)
+	require.True(t, proto.Equal(orig, out[0]))
+	require.Same(t, plain, out[1], "unencrypted payload should pass through by reference")
+	require.Equal(t, 1, v.opens, "Open must be called only for the sealed payload")
+}
+
+func TestEncryptPayloadsNamespace(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		ctx  func(t *testing.T) context.Context
+		want string
+	}{
+		{
+			name: "namespace from metadata",
+			ctx:  func(t *testing.T) context.Context { return meta.WithNamespace(t.Context(), "orders") },
+			want: "orders",
+		},
+		{
+			name: "absent namespace seals under empty string",
+			ctx:  func(t *testing.T) context.Context { return t.Context() },
+			want: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			v := &fakeVault{}
+			_, err := encryptPayloads(v)(visitCtx(tc.ctx(t)), []*common.Payload{testPayload("json/plain", "x")})
+			require.NoError(t, err)
+			require.Equal(t, []string{tc.want}, v.namespaces)
+		})
+	}
+}
+
+func TestEncryptDecryptPayloadsErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("seal error", func(t *testing.T) {
+		t.Parallel()
+
+		v := &fakeVault{sealErr: errors.New("kms unavailable")}
+		_, err := encryptPayloads(v)(visitCtx(t.Context()), []*common.Payload{testPayload("json/plain", "x")})
+		require.ErrorContains(t, err, "failed to encrypt payload")
+	})
+
+	t.Run("open error", func(t *testing.T) {
+		t.Parallel()
+
+		v := &fakeVault{}
+		vc := visitCtx(meta.WithNamespace(t.Context(), "ns1"))
+		sealed, err := encryptPayloads(v)(vc, []*common.Payload{testPayload("json/plain", "x")})
+		require.NoError(t, err)
+
+		v.openErr = errors.New("unwrap failed")
+		_, err = decryptPayloads(v)(vc, sealed)
+		require.ErrorContains(t, err, "failed to decrypt payload")
+	})
+
+	t.Run("unmarshal error", func(t *testing.T) {
+		t.Parallel()
+
+		v := &fakeVault{openReturn: []byte{0xFF, 0xFF, 0xFF}}
+		vc := visitCtx(meta.WithNamespace(t.Context(), "ns1"))
+		sealed, err := encryptPayloads(v)(vc, []*common.Payload{testPayload("json/plain", "x")})
+		require.NoError(t, err)
+
+		_, err = decryptPayloads(v)(vc, sealed)
+		require.ErrorContains(t, err, "failed to unmarshal payload")
+	})
+}
+
+func (f *fakeVault) Seal(_ context.Context, ns string, data []byte) (*crypto.Message, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.sealErr != nil {
+		return nil, f.sealErr
+	}
+
+	f.namespaces = append(f.namespaces, ns)
+	return &crypto.Message{
+		Ciphertext:  append([]byte(sealPrefix), data...),
+		KeyMaterial: &crypto.DEKMaterial{KEKID: testKEKID, EncryptedDEK: "dek:" + ns},
+	}, nil
+}
+
+func (f *fakeVault) Open(_ context.Context, msg *crypto.Message) ([]byte, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.opens++
+	if f.openErr != nil {
+		return nil, f.openErr
+	}
+	if f.openReturn != nil {
+		return f.openReturn, nil
+	}
+
+	if !bytes.HasPrefix(msg.Ciphertext, []byte(sealPrefix)) {
+		return nil, fmt.Errorf("ciphertext was not sealed by fakeVault")
+	}
+
+	return bytes.TrimPrefix(msg.Ciphertext, []byte(sealPrefix)), nil
+}
+
+func testPayload(encoding, data string) *common.Payload {
+	return &common.Payload{
+		Metadata: map[string][]byte{metadataEncoding: []byte(encoding)},
+		Data:     []byte(data),
+	}
+}
+
+func mustMarshal(t *testing.T, p *common.Payload) []byte {
+	t.Helper()
+
+	data, err := p.Marshal()
+	require.NoError(t, err)
+	return data
+}
+
+func visitCtx(ctx context.Context) *proxy.VisitPayloadsContext {
+	return &proxy.VisitPayloadsContext{Context: ctx}
+}

--- a/internal/proxy/fx.go
+++ b/internal/proxy/fx.go
@@ -13,12 +13,20 @@ import (
 	"github.com/temporalio/temporal-proxy/internal/protoutil"
 	"github.com/temporalio/temporal-proxy/internal/transport/connect"
 	"github.com/temporalio/temporal-proxy/internal/transport/creds"
+	"github.com/temporalio/temporal-proxy/pkg/crypto"
 	"github.com/temporalio/temporal-proxy/pkg/logger"
 )
 
 // Module is the fx module that constructs the proxy [Server] from [ProxyParams]
 // and binds its lifecycle to the application.
 var Module = fx.Options(fx.Invoke(func(p ProxyParams) error {
+	// Encryption is a security control: if it is enabled but no vault reached
+	// the proxy (a wiring fault, since kms.Module builds one whenever keys are
+	// configured), fail fast rather than silently forwarding cleartext upstream.
+	if p.Config.Encryption.Enabled && p.Vault == nil {
+		return fmt.Errorf("encryption is enabled but no vault was provided")
+	}
+
 	for i := range p.Config.Upstreams {
 		up := &p.Config.Upstreams[i]
 		if err := up.Validate(); err != nil {
@@ -39,6 +47,23 @@ var Module = fx.Options(fx.Invoke(func(p ProxyParams) error {
 		}
 		if cp != nil {
 			dialOpts = append(dialOpts, auth.DialOptions(cp)...)
+		}
+
+		// Payload encryption. A vault is present whenever encryption keys are
+		// configured (see kms.Module), which may be true even when encryption is
+		// disabled; install the interceptor whenever one is present and pass
+		// Enabled so sealing is gated while inbound decryption always runs. This
+		// keeps payloads sealed earlier openable after encryption is turned off
+		// for new traffic. Added after translation so it is the innermost unary
+		// interceptor, sealing outbound payloads last and opening inbound
+		// payloads first.
+		if p.Vault != nil {
+			enc, err := EncryptionInterceptor(p.Config.Encryption.Enabled, p.Vault)
+			if err != nil {
+				return fmt.Errorf("failed to build encryption interceptor for upstream %q: %w", up.Name, err)
+			}
+
+			dialOpts = append(dialOpts, grpc.WithChainUnaryInterceptor(enc))
 		}
 
 		res, err := upstreamResolver(up, dialOpts)
@@ -106,6 +131,7 @@ type ProxyParams struct {
 	Config     *config.Config
 	Translator *protoutil.Translator
 	Pool       *connect.Pool
+	Vault      *crypto.Vault
 
 	// Optional values
 	Logger logger.Logger `optional:"true"`

--- a/internal/proxy/fx_test.go
+++ b/internal/proxy/fx_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/temporalio/temporal-proxy/internal/protoutil"
 	"github.com/temporalio/temporal-proxy/internal/proxy"
 	"github.com/temporalio/temporal-proxy/internal/transport/connect"
+	"github.com/temporalio/temporal-proxy/pkg/crypto"
 	"github.com/temporalio/temporal-proxy/pkg/logger"
 	"github.com/temporalio/temporal-proxy/pkg/testutil"
 	"github.com/temporalio/temporal-proxy/pkg/validation"
@@ -208,6 +209,21 @@ func TestModuleInstallsNamespaceTranslation(t *testing.T) {
 	startServeStop(t, app, upstream)
 }
 
+func TestModuleFailsFastWhenEncryptionEnabledWithoutVault(t *testing.T) {
+	t.Parallel()
+
+	// Encryption is a security control. If it is enabled but the vault is nil
+	// (a wiring fault), the proxy must refuse to start rather than silently
+	// forward cleartext upstream. newProxyApp supplies a nil vault.
+	app := newProxyApp(t, &config.Config{
+		Encryption: config.Encryption{Enabled: true},
+		Upstreams:  []config.Upstream{{Name: "primary", Listen: config.ListenConfig{HostPort: "127.0.0.1:47243"}}},
+	})
+
+	require.Error(t, app.Err())
+	require.ErrorContains(t, app.Err(), "encryption is enabled but no vault")
+}
+
 func TestModuleRequiresTranslator(t *testing.T) {
 	t.Parallel()
 
@@ -216,6 +232,7 @@ func TestModuleRequiresTranslator(t *testing.T) {
 		fx.Supply(&config.Config{
 			Upstreams: []config.Upstream{{Name: "primary", Listen: config.ListenConfig{HostPort: "127.0.0.1:47242"}}},
 		}),
+		fx.Provide(func() *crypto.Vault { return nil }),
 		connect.Module,
 		proxy.Module,
 		fx.NopLogger,
@@ -230,6 +247,10 @@ func newProxyApp(t *testing.T, cfg *config.Config, opts ...fx.Option) *fx.App {
 	base := []fx.Option{
 		fx.Supply(fx.Annotate(t.Context(), fx.As(new(context.Context)))),
 		fx.Supply(cfg),
+		// No encryption keys configured: kms.Module provides a nil vault in that
+		// case, and the proxy skips the encryption interceptor. Tests that
+		// exercise encryption override this with a real vault.
+		fx.Provide(func() *crypto.Vault { return nil }),
 		connect.Module,
 		protoutil.Module,
 		proxy.Module,


### PR DESCRIPTION
The proxy forwards worker traffic to upstream Temporal frontends in the clear. This wires envelope encryption into that hop so payloads are sealed before leaving the proxy and opened on the way back, while local workers keep exchanging cleartext.

EncryptionInterceptor is a unary client interceptor installed on each upstream connection, after namespace translation so it sits innermost: outbound request payloads are sealed last (closest to the wire) and inbound response payloads opened first. Sealing is gated on Encryption.Enabled; decryption always runs so data sealed earlier can still be opened. It is installed only when a vault is present (nil when encryption is disabled, per kms.Module), so the disabled path is untouched.

Adding a required Vault to ProxyParams left the proxy and e2e fx harnesses without a provider; the full-stack harness now wires the real kms.Module (matching cmd/proxy/serve.go) and the minimal helpers supply a nil vault.

Covered by unit tests for the interceptor (round-trip, namespace plumbing, pass-through of unencrypted payloads, error paths) and an end-to-end QueryWorkflow test that proves both directions through the full stack using a local testing:// key.
