### PR TITLE
[creds]: Accept ECDSA server certs in preferredCipherSuites

### DIFF
--- a/internal/transport/creds/tls.go
+++ b/internal/transport/creds/tls.go
@@ -16,12 +16,16 @@ import (
 const minTLSVersion = tls.VersionTLS12
 
 // preferredCipherSuites lists the only TLS 1.2 cipher suites accepted on
-// server connections. Both use ECDHE for forward secrecy and AES-GCM for
-// authenticated encryption. TLS 1.3 cipher suites are not controlled by this
-// field and are always negotiated by the Go runtime.
+// server connections. All use ECDHE for forward secrecy and AES-GCM for
+// authenticated encryption; both RSA and ECDSA leaf keys are supported so the
+// proxy accepts identity material from either family. TLS 1.3 cipher suites
+// are not controlled by this field and are always negotiated by the Go
+// runtime.
 var preferredCipherSuites = []uint16{
 	tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
 	tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+	tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+	tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
 }
 
 // TLS enables one-way (server-side) TLS on gRPC connections. The server

--- a/internal/transport/creds/tls_test.go
+++ b/internal/transport/creds/tls_test.go
@@ -93,7 +93,6 @@ func TestTLS_Validate(t *testing.T) {
 	t.Run("valid RSA cert passes", func(t *testing.T) {
 		t.Parallel()
 
-		// preferredCipherSuites are RSA-only, so the leaf must use an RSA key.
 		// Validate only checks that the key file exists and is PEM; it does
 		// not verify cert/key matching (LoadX509KeyPair does that at runtime).
 		certFile := writePEMFile(t, testutil.RSACert(t, validTemplate()))
@@ -122,12 +121,13 @@ func TestTLS_Validate(t *testing.T) {
 		require.ErrorContains(t, err, "expired")
 	})
 
-	t.Run("ECDSA cert rejected by RSA-only cipher suites", func(t *testing.T) {
+	t.Run("ECDSA cert accepted", func(t *testing.T) {
 		t.Parallel()
 
+		// preferredCipherSuites includes ECDHE_ECDSA suites so
+		// ECDSA identity material validates successfully.
 		certFile := writePEMFile(t, testutil.ECDSACert(t, validTemplate()))
-		err := creds.NewServerTLS(certFile, "").Validate()
-		require.ErrorContains(t, err, "key type")
+		require.NoError(t, creds.NewServerTLS(certFile, validKey(t)).Validate())
 	})
 
 	t.Run("client TLS has no certFile and fails to read", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Add `TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384` and `TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256` to `preferredCipherSuites` in `internal/transport/creds/tls.go`.

Until now `preferredCipherSuites` listed only `ECDHE_RSA` variants, so `TLS.Validate()` — via `UsesSecureCertificateAlgorithm(preferredCipherSuites...)` in `internal/transport/creds/validation.go` — rejected any server credential whose leaf uses an ECDSA key with:

```
key type "ecdsa" incompatible with allowed cipher suites
```

That's a real deployment blocker for identity systems that issue ECDSA leaves by default. Adding the two ECDHE_ECDSA_AES_GCM suites is the minimum change to accept ECDSA leaves without loosening any other property of the negotiated session:

- Still ECDHE (forward secrecy).
- Still AES-GCM (authenticated encryption).
- Still TLS 1.2 minimum; TLS 1.3 negotiation is unchanged (Go doesn't let this field control it).
- No new key exchanges (no static-RSA, no CBC, no ChaCha20 additions).

So this widens the set of acceptable *leaf key types* on the server side without widening the negotiation surface.

## Test plan

- [x] `go test ./internal/transport/creds/...` — passes locally.
- [x] Updated the existing `TestTLS_Validate` subtest for ECDSA:
      renamed `"ECDSA cert rejected by RSA-only cipher suites"` → `"ECDSA cert accepted"`, replaced the `require.ErrorContains(err, "key type")` assertion with `require.NoError(...)`.
- [x] Dropped a now-inaccurate `// preferredCipherSuites are RSA-only` comment on the RSA-cert subtest.
- [x] `go vet ./internal/transport/creds/...` clean.

## Notes for reviewers

- No production code paths changed besides the cipher-suite slice literal.
- `HasSufficientKeySize` in `internal/transport/creds/validation.go` already accepted ECDSA keys (min 256-bit curve) — that path was reachable but only via a non-empty `allowedSuites` set that included at least one ECDSA suite, which is why it hadn't been triggered by prior tests.
- `MTLS.Validate()` also feeds `preferredCipherSuites` into `UsesSecureCertificateAlgorithm` (see `internal/transport/creds/mtls.go`), so mTLS server-side validation gets the same fix for free.