### PR TITLE
[kms]: Apply per-namespace encryption key overrides

### DIFF
--- a/internal/config/encryption.go
+++ b/internal/config/encryption.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"maps"
 	"net/url"
 	"slices"
 	"strings"
@@ -20,11 +21,15 @@ var validKeySchemes = []string{
 type (
 	// Encryption configures envelope encryption of payloads. When Enabled, a
 	// Default key policy is required and governs how DEKs are provisioned and
-	// rotated. CacheSize bounds the in-memory DEK cache.
+	// rotated. CacheSize bounds the in-memory DEK cache. Overrides maps a
+	// namespace to a key policy that supersedes Default for that namespace; the
+	// keys are pre-translation (local) namespace names, matching the namespace
+	// the vault seals under at request time.
 	Encryption struct {
-		Enabled   bool       `yaml:"enabled"`
-		CacheSize int        `yaml:"cacheSize"`
-		Default   *KeyPolicy `yaml:"default"`
+		Enabled   bool                 `yaml:"enabled"`
+		CacheSize int                  `yaml:"cacheSize"`
+		Default   *KeyPolicy           `yaml:"default"`
+		Overrides map[string]KeyPolicy `yaml:"overrides"`
 	}
 
 	// KeyPolicy describes the KMS key backing a DEK and its rotation schedule.
@@ -44,15 +49,26 @@ type (
 // encryption is Enabled, and (when a Default is present at all) that the policy
 // itself is valid.
 func (e *Encryption) Validate() error {
-	return validation.Validate(
-		"",
+	rules := []validation.Rule{
 		validation.Field("cacheSize", e.CacheSize, validation.GTE(0)),
 		validation.WhenRules(
 			func() bool { return e.Enabled },
 			validation.Field("default", e.Default, validation.Required[*KeyPolicy]()),
 		),
 		validation.WhenNested(func() bool { return e.Default != nil }, "default", e.Default),
-	)
+	}
+
+	// Sort the namespace keys so error ordering is deterministic across runs.
+	for _, ns := range slices.Sorted(maps.Keys(e.Overrides)) {
+		policy := e.Overrides[ns]
+		subject := fmt.Sprintf("overrides[%s]", ns)
+		rules = append(rules,
+			validation.Field(subject, ns, validation.Required[string]()),
+			validation.Nested(subject, &policy),
+		)
+	}
+
+	return validation.Validate("", rules...)
 }
 
 // Validate requires a valid primary and decrypt key URIs, a positive Duration,

--- a/internal/config/encryption_test.go
+++ b/internal/config/encryption_test.go
@@ -46,6 +46,34 @@ func TestEncryptionValidate(t *testing.T) {
 			},
 			wantErr: "renewBefore",
 		},
+		{
+			name: "valid overrides",
+			cfg: config.Encryption{
+				Enabled:   true,
+				Default:   &valid,
+				Overrides: map[string]config.KeyPolicy{"payments": valid},
+			},
+		},
+		{
+			name: "override with invalid policy",
+			cfg: config.Encryption{
+				Enabled: true,
+				Default: &valid,
+				Overrides: map[string]config.KeyPolicy{
+					"payments": {URI: mustURL(t, "https://example.com/key"), Duration: time.Hour},
+				},
+			},
+			wantErr: "overrides[payments]",
+		},
+		{
+			name: "empty override namespace key",
+			cfg: config.Encryption{
+				Enabled:   true,
+				Default:   &valid,
+				Overrides: map[string]config.KeyPolicy{"": valid},
+			},
+			wantErr: "overrides",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/kms/fx.go
+++ b/internal/kms/fx.go
@@ -3,7 +3,9 @@ package kms
 import (
 	"context"
 	"fmt"
+	"maps"
 	"net/url"
+	"slices"
 	"time"
 
 	"go.uber.org/fx"
@@ -125,13 +127,23 @@ func runRotation(ctx context.Context, v vaultRefresher, interval time.Duration, 
 // size and, when a default key policy is set, its DEK duration and renewal lead
 // time.
 func createVault(c *config.Config, r *crypto.KEKRegistry) (*crypto.Vault, error) {
-	opts := make([]crypto.VaultOption, 0, 2)
+	opts := make([]crypto.VaultOption, 0, 2+len(c.Encryption.Overrides))
 	opts = append(opts, crypto.WithCacheSize(c.Encryption.CacheSize))
 
 	if dp := c.Encryption.Default; dp != nil {
 		opts = append(opts, crypto.WithDefaultKeyConfig(crypto.KeyConfig{
 			Duration:    dp.Duration,
 			RenewBefore: dp.RenewBefore,
+		}))
+	}
+
+	// Each override carries its own DEK lifetime; register it so the override
+	// namespace rotates on its own schedule rather than inheriting the default.
+	for _, ns := range slices.Sorted(maps.Keys(c.Encryption.Overrides)) {
+		policy := c.Encryption.Overrides[ns]
+		opts = append(opts, crypto.WithKeyConfig(ns, crypto.KeyConfig{
+			Duration:    policy.Duration,
+			RenewBefore: policy.RenewBefore,
 		}))
 	}
 
@@ -149,7 +161,19 @@ func createVault(c *config.Config, r *crypto.KEKRegistry) (*crypto.Vault, error)
 func createKEKRegistry(ctx context.Context, lc fx.Lifecycle, c *config.Config, logger logger.Logger) (*crypto.KEKRegistry, error) {
 	opts := []crypto.KEKRegistryOption{}
 	if dp := c.Encryption.Default; dp != nil {
-		res, err := keyPolicyRegistryOpts(ctx, dp, logger, defaultNamespace)
+		res, err := keyPolicyRegistryOpts(ctx, dp, logger, defaultNamespace, true)
+		if err != nil {
+			return nil, err
+		}
+
+		opts = append(opts, res...)
+	}
+
+	// Sort the namespace keys so keys open in a deterministic order (steadier
+	// logs and, on a partial failure, a repeatable point of failure).
+	for _, ns := range slices.Sorted(maps.Keys(c.Encryption.Overrides)) {
+		policy := c.Encryption.Overrides[ns]
+		res, err := keyPolicyRegistryOpts(ctx, &policy, logger, ns, false)
 		if err != nil {
 			return nil, err
 		}
@@ -171,14 +195,18 @@ func createKEKRegistry(ctx context.Context, lc fx.Lifecycle, c *config.Config, l
 }
 
 // keyPolicyRegistryOpts turns a single key policy into registry options for the
-// given namespace: the policy's primary URI becomes the namespace's encryption
-// key (the default key when ns is the default namespace), and every DecryptURIs
-// entry is registered decrypt-only.
+// given namespace: the policy's primary URI becomes an encryption key and every
+// DecryptURIs entry is registered decrypt-only. When asDefault is true the
+// primary is registered as the registry's fallback default key; otherwise it is
+// bound to ns. asDefault is passed explicitly rather than inferred from ns so an
+// override for the literal "default" namespace registers a namespace key instead
+// of clobbering the configured default.
 func keyPolicyRegistryOpts(
 	ctx context.Context,
 	p *config.KeyPolicy,
 	log logger.Logger,
 	ns string,
+	asDefault bool,
 ) ([]crypto.KEKRegistryOption, error) {
 	opts := []crypto.KEKRegistryOption{}
 	keys, err := createKEKs(ctx, p, log, ns)
@@ -187,7 +215,7 @@ func keyPolicyRegistryOpts(
 	}
 
 	// NB: KeyConfig.URI is required and therefore this will never be out of bounds.
-	if ns == defaultNamespace {
+	if asDefault {
 		opts = append(opts, crypto.WithDefaultKey(keys[0]))
 	} else {
 		opts = append(opts, crypto.WithKeyForNamespace(ns, keys[0]))

--- a/internal/kms/fx_test.go
+++ b/internal/kms/fx_test.go
@@ -127,14 +127,14 @@ func TestKeyPolicyRegistryOpts(t *testing.T) {
 
 	log := logger.NewNoopLogger()
 
-	// The default namespace registers a default key, so the registry builds.
-	// A non-default namespace registers only a namespace key, which is not
-	// sufficient on its own (NewKEKRegistry requires a default), proving the
-	// branch chose WithKeyForNamespace over WithDefaultKey.
-	t.Run("default namespace yields a usable default key", func(t *testing.T) {
+	// asDefault selects WithDefaultKey vs WithKeyForNamespace. A default key lets
+	// NewKEKRegistry build; a namespace key alone does not (a default is
+	// required), so the registry's success or failure reveals which option was
+	// chosen.
+	t.Run("asDefault registers a usable default key", func(t *testing.T) {
 		t.Parallel()
 
-		opts, err := keyPolicyRegistryOpts(t.Context(), &config.KeyPolicy{URI: distinctKeyURL(t, 1)}, log, defaultNamespace)
+		opts, err := keyPolicyRegistryOpts(t.Context(), &config.KeyPolicy{URI: distinctKeyURL(t, 1)}, log, defaultNamespace, true)
 		require.NoError(t, err)
 
 		reg, err := crypto.NewKEKRegistry(opts...)
@@ -142,10 +142,23 @@ func TestKeyPolicyRegistryOpts(t *testing.T) {
 		require.NoError(t, reg.Close())
 	})
 
-	t.Run("non-default namespace has no default key", func(t *testing.T) {
+	t.Run("non-default registers only a namespace key", func(t *testing.T) {
 		t.Parallel()
 
-		opts, err := keyPolicyRegistryOpts(t.Context(), &config.KeyPolicy{URI: distinctKeyURL(t, 2)}, log, "other")
+		opts, err := keyPolicyRegistryOpts(t.Context(), &config.KeyPolicy{URI: distinctKeyURL(t, 2)}, log, "other", false)
+		require.NoError(t, err)
+
+		_, err = crypto.NewKEKRegistry(opts...)
+		require.Error(t, err)
+	})
+
+	// The decision is driven by asDefault, not by the namespace string: an
+	// override for the literal "default" namespace must register a namespace key,
+	// not silently overwrite the configured default key.
+	t.Run("default namespace with asDefault false is a namespace key", func(t *testing.T) {
+		t.Parallel()
+
+		opts, err := keyPolicyRegistryOpts(t.Context(), &config.KeyPolicy{URI: distinctKeyURL(t, 3)}, log, defaultNamespace, false)
 		require.NoError(t, err)
 
 		_, err = crypto.NewKEKRegistry(opts...)
@@ -187,6 +200,31 @@ func TestCreateVault(t *testing.T) {
 	}
 }
 
+func TestCreateVault_AppliesOverrideKeyConfig(t *testing.T) {
+	t.Parallel()
+
+	dk, err := newKEK(t.Context(), "testing://")
+	require.NoError(t, err)
+	reg, err := crypto.NewKEKRegistry(crypto.WithDefaultKey(dk))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = reg.Close() })
+
+	// An override with an invalid KeyConfig (RenewBefore >= Duration) must make
+	// createVault fail. Config validation would normally reject this, but calling
+	// createVault directly bypasses it, so the error proves the override's config
+	// reaches WithKeyConfig instead of being dropped.
+	cfg := &config.Config{Encryption: config.Encryption{
+		CacheSize: 10,
+		Default:   &config.KeyPolicy{Duration: time.Hour, RenewBefore: time.Minute},
+		Overrides: map[string]config.KeyPolicy{
+			"payments": {Duration: time.Hour, RenewBefore: time.Hour},
+		},
+	}}
+
+	_, err = createVault(cfg, reg)
+	require.Error(t, err)
+}
+
 func TestCreateKEKRegistry(t *testing.T) {
 	t.Parallel()
 
@@ -200,6 +238,41 @@ func TestCreateKEKRegistry(t *testing.T) {
 	// The registered OnStop hook closes the registry without error.
 	lc.RequireStart()
 	lc.RequireStop()
+}
+
+func TestCreateKEKRegistry_OverrideKeySelectedByNamespace(t *testing.T) {
+	t.Parallel()
+
+	lc := fxtest.NewLifecycle(t)
+	defaultURL := distinctKeyURL(t, 1)
+	overrideURL := distinctKeyURL(t, 2)
+
+	cfg := &config.Config{Encryption: config.Encryption{
+		Enabled:   true,
+		CacheSize: 10,
+		Default:   &config.KeyPolicy{URI: defaultURL, Duration: time.Hour, RenewBefore: time.Minute},
+		Overrides: map[string]config.KeyPolicy{
+			"payments": {URI: overrideURL, Duration: time.Hour, RenewBefore: time.Minute},
+		},
+	}}
+
+	reg, err := createKEKRegistry(t.Context(), lc, cfg, logger.NewNoopLogger())
+	require.NoError(t, err)
+	lc.RequireStart()
+	t.Cleanup(func() { lc.RequireStop() })
+
+	vault, err := createVault(cfg, reg)
+	require.NoError(t, err)
+
+	// The override namespace seals under its own KEK.
+	msg, err := vault.Seal(t.Context(), "payments", []byte("secret"))
+	require.NoError(t, err)
+	require.Equal(t, "base64key://"+overrideURL.Host, msg.KeyMaterial.KEKID)
+
+	// Any namespace without an override falls back to the default KEK.
+	msg, err = vault.Seal(t.Context(), "other", []byte("secret"))
+	require.NoError(t, err)
+	require.Equal(t, "base64key://"+defaultURL.Host, msg.KeyMaterial.KEKID)
 }
 
 func TestModule_NoKeys_ProvidesNilVault(t *testing.T) {


### PR DESCRIPTION
Add overrides to the encryption config (map of namespace -> KeyPolicy) to let individual namespaces use a key policy other than the default.

The override keys are pre-translation (local) namespace names, which matches the namespace the vault seals under at request time (meta.NamespaceFrom reads x-temporal-proxy-namespace, which translation never rewrites).

keyPolicyRegistryOpts previously decided "is this the default key?" by comparing ns == "default", which conflated the internal sentinel with a real, common Temporal namespace. An override keyed "default" would have silently overwritten the configured default key. It now requires an explicit flag, so an override for "default" registers a proper namespace key (which the vault already prefers over the fallback), while Default remains the catch-all.