### PR TITLE
[api]: Add extension servers as pluggable KEK providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ reaches a different upstream with no change to the Worker.
 - **Payload encryption.** Optionally seal payloads with envelope encryption on the hop to an upstream and open them on
   responses, so the upstream only ever sees ciphertext while local Workers keep exchanging cleartext. DEKs are wrapped
   by a KMS key (AWS KMS, Azure Key Vault, or GCP KMS), rotate automatically, and can be overridden per Namespace.
+- **Pluggable key management.** For a backend the proxy has no built-in support for, such as an on-prem HSM or an
+  internal key service, point it at an extension server you run and it wraps DEKs through that instead. Only key
+  material is exchanged; payloads never reach it.
 - **Inbound authentication.** Optional static-token or JWKS validation on the gateway; off by default.
 - **Codec-transparent.** The gateway never parses payloads. It peeks the Namespace, picks an upstream, and relays raw
   frames in both directions.
@@ -147,6 +150,7 @@ rewrite on the way to Cloud. Follow its README to run it end to end.
 | gateway          | The single inbound gRPC endpoint that every SDK Client, Worker, and the UI connects to. It routes each request to an upstream by Namespace and/or request metadata, and never parses payloads. |
 | upstream         | A configured destination the proxy forwards to: a Temporal Service (local dev, self-hosted, or Temporal Cloud), or another Temporal Proxy.                                                     |
 | system upstream  | The upstream that handles Namespace-less requests, such as the SDK's `GetSystemInfo` call on connect.                                                                                          |
+| extension server | A gRPC service you run that the proxy calls out to for a capability it has no built-in backend for. Today that means wrapping DEKs as a key management backend.                                |
 | Temporal Service | A Temporal frontend the proxy connects to.                                                                                                                                                     |
 
 ## Development

--- a/cmd/proxy/serve.go
+++ b/cmd/proxy/serve.go
@@ -9,6 +9,7 @@ import (
 	"go.uber.org/fx"
 	"google.golang.org/protobuf/reflect/protoreflect"
 
+	"github.com/temporalio/temporal-proxy/internal/api"
 	"github.com/temporalio/temporal-proxy/internal/auth"
 	"github.com/temporalio/temporal-proxy/internal/config"
 	"github.com/temporalio/temporal-proxy/internal/kms"
@@ -72,6 +73,7 @@ func serve() *cli.Command {
 					func() prometheus.Gatherer { return prometheus.DefaultGatherer },
 					func() prometheus.Registerer { return prometheus.DefaultRegisterer },
 				),
+				api.Module,
 				auth.Module,
 				config.Module,
 				connect.Module,

--- a/e2e/harness_test.go
+++ b/e2e/harness_test.go
@@ -17,6 +17,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
 
+	"github.com/temporalio/temporal-proxy/internal/api"
 	"github.com/temporalio/temporal-proxy/internal/auth"
 	"github.com/temporalio/temporal-proxy/internal/config"
 	"github.com/temporalio/temporal-proxy/internal/kms"
@@ -99,6 +100,7 @@ func newFullApp(t *testing.T, cfg *config.Config) *fx.App {
 			func() prometheus.Gatherer { return reg },
 			func() prometheus.Registerer { return reg },
 		),
+		api.Module,
 		auth.Module,
 		connect.Module,
 		kms.Module,

--- a/internal/api/doc.go
+++ b/internal/api/doc.go
@@ -1,0 +1,18 @@
+// Package api reaches the extension servers an operator runs: gRPC services
+// implementing one of the contracts published under api/, currently
+// api.kms.v1.EncryptionService.
+//
+// Extension servers exist so an operator can plug in a backend the proxy has no
+// built-in support for, such as an on-prem HSM or an internal key service.
+//
+// [Module] dials every server named in the configuration and publishes the
+// results as [Connections], keyed by server name. Callers build their own
+// clients over those connections rather than receiving finished ones, because
+// the two do not correspond one-to-one: [KMS] is the client for the encryption
+// service, and one is built per key, several of which may live on one server.
+//
+// Dialing happens when the connections are first demanded rather than on the
+// first call over them, so a bad address, certificate, or credential is caught
+// during construction. The connections outlive this package and are closed with
+// the application, not by any client built over them.
+package api

--- a/internal/api/fx.go
+++ b/internal/api/fx.go
@@ -1,0 +1,116 @@
+package api
+
+import (
+	"fmt"
+
+	"go.uber.org/fx"
+	"google.golang.org/grpc"
+
+	"github.com/temporalio/temporal-proxy/internal/auth"
+	"github.com/temporalio/temporal-proxy/internal/config"
+	"github.com/temporalio/temporal-proxy/internal/transport/connect"
+)
+
+// extensionKeyPrefix namespaces extension-server entries in the shared
+// connection pool.
+//
+// A static resolver uses its dial address as the pool key, and Pool.ConnOrCreate
+// returns the existing connection for a key while ignoring the options passed
+// with it. Upstream hostPorts are unique among themselves, but nothing stops an
+// extension server from sitting on the same host:port as an upstream, so without
+// a distinct key the two would collapse onto whichever was dialed first and
+// silently inherit its TLS settings and credentials.
+const extensionKeyPrefix = "extension:"
+
+// Module provides the pooled connection for every configured extension server,
+// built when the provider runs rather than on first use, so a bad dial target,
+// certificate, or credential surfaces at construction instead of on the first
+// encryption call.
+var Module = fx.Options(
+	fx.Provide(func(p APIParams) (Connections, error) {
+		// api.Module is wired ahead of server.Module, which is what validates the
+		// config as a whole, so re-check here rather than dial whatever happened
+		// to parse. Validating the list rather than each entry also covers its
+		// collection invariants: duplicate names would otherwise collapse into a
+		// single map entry, silently dropping a server.
+		if err := p.Config.ExtensionServers.Validate(); err != nil {
+			return nil, fmt.Errorf("invalid extension server configuration: %w", err)
+		}
+
+		out := make(Connections, len(p.Config.ExtensionServers))
+		for i := range p.Config.ExtensionServers {
+			es := &p.Config.ExtensionServers[i]
+
+			conn, err := extensionConn(p.Pool, es)
+			if err != nil {
+				return nil, err
+			}
+
+			out[es.Name] = conn
+		}
+
+		return out, nil
+	}),
+)
+
+type (
+	// APIParams collects the fx-provided dependencies needed to reach the
+	// configured extension servers. Pool is shared with the proxy's upstream
+	// connections; [connect.Module] owns it and closes every pooled connection
+	// on shutdown, which is why [KMS.Close] is a no-op.
+	APIParams struct {
+		fx.In
+
+		Config *config.Config
+		Pool   *connect.Pool
+	}
+
+	// Connections maps an extension server name to a connection to that server.
+	// It carries no lifecycle: closing a connection is the owner's
+	// responsibility, not the caller's.
+	//
+	// Callers get connections rather than finished clients because the two do not
+	// correspond one-to-one: several keys may live on one extension server, so a
+	// caller builds one [KMS] per key over the shared connection.
+	Connections map[string]grpc.ClientConnInterface
+)
+
+// extensionConn builds the pooled connection for a single extension server.
+// Config rejects a templated hostPort, so the target is always static: the
+// resolver is fixed and [connect.NewConn] creates the connection eagerly.
+//
+// This is deliberately narrower than the equivalent upstream path in
+// internal/proxy. There is no namespace translation, because an extension
+// server is not a Temporal service and has no namespaces to rewrite, and no
+// payload encryption interceptor, because an extension server is the thing that
+// wraps DEKs; sealing its traffic with the vault it backs would be circular.
+func extensionConn(pool *connect.Pool, s *config.ExtensionServer) (*connect.Conn, error) {
+	var opts []grpc.DialOption
+
+	cp, err := auth.CredentialProviderFor(s.Credentials)
+	if err != nil {
+		return nil, fmt.Errorf("invalid credentials for extension server %q: %w", s.Name, err)
+	}
+
+	if cp != nil {
+		opts = append(opts, auth.DialOptions(cp)...)
+	}
+
+	// A nil TLS block resolves to a plaintext dialer, so this is safe unset.
+	serverName := ""
+	if s.Listen.TLS != nil {
+		serverName = s.Listen.TLS.ServerName
+	}
+
+	cred, err := s.Listen.TLS.Dialer().DialOption(serverName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build credentials for extension server %q: %w", s.Name, err)
+	}
+
+	return connect.NewConn(
+		func(key, target string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+			return pool.ConnOrCreate(extensionKeyPrefix+key, target, opts...)
+		},
+		connect.StaticResolver(s.Listen.HostPort, append(opts, cred)...),
+	)
+}

--- a/internal/api/fx_test.go
+++ b/internal/api/fx_test.go
@@ -1,0 +1,235 @@
+package api_test
+
+import (
+	"maps"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/temporalio/temporal-proxy/internal/api"
+	"github.com/temporalio/temporal-proxy/internal/config"
+	"github.com/temporalio/temporal-proxy/internal/transport/connect"
+)
+
+// buildModule wires api.Module against the supplied config and pool, returning
+// the extension server connections and whatever error fx reported. fx.Populate
+// demands the value, so a dial failure surfaces from fx.New.
+func buildModule(t *testing.T, cfg *config.Config, pool *connect.Pool) (api.Connections, error) {
+	t.Helper()
+
+	var out api.Connections
+	app := fx.New(
+		fx.Supply(cfg, pool),
+		api.Module,
+		fx.Populate(&out),
+		fx.NopLogger,
+	)
+
+	return out, app.Err()
+}
+
+func extensionServers(servers ...config.ExtensionServer) *config.Config {
+	return &config.Config{
+		Listen:           config.ListenConfig{HostPort: ":8080"},
+		ExtensionServers: servers,
+		Upstreams: config.UpstreamList{
+			{Name: "primary", Listen: config.ListenConfig{HostPort: "127.0.0.1:7233"}},
+		},
+	}
+}
+
+func TestModuleBuildsAConnPerExtensionServer(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		servers   []config.ExtensionServer
+		wantNames []string
+	}{
+		{
+			name:      "no extension servers yields no connections",
+			wantNames: []string{},
+		},
+		{
+			name: "one server is keyed by its name",
+			servers: []config.ExtensionServer{
+				{Name: "audit", Listen: config.ListenConfig{HostPort: "127.0.0.1:9090"}},
+			},
+			wantNames: []string{"audit"},
+		},
+		{
+			name: "every server gets its own entry",
+			servers: []config.ExtensionServer{
+				{Name: "audit", Listen: config.ListenConfig{HostPort: "127.0.0.1:9090"}},
+				{Name: "quota", Listen: config.ListenConfig{HostPort: "127.0.0.1:9091"}},
+				{Name: "hsm", Listen: config.ListenConfig{HostPort: "127.0.0.1:9092"}},
+			},
+			wantNames: []string{"audit", "quota", "hsm"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := buildModule(t, extensionServers(tt.servers...), connect.NewPool())
+			require.NoError(t, err)
+			require.ElementsMatch(t, tt.wantNames, slices.Collect(maps.Keys(got)))
+
+			for name, conn := range got {
+				require.NotNil(t, conn, "no connection for %q", name)
+			}
+		})
+	}
+}
+
+func TestModuleGivesEachServerADistinctConn(t *testing.T) {
+	t.Parallel()
+
+	// Several keys may address one extension server and share its connection,
+	// but two different servers must never share one.
+	got, err := buildModule(t, extensionServers(
+		config.ExtensionServer{Name: "audit", Listen: config.ListenConfig{HostPort: "127.0.0.1:9090"}},
+		config.ExtensionServer{Name: "quota", Listen: config.ListenConfig{HostPort: "127.0.0.1:9091"}},
+	), connect.NewPool())
+	require.NoError(t, err)
+	require.NotSame(t, got["audit"], got["quota"])
+}
+
+func TestModuleRejectsInvalidExtensionServers(t *testing.T) {
+	t.Parallel()
+
+	// api.Module is wired ahead of server.Module, so it cannot assume the
+	// config has been validated; a bad entry must fail here rather than be
+	// dialed as-is.
+	tests := []struct {
+		name    string
+		server  config.ExtensionServer
+		wantErr string
+	}{
+		{
+			name:    "templated hostPort",
+			server:  config.ExtensionServer{Name: "audit", Listen: config.ListenConfig{HostPort: "{{ .Ns }}.acme.cloud:9090"}},
+			wantErr: "templates are not resolved for extension servers",
+		},
+		{
+			name:    "missing name",
+			server:  config.ExtensionServer{Listen: config.ListenConfig{HostPort: "127.0.0.1:9090"}},
+			wantErr: "name",
+		},
+		{
+			name:    "invalid hostPort",
+			server:  config.ExtensionServer{Name: "audit", Listen: config.ListenConfig{HostPort: "nope"}},
+			wantErr: "is not a valid host:port",
+		},
+		{
+			name: "credentials without TLS",
+			server: config.ExtensionServer{
+				Name:        "audit",
+				Listen:      config.ListenConfig{HostPort: "127.0.0.1:9090"},
+				Credentials: &config.CredentialConfig{Static: &config.StaticCredentialConfig{APIKey: "k"}},
+			},
+			wantErr: "requires TLS",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := buildModule(t, extensionServers(tt.server), connect.NewPool())
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestModulePoolsConnectionsUnderANamespacedKey(t *testing.T) {
+	t.Parallel()
+
+	pool := connect.NewPool()
+	_, err := buildModule(t, extensionServers(
+		config.ExtensionServer{Name: "audit", Listen: config.ListenConfig{HostPort: "127.0.0.1:9090"}},
+	), pool)
+	require.NoError(t, err)
+
+	// The connection is created eagerly, under a key distinct from the bare
+	// dial address, so it cannot be handed to a caller resolving that address.
+	conn, err := pool.Conn("extension:127.0.0.1:9090")
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+
+	_, err = pool.Conn("127.0.0.1:9090")
+	require.ErrorIs(t, err, connect.ErrKeyNotFound)
+}
+
+func TestModuleDoesNotCollideWithAnUpstreamOnTheSameHostPort(t *testing.T) {
+	t.Parallel()
+
+	const hostPort = "127.0.0.1:7233"
+
+	// Config permits an extension server to sit on an upstream's hostPort, and
+	// the pool is shared between them. Stand in for the upstream by seeding the
+	// pool the way a static resolver would, keyed by the bare address.
+	pool := connect.NewPool()
+	upstreamConn, err := grpc.NewClient(hostPort, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	require.NoError(t, pool.Set(hostPort, upstreamConn))
+
+	_, err = buildModule(t, extensionServers(
+		config.ExtensionServer{Name: "audit", Listen: config.ListenConfig{HostPort: hostPort}},
+	), pool)
+	require.NoError(t, err)
+
+	extensionConn, err := pool.Conn("extension:" + hostPort)
+	require.NoError(t, err)
+
+	// Distinct entries: the extension server did not inherit the upstream's
+	// connection, which carries the upstream's TLS settings and credentials.
+	require.NotSame(t, upstreamConn, extensionConn)
+
+	got, err := pool.Conn(hostPort)
+	require.NoError(t, err)
+	require.Same(t, upstreamConn, got, "the upstream entry must be left untouched")
+}
+
+func TestModuleRejectsCollectionLevelConfigErrors(t *testing.T) {
+	t.Parallel()
+
+	// The whole list is validated, not just each entry. Duplicates would
+	// otherwise collapse into one map key and silently drop a server.
+	tests := []struct {
+		name    string
+		servers []config.ExtensionServer
+		wantErr string
+	}{
+		{
+			name: "duplicate names",
+			servers: []config.ExtensionServer{
+				{Name: "audit", Listen: config.ListenConfig{HostPort: "127.0.0.1:9090"}},
+				{Name: "audit", Listen: config.ListenConfig{HostPort: "127.0.0.1:9091"}},
+			},
+			wantErr: "contains duplicate value: audit",
+		},
+		{
+			name: "duplicate hostPorts",
+			servers: []config.ExtensionServer{
+				{Name: "audit", Listen: config.ListenConfig{HostPort: "127.0.0.1:9090"}},
+				{Name: "quota", Listen: config.ListenConfig{HostPort: "127.0.0.1:9090"}},
+			},
+			wantErr: "contains duplicate value: 127.0.0.1:9090",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := buildModule(t, extensionServers(tt.servers...), connect.NewPool())
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}

--- a/internal/api/kms.go
+++ b/internal/api/kms.go
@@ -9,11 +9,20 @@ import (
 	"github.com/temporalio/temporal-proxy/pkg/api/kms/v1"
 )
 
+// KMS wraps and unwraps data encryption keys on an extension server
+// implementing api.kms.v1.EncryptionService. Only key material crosses the
+// wire; payload plaintext never reaches the server.
+//
+// The id names the key this client addresses. It is recorded in every DEK the
+// key wraps and is what selects the key again when unwrapping, so it must stay
+// stable for as long as any sealed payload references it.
 type KMS struct {
 	id  string
 	kms kms.EncryptionServiceClient
 }
 
+// NewKMS returns a KMS addressing the key named by id over cc. Several keys may
+// live on one extension server and share a connection, so cc is not owned here.
 func NewKMS(id string, cc grpc.ClientConnInterface) *KMS {
 	return &KMS{
 		id:  id,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,11 +15,12 @@ import (
 type (
 	// Config is the top-level proxy configuration.
 	Config struct {
-		Listen     ListenConfig `yaml:",inline"`
-		Encryption Encryption   `yaml:"encryption"`
-		Routing    Routing      `yaml:"routing"`
-		Upstreams  []Upstream   `yaml:"upstreams"`
-		Auth       *AuthConfig  `yaml:"auth"`
+		Listen           ListenConfig        `yaml:",inline"`
+		Encryption       Encryption          `yaml:"encryption"`
+		ExtensionServers ExtensionServerList `yaml:"extensionServers"`
+		Routing          Routing             `yaml:"routing"`
+		Upstreams        UpstreamList        `yaml:"upstreams"`
+		Auth             *AuthConfig         `yaml:"auth"`
 	}
 )
 
@@ -62,7 +63,7 @@ func LoadFile(path string) (*Config, error) {
 // routing reference on the "routing"/"routing.rules[i]" subject.
 func (c *Config) Validate() error {
 	rules := []validation.Rule{
-		validation.Field("upstreams", c.Upstreams, func(us []Upstream) error {
+		validation.Field("upstreams", c.Upstreams, func(us UpstreamList) error {
 			if len(us) == 0 {
 				return errors.New("at least one upstream is required")
 			}
@@ -71,23 +72,24 @@ func (c *Config) Validate() error {
 		}),
 		validation.Nested("", &c.Listen),
 		validation.Nested("encryption", &c.Encryption),
+		validation.Nested("extensionServers", &c.ExtensionServers),
 		validation.Nested("routing", &c.Routing),
 		validation.WhenRules(func() bool { return c.Auth != nil }, validation.Nested("auth", c.Auth)),
-		validation.Children("upstreams", c.Upstreams, func(u *Upstream) error { return u.Validate() }),
+		validation.Nested("upstreams", &c.Upstreams),
 	}
 
-	names := make([]string, len(c.Upstreams))
-	hostPorts := make([]string, len(c.Upstreams))
 	known := make(map[string]struct{}, len(c.Upstreams))
 	for i := range c.Upstreams {
-		names[i] = c.Upstreams[i].Name
-		hostPorts[i] = c.Upstreams[i].Listen.HostPort
-		known[names[i]] = struct{}{}
+		known[c.Upstreams[i].Name] = struct{}{}
 	}
 
-	rules = append(rules, validation.Field("upstreams[name]", names, validation.Unique[string]()))
-	rules = append(rules, validation.Field("upstreams[hostPort]", hostPorts, validation.Unique[string]()))
+	knownExtensions := make(map[string]struct{}, len(c.ExtensionServers))
+	for i := range c.ExtensionServers {
+		knownExtensions[c.ExtensionServers[i].Name] = struct{}{}
+	}
+
 	rules = append(rules, c.Routing.referentialRules(known)...)
+	rules = append(rules, c.Encryption.referentialRules(knownExtensions)...)
 	return validation.Validate("", rules...)
 }
 

--- a/internal/config/encryption.go
+++ b/internal/config/encryption.go
@@ -11,9 +11,14 @@ import (
 	"github.com/temporalio/temporal-proxy/pkg/validation"
 )
 
+// extensionKeyScheme addresses a key served by a configured extension server,
+// as "extension://<server>/<key>". The host names an entry in ExtensionServers.
+const extensionKeyScheme = "extension"
+
 var validKeySchemes = []string{
 	"awskms",
 	"azurekeyvault",
+	extensionKeyScheme,
 	"gcpkms",
 	"testing",
 }
@@ -86,6 +91,60 @@ func (p *KeyPolicy) Validate() error {
 	)
 }
 
+// referentialRules checks that every "extension://" key URI names a configured
+// extension server, given the set of known names. Each failure is stamped with
+// the referring policy's YAML path so it lands on the right key (e.g.
+// "encryption.default"/"uri" or "encryption.overrides[payments]"/"decryptURIs[1]").
+// Non-extension URIs are skipped; their scheme is already checked by validKeyURI.
+//
+// The rules are appended at the Config level rather than composed under
+// Encryption.Validate because they need the full set of extension server names,
+// which is only known there.
+func (e *Encryption) referentialRules(known map[string]struct{}) []validation.Rule {
+	var rules []validation.Rule
+
+	policy := func(subject string, p *KeyPolicy) {
+		rules = append(rules, extensionRef(subject, "uri", &p.URI, known))
+		for i := range p.DecryptURIs {
+			rules = append(rules, extensionRef(subject, fmt.Sprintf("decryptURIs[%d]", i), &p.DecryptURIs[i], known))
+		}
+	}
+
+	if e.Default != nil {
+		policy("encryption.default", e.Default)
+	}
+
+	// Sorted so error ordering is deterministic across runs, matching Validate.
+	for _, ns := range slices.Sorted(maps.Keys(e.Overrides)) {
+		p := e.Overrides[ns]
+		policy(fmt.Sprintf("encryption.overrides[%s]", ns), &p)
+	}
+
+	return rules
+}
+
+// extensionRef builds a Rule reporting an extension key URI whose host names no
+// configured extension server. A URI with another scheme, or with no host at
+// all, yields nothing: the former is not a reference and the latter is reported
+// by the scheme check.
+func extensionRef(subject, field string, u *url.URL, known map[string]struct{}) validation.Rule {
+	return func() validation.Errors {
+		if !strings.EqualFold(u.Scheme, extensionKeyScheme) || u.Host == "" {
+			return nil
+		}
+
+		if _, ok := known[u.Host]; ok {
+			return nil
+		}
+
+		return validation.Errors{{
+			Subject: subject,
+			Field:   field,
+			Message: fmt.Sprintf("unknown extension server: %s", u.Host),
+		}}
+	}
+}
+
 // validKeyURI adapts validKeyURIRef to a by-value url.URL so it can check the
 // KeyPolicy.URI field directly.
 func validKeyURI() validation.Check[url.URL] {
@@ -96,7 +155,12 @@ func validKeyURI() validation.Check[url.URL] {
 }
 
 // validKeyURIRef rejects a key URI whose scheme is not one of the supported KMS
-// providers. The scheme match is case-insensitive.
+// providers, and an extension URI that names no server. The scheme match is
+// case-insensitive.
+//
+// The empty-host case is checked here rather than in referentialRules because
+// that rule reports a host that matches no configured server, and a missing host
+// gives it no name to report.
 func validKeyURIRef() validation.Check[*url.URL] {
 	return func(u *url.URL) error {
 		if !slices.Contains(validKeySchemes, strings.ToLower(u.Scheme)) {
@@ -105,6 +169,10 @@ func validKeyURIRef() validation.Check[*url.URL] {
 				u.String(),
 				strings.Join(validKeySchemes, ","),
 			)
+		}
+
+		if strings.EqualFold(u.Scheme, extensionKeyScheme) && u.Host == "" {
+			return fmt.Errorf("extension key URI must name an extension server: %s", u)
 		}
 
 		return nil

--- a/internal/config/encryption_test.go
+++ b/internal/config/encryption_test.go
@@ -175,3 +175,158 @@ func validKeyPolicy(t *testing.T) config.KeyPolicy {
 		RenewBefore: 10 * time.Minute,
 	}
 }
+
+func TestEncryption_ValidateAcceptsExtensionKeyScheme(t *testing.T) {
+	t.Parallel()
+
+	// The referential check lives at the Config level; Encryption.Validate only
+	// sees the scheme, which must now be recognized.
+	e := &config.Encryption{Default: &config.KeyPolicy{
+		URI:         mustURL(t, "extension://audit/payments"),
+		Duration:    time.Hour,
+		RenewBefore: time.Minute,
+	}}
+
+	require.NoError(t, e.Validate())
+}
+
+func TestConfig_ValidateExtensionKeyReferences(t *testing.T) {
+	t.Parallel()
+
+	policy := func(uri string, decrypt ...string) *config.KeyPolicy {
+		p := &config.KeyPolicy{
+			URI:         mustURL(t, uri),
+			Duration:    time.Hour,
+			RenewBefore: time.Minute,
+		}
+		for _, d := range decrypt {
+			p.DecryptURIs = append(p.DecryptURIs, mustURL(t, d))
+		}
+
+		return p
+	}
+
+	base := func(e config.Encryption) *config.Config {
+		return &config.Config{
+			Listen:     config.ListenConfig{HostPort: ":8080"},
+			Encryption: e,
+			ExtensionServers: config.ExtensionServerList{
+				{Name: "audit", Listen: config.ListenConfig{HostPort: "127.0.0.1:9090"}},
+			},
+			Upstreams: config.UpstreamList{
+				{Name: "primary", Listen: config.ListenConfig{HostPort: "127.0.0.1:7233"}},
+			},
+		}
+	}
+
+	tests := []struct {
+		name       string
+		encryption config.Encryption
+		wantTuples [][2]string
+	}{
+		{
+			name:       "a configured extension server resolves",
+			encryption: config.Encryption{Default: policy("extension://audit/payments")},
+		},
+		{
+			name:       "several keys may name the same server",
+			encryption: config.Encryption{Default: policy("extension://audit/payments", "extension://audit/billing")},
+		},
+		{
+			// An ARN goes in the path (gocloud's "awskms:///<ARN>" form, since a
+			// bare ARN has colons that url.Parse reads as a port), so the host is
+			// empty. That must not be mistaken for an extension server reference.
+			name:       "a hostless non-extension uri is not treated as a reference",
+			encryption: config.Encryption{Default: policy("awskms:///arn:aws:kms:us-east-1:932528106278:key/8be0dcc5")},
+		},
+		{
+			name:       "a non-extension uri with a host is not treated as a reference",
+			encryption: config.Encryption{Default: policy("awskms://alias/payments")},
+		},
+		{
+			name:       "an unknown server on the primary uri",
+			encryption: config.Encryption{Default: policy("extension://missing/payments")},
+			wantTuples: [][2]string{{"encryption.default", "uri"}},
+		},
+		{
+			name:       "an unknown server on a decrypt uri keeps its index",
+			encryption: config.Encryption{Default: policy("extension://audit/v2", "extension://audit/v1", "extension://gone/v0")},
+			wantTuples: [][2]string{{"encryption.default", "decryptURIs[1]"}},
+		},
+		{
+			name: "an unknown server in an override is stamped with its namespace",
+			encryption: config.Encryption{
+				Default:   policy("extension://audit/payments"),
+				Overrides: map[string]config.KeyPolicy{"billing": *policy("extension://nope/k")},
+			},
+			wantTuples: [][2]string{{"encryption.overrides[billing]", "uri"}},
+		},
+		{
+			name: "failures across default and overrides aggregate",
+			encryption: config.Encryption{
+				Default:   policy("extension://gone/a"),
+				Overrides: map[string]config.KeyPolicy{"billing": *policy("extension://nope/b")},
+			},
+			wantTuples: [][2]string{
+				{"encryption.default", "uri"},
+				{"encryption.overrides[billing]", "uri"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assertTuples(t, base(tt.encryption).Validate(), tt.wantTuples)
+		})
+	}
+}
+
+func TestEncryption_ValidateRejectsHostlessExtensionURI(t *testing.T) {
+	t.Parallel()
+
+	// A hostless extension URI names no server, so the referential check has
+	// nothing to report against. Catch it with the scheme instead, at config
+	// validation rather than when the KEK is opened.
+	tests := []struct {
+		name    string
+		uri     string
+		wantErr string
+	}{
+		{
+			name:    "no host at all",
+			uri:     "extension://",
+			wantErr: "must name an extension server",
+		},
+		{
+			name:    "a path but no host",
+			uri:     "extension:///payments",
+			wantErr: "must name an extension server",
+		},
+		{
+			name: "a host is accepted",
+			uri:  "extension://audit/payments",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			e := &config.Encryption{Default: &config.KeyPolicy{
+				URI:         mustURL(t, tt.uri),
+				Duration:    time.Hour,
+				RenewBefore: time.Minute,
+			}}
+
+			err := e.Validate()
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}

--- a/internal/config/extensions.go
+++ b/internal/config/extensions.go
@@ -1,0 +1,106 @@
+package config
+
+import (
+	"errors"
+
+	"github.com/temporalio/temporal-proxy/pkg/validation"
+)
+
+type (
+	// ExtensionServer addresses an operator-run gRPC server implementing the
+	// extension APIs under api/, currently api.kms.v1.EncryptionService, the
+	// pluggable Key Encryption Key provider. The proxy has built-in KMS providers
+	// (awskms, azurekeyvault, gcpkms); an extension server is how an operator plugs
+	// in a backend the proxy does not support natively, such as an on-prem HSM or
+	// an internal key service.
+	//
+	// Name identifies the server within the configuration so other blocks can
+	// reference it, and must be unique across the list. Credentials, when set,
+	// attach per-request credentials to the outbound calls and require TLS,
+	// since sending them over a plaintext connection would expose them on the wire.
+	//
+	// Unlike Upstream, an extension server is dialed at a fixed address rather
+	// than resolved per request, so a templated hostPort is rejected outright
+	// instead of being deferred to request time.
+	ExtensionServer struct {
+		Name        string            `yaml:"name"`
+		Listen      ListenConfig      `yaml:",inline"`
+		Credentials *CredentialConfig `yaml:"credentials"`
+	}
+
+	// ExtensionServerList is the configured set of extension servers. It exists
+	// as a named type so the checks that span the whole collection - name and
+	// address uniqueness - live alongside the per-entry checks instead of in
+	// the parent Config.
+	ExtensionServerList []ExtensionServer
+)
+
+// Validate checks a single extension server: a name is required, hostPort must
+// be a literal host:port with no template action, and any TLS block must be
+// valid for dialing out. Credentials without TLS are rejected. Failures are
+// unattributed, leaving the caller to stamp the path - ExtensionServerList
+// supplies the index.
+func (s *ExtensionServer) Validate() error {
+	return validation.Validate(
+		"",
+		validation.Field("name", s.Name, validation.Required[string]()),
+		validation.Field("hostPort", s.Listen.HostPort, isLiteralHostPort()),
+		validation.WhenRules(
+			func() bool { return s.Listen.TLS != nil },
+			func() validation.Errors { return s.Listen.TLS.validateOutbound() },
+		),
+		validation.WhenRules(
+			func() bool { return s.Credentials != nil },
+			validation.Nested("credentials", s.Credentials),
+		),
+		validation.WhenRules(
+			func() bool { return s.Credentials != nil && s.Listen.TLS == nil },
+			func() validation.Errors {
+				return validation.Errors{{Field: "credentials", Message: "requires TLS to the extension server"}}
+			},
+		),
+	)
+}
+
+// Validate checks every entry and enforces that names and addresses are unique
+// across the list: two servers sharing a name would make a reference ambiguous,
+// and two sharing an address is a copy-paste error rather than a useful
+// configuration. Uniqueness failures are reported on a "[name]"/"[hostPort]"
+// field because they belong to the collection rather than to any one entry,
+// while per-entry failures are stamped with a "[i]" subject. Both compose onto
+// the parent's path, so Config surfaces them as "extensionServers[name]" and
+// "extensionServers[0]". An empty or nil list is valid.
+func (sl ExtensionServerList) Validate() error {
+	names := make([]string, len(sl))
+	hostPorts := make([]string, len(sl))
+	for i, s := range sl {
+		names[i] = s.Name
+		hostPorts[i] = s.Listen.HostPort
+	}
+
+	return validation.Validate(
+		"",
+		validation.Field("[name]", names, validation.Unique[string]()),
+		validation.Field("[hostPort]", hostPorts, validation.Unique[string]()),
+		validation.Children("", sl, func(s *ExtensionServer) error {
+			return s.Validate()
+		}),
+	)
+}
+
+// isLiteralHostPort accepts only a static host:port. The template check runs
+// first and short-circuits, because a template is not merely unresolvable here
+// but indistinguishable from a valid address once it carries a literal port:
+// "{{ .Namespace }}.acme.cloud:9090" splits cleanly into host and port and
+// would otherwise be accepted, then dialed verbatim.
+func isLiteralHostPort() validation.Check[string] {
+	hostPort := validation.IsHostPort()
+
+	return func(s string) error {
+		if isTemplated(s) {
+			return errors.New("must be a literal host:port; templates are not resolved for extension servers")
+		}
+
+		return hostPort(s)
+	}
+}

--- a/internal/config/extensions_test.go
+++ b/internal/config/extensions_test.go
@@ -1,0 +1,332 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/temporalio/temporal-proxy/internal/config"
+	"github.com/temporalio/temporal-proxy/pkg/testutil"
+)
+
+func TestExtensionServer_Validate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		server     *config.ExtensionServer
+		wantTuples [][2]string
+	}{
+		{
+			name: "valid name and hostPort",
+			server: &config.ExtensionServer{
+				Name:   "audit",
+				Listen: config.ListenConfig{HostPort: "127.0.0.1:9090"},
+			},
+		},
+		{
+			name: "missing name surfaces required error",
+			server: &config.ExtensionServer{
+				Listen: config.ListenConfig{HostPort: "127.0.0.1:9090"},
+			},
+			wantTuples: [][2]string{{"", "name"}},
+		},
+		{
+			name: "invalid hostPort is rejected",
+			server: &config.ExtensionServer{
+				Name:   "audit",
+				Listen: config.ListenConfig{HostPort: "not-a-host-port"},
+			},
+			wantTuples: [][2]string{{"", "hostPort"}},
+		},
+		{
+			name:       "missing name and hostPort aggregate",
+			server:     &config.ExtensionServer{},
+			wantTuples: [][2]string{{"", "name"}, {"", "hostPort"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assertTuples(t, tt.server.Validate(), tt.wantTuples)
+		})
+	}
+}
+
+func TestExtensionServer_ValidateRejectsTemplatedHostPort(t *testing.T) {
+	t.Parallel()
+
+	// Unlike Upstream, an extension server is dialed at a fixed address with no
+	// per-request template resolution, so a template is rejected outright. It
+	// is not enough to lean on the host:port check: a template carrying a
+	// literal port parses as a valid host:port and would otherwise be accepted.
+	tests := []struct {
+		name     string
+		hostPort string
+	}{
+		{
+			name:     "template with a literal port",
+			hostPort: "{{ .RemoteNamespace }}.acme.cloud:9090",
+		},
+		{
+			name:     "template without a port",
+			hostPort: "{{ .RemoteNamespace }}.acme.cloud",
+		},
+		{
+			name:     "template in the port position",
+			hostPort: "audit.internal:{{ .Port }}",
+		},
+		{
+			name:     "template spanning the whole value",
+			hostPort: "{{ .ExtensionHostPort }}",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			s := &config.ExtensionServer{
+				Name:   "audit",
+				Listen: config.ListenConfig{HostPort: tt.hostPort},
+			}
+
+			err := s.Validate()
+			assertTuples(t, err, [][2]string{{"", "hostPort"}})
+			require.ErrorContains(t, err, "templates are not resolved for extension servers")
+		})
+	}
+}
+
+func TestExtensionServer_ValidateCredentialsRequireTLS(t *testing.T) {
+	t.Parallel()
+
+	base := func() config.ExtensionServer {
+		return config.ExtensionServer{
+			Name:        "audit",
+			Listen:      config.ListenConfig{HostPort: "audit.internal:9090"},
+			Credentials: &config.CredentialConfig{Static: &config.StaticCredentialConfig{APIKey: "k"}},
+		}
+	}
+
+	t.Run("credentials without tls is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		s := base()
+		require.ErrorContains(t, s.Validate(), "requires TLS")
+	})
+
+	t.Run("credentials with tls is accepted", func(t *testing.T) {
+		t.Parallel()
+
+		s := base()
+		s.Listen.TLS = &config.TLSConfig{ServerName: "audit.internal"}
+		require.NoError(t, s.Validate())
+	})
+}
+
+func TestExtensionServer_ValidateOutboundTLS(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		tls     func(t *testing.T) *config.TLSConfig
+		wantErr string
+	}{
+		{
+			name: "server name only is valid (system roots)",
+			tls: func(*testing.T) *config.TLSConfig {
+				return &config.TLSConfig{ServerName: "audit.internal"}
+			},
+		},
+		{
+			name: "CA plus client key pair is valid (mutual TLS)",
+			tls: func(t *testing.T) *config.TLSConfig {
+				caFile, certFile, keyFile := testutil.GenerateMTLSCerts(t)
+				return &config.TLSConfig{CA: caFile, Cert: certFile, Key: keyFile, ServerName: "localhost"}
+			},
+		},
+		{
+			name: "cert without key is rejected",
+			tls: func(t *testing.T) *config.TLSConfig {
+				_, certFile, _ := testutil.GenerateMTLSCerts(t)
+				return &config.TLSConfig{Cert: certFile}
+			},
+			wantErr: "certificate and key must be set together",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			s := config.ExtensionServer{
+				Name:   "audit",
+				Listen: config.ListenConfig{HostPort: "audit.internal:9090", TLS: tt.tls(t)},
+			}
+
+			err := s.Validate()
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestExtensionServerList_Validate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		list       config.ExtensionServerList
+		wantTuples [][2]string
+	}{
+		{
+			name: "empty list yields no error",
+			list: config.ExtensionServerList{},
+		},
+		{
+			name: "nil list yields no error",
+			list: nil,
+		},
+		{
+			name: "single valid server yields no error",
+			list: config.ExtensionServerList{
+				{Name: "audit", Listen: config.ListenConfig{HostPort: "127.0.0.1:9090"}},
+			},
+		},
+		{
+			name: "distinct names and hostPorts yield no error",
+			list: config.ExtensionServerList{
+				{Name: "audit", Listen: config.ListenConfig{HostPort: "127.0.0.1:9090"}},
+				{Name: "quota", Listen: config.ListenConfig{HostPort: "127.0.0.1:9091"}},
+			},
+		},
+		{
+			name: "duplicate names surface on the collection field",
+			list: config.ExtensionServerList{
+				{Name: "dup", Listen: config.ListenConfig{HostPort: "127.0.0.1:9090"}},
+				{Name: "dup", Listen: config.ListenConfig{HostPort: "127.0.0.1:9091"}},
+			},
+			wantTuples: [][2]string{{"", "[name]"}},
+		},
+		{
+			name: "duplicate hostPorts surface on the collection field",
+			list: config.ExtensionServerList{
+				{Name: "audit", Listen: config.ListenConfig{HostPort: "127.0.0.1:9090"}},
+				{Name: "quota", Listen: config.ListenConfig{HostPort: "127.0.0.1:9090"}},
+			},
+			wantTuples: [][2]string{{"", "[hostPort]"}},
+		},
+		{
+			name: "element failure is stamped with its index",
+			list: config.ExtensionServerList{
+				{Name: "audit", Listen: config.ListenConfig{HostPort: "127.0.0.1:9090"}},
+				{Listen: config.ListenConfig{HostPort: "127.0.0.1:9091"}},
+			},
+			wantTuples: [][2]string{{"[1]", "name"}},
+		},
+		{
+			name: "collection and element failures aggregate",
+			list: config.ExtensionServerList{
+				{Name: "dup", Listen: config.ListenConfig{HostPort: "127.0.0.1:9090"}},
+				{Name: "dup", Listen: config.ListenConfig{HostPort: "nope"}},
+			},
+			wantTuples: [][2]string{{"", "[name]"}, {"[1]", "hostPort"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assertTuples(t, tt.list.Validate(), tt.wantTuples)
+		})
+	}
+}
+
+func TestConfig_Validate_ExtensionServers(t *testing.T) {
+	t.Parallel()
+
+	base := func(servers config.ExtensionServerList) *config.Config {
+		return &config.Config{
+			Listen:           config.ListenConfig{HostPort: ":8080"},
+			ExtensionServers: servers,
+			Upstreams: config.UpstreamList{
+				{Name: "primary", Listen: config.ListenConfig{HostPort: "127.0.0.1:7233"}},
+			},
+		}
+	}
+
+	tests := []struct {
+		name       string
+		servers    config.ExtensionServerList
+		wantTuples [][2]string
+	}{
+		{
+			name:    "absent extension servers are optional",
+			servers: nil,
+		},
+		{
+			name: "valid extension servers yield no error",
+			servers: config.ExtensionServerList{
+				{Name: "audit", Listen: config.ListenConfig{HostPort: "127.0.0.1:9090"}},
+			},
+		},
+		{
+			name: "element failure carries the indexed extensionServers subject",
+			servers: config.ExtensionServerList{
+				{Listen: config.ListenConfig{HostPort: "127.0.0.1:9090"}},
+			},
+			wantTuples: [][2]string{{"extensionServers[0]", "name"}},
+		},
+		{
+			name: "duplicate names carry the extensionServers[name] field and no subject",
+			servers: config.ExtensionServerList{
+				{Name: "dup", Listen: config.ListenConfig{HostPort: "127.0.0.1:9090"}},
+				{Name: "dup", Listen: config.ListenConfig{HostPort: "127.0.0.1:9091"}},
+			},
+			wantTuples: [][2]string{{"", "extensionServers[name]"}},
+		},
+		{
+			name: "duplicate hostPorts carry the extensionServers[hostPort] field",
+			servers: config.ExtensionServerList{
+				{Name: "audit", Listen: config.ListenConfig{HostPort: "127.0.0.1:9090"}},
+				{Name: "quota", Listen: config.ListenConfig{HostPort: "127.0.0.1:9090"}},
+			},
+			wantTuples: [][2]string{{"", "extensionServers[hostPort]"}},
+		},
+		{
+			name: "an extension server may reuse an upstream hostPort",
+			servers: config.ExtensionServerList{
+				{Name: "audit", Listen: config.ListenConfig{HostPort: "127.0.0.1:7233"}},
+			},
+		},
+		{
+			name: "a nested TLS failure composes onto the indexed subject",
+			servers: config.ExtensionServerList{
+				{
+					Name: "audit",
+					Listen: config.ListenConfig{
+						HostPort: "127.0.0.1:9090",
+						TLS:      &config.TLSConfig{Cert: "/nope/cert.pem"},
+					},
+				},
+			},
+			wantTuples: [][2]string{{"extensionServers[0].tls", "cert"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assertTuples(t, base(tt.servers).Validate(), tt.wantTuples)
+		})
+	}
+}

--- a/internal/config/upstream.go
+++ b/internal/config/upstream.go
@@ -19,6 +19,8 @@ type (
 		Credentials *CredentialConfig `yaml:"credentials"`
 	}
 
+	UpstreamList []Upstream
+
 	// NamespaceConfig groups the namespace translation rules for an upstream.
 	NamespaceConfig struct {
 		Rules NamespaceRules `yaml:"rules"`
@@ -88,6 +90,24 @@ func (u *Upstream) IsTemplated() bool {
 	}
 
 	return u.Listen.TLS != nil && isTemplated(u.Listen.TLS.ServerName)
+}
+
+func (ul UpstreamList) Validate() error {
+	names := make([]string, len(ul))
+	hostPorts := make([]string, len(ul))
+	for i, s := range ul {
+		names[i] = s.Name
+		hostPorts[i] = s.Listen.HostPort
+	}
+
+	return validation.Validate(
+		"",
+		validation.Field("[name]", names, validation.Unique[string]()),
+		validation.Field("[hostPort]", hostPorts, validation.Unique[string]()),
+		validation.Children("", ul, func(u *Upstream) error {
+			return u.Validate()
+		}),
+	)
 }
 
 // Validate checks the namespace translation rules.

--- a/internal/kms/doc.go
+++ b/internal/kms/doc.go
@@ -1,10 +1,15 @@
 // Package kms wires the proxy's encryption configuration into a running
 // [crypto.Vault].
 //
-// It reads [config.Encryption], opens the configured KMS keys as KEKs (via
-// gocloud.dev/secrets, so any of awskms, azurekeyvault, gcpkms, or a local
-// testing key is supported), assembles a [crypto.KEKRegistry], and constructs
-// the [crypto.Vault] that the rest of the proxy uses to seal and open payloads.
+// It reads [config.Encryption], opens the configured keys as KEKs, assembles a
+// [crypto.KEKRegistry], and constructs the [crypto.Vault] that the rest of the
+// proxy uses to seal and open payloads.
+//
+// A key is opened one of two ways, chosen by its URI scheme. A cloud KMS key
+// goes through gocloud.dev/secrets (awskms, azurekeyvault, gcpkms, or a local
+// testing key). An "extension://" key instead resolves to an operator-run
+// extension server over a connection supplied by the api package; several keys
+// may name the same server, so each is identified by its whole URI.
 //
 // The package exposes a single [Module] for Uber fx. When encryption is
 // disabled the module provides a nil *crypto.Vault and starts no background

--- a/internal/kms/fx.go
+++ b/internal/kms/fx.go
@@ -10,6 +10,7 @@ import (
 
 	"go.uber.org/fx"
 
+	"github.com/temporalio/temporal-proxy/internal/api"
 	"github.com/temporalio/temporal-proxy/internal/config"
 	"github.com/temporalio/temporal-proxy/internal/metrics"
 	"github.com/temporalio/temporal-proxy/pkg/crypto"
@@ -44,6 +45,7 @@ var Module = fx.Options(
 				p.Config,
 				p.Logger,
 				reporter,
+				p.Extensions,
 			)
 			if err != nil {
 				return nil, err
@@ -88,6 +90,9 @@ type (
 		Lifecycle fx.Lifecycle
 		Logger    logger.Logger
 		Factory   *metrics.Factory
+
+		// Extensions supplies the connections behind "extension://" key URIs.
+		Extensions api.Connections
 	}
 
 	// vaultRefresher is the subset of *crypto.Vault the rotation loop depends
@@ -166,10 +171,17 @@ func createVault(c *config.Config, r *crypto.KEKRegistry, reporter *Reporter) (*
 // createKEKRegistry opens the configured KEKs and assembles a registry,
 // registering an fx OnStop hook that closes the registry (and its KEKs) on
 // shutdown.
-func createKEKRegistry(ctx context.Context, lc fx.Lifecycle, c *config.Config, logger logger.Logger, reporter *Reporter) (*crypto.KEKRegistry, error) {
+func createKEKRegistry(
+	ctx context.Context,
+	lc fx.Lifecycle,
+	c *config.Config,
+	logger logger.Logger,
+	reporter *Reporter,
+	conns api.Connections,
+) (*crypto.KEKRegistry, error) {
 	opts := []crypto.KEKRegistryOption{}
 	if dp := c.Encryption.Default; dp != nil {
-		res, err := keyPolicyRegistryOpts(ctx, dp, logger, defaultNamespace, true, reporter)
+		res, err := keyPolicyRegistryOpts(ctx, dp, logger, defaultNamespace, true, reporter, conns)
 		if err != nil {
 			return nil, err
 		}
@@ -181,7 +193,7 @@ func createKEKRegistry(ctx context.Context, lc fx.Lifecycle, c *config.Config, l
 	// logs and, on a partial failure, a repeatable point of failure).
 	for _, ns := range slices.Sorted(maps.Keys(c.Encryption.Overrides)) {
 		policy := c.Encryption.Overrides[ns]
-		res, err := keyPolicyRegistryOpts(ctx, &policy, logger, ns, false, reporter)
+		res, err := keyPolicyRegistryOpts(ctx, &policy, logger, ns, false, reporter, conns)
 		if err != nil {
 			return nil, err
 		}
@@ -216,9 +228,10 @@ func keyPolicyRegistryOpts(
 	ns string,
 	asDefault bool,
 	reporter *Reporter,
+	conns api.Connections,
 ) ([]crypto.KEKRegistryOption, error) {
 	opts := []crypto.KEKRegistryOption{}
-	keys, err := createKEKs(ctx, p, log, ns, reporter)
+	keys, err := createKEKs(ctx, p, log, ns, reporter, conns)
 	if err != nil {
 		return nil, err
 	}
@@ -241,7 +254,14 @@ func keyPolicyRegistryOpts(
 // returning the KEKs in that order. The primary key is always element zero. If
 // any key fails to open, every key opened so far is closed before returning, so
 // a partial failure leaks no keepers.
-func createKEKs(ctx context.Context, p *config.KeyPolicy, log logger.Logger, ns string, reporter *Reporter) (_ []crypto.KEK, err error) {
+func createKEKs(
+	ctx context.Context,
+	p *config.KeyPolicy,
+	log logger.Logger,
+	ns string,
+	reporter *Reporter,
+	conns api.Connections,
+) (_ []crypto.KEK, err error) {
 	log = log.With(tag.String("namespace", ns))
 	keys := make([]crypto.KEK, 0, len(p.DecryptURIs)+1)
 
@@ -255,7 +275,7 @@ func createKEKs(ctx context.Context, p *config.KeyPolicy, log logger.Logger, ns 
 
 	mkKey := func(uri *url.URL) error {
 		log.Info("Registering crypto key", tag.String("uri", safeKeyString(uri.String())))
-		k, err := newKEK(ctx, uri.String())
+		k, err := newKEKForURI(ctx, uri, conns)
 		if err != nil {
 			return err
 		}

--- a/internal/kms/fx_test.go
+++ b/internal/kms/fx_test.go
@@ -17,6 +17,7 @@ import (
 	"go.uber.org/fx"
 	"go.uber.org/fx/fxtest"
 
+	"github.com/temporalio/temporal-proxy/internal/api"
 	"github.com/temporalio/temporal-proxy/internal/config"
 	"github.com/temporalio/temporal-proxy/internal/metrics"
 	"github.com/temporalio/temporal-proxy/pkg/crypto"
@@ -91,7 +92,7 @@ func TestCreateKEKs(t *testing.T) {
 		t.Parallel()
 
 		p := &config.KeyPolicy{URI: primary, DecryptURIs: []url.URL{distinctKeyURL(t, 2), distinctKeyURL(t, 3)}}
-		keys, err := createKEKs(t.Context(), p, log, defaultNamespace, newFxTestReporter(t))
+		keys, err := createKEKs(t.Context(), p, log, defaultNamespace, newFxTestReporter(t), nil)
 		require.NoError(t, err)
 		t.Cleanup(func() { closeKEKs(t, keys) })
 
@@ -102,7 +103,7 @@ func TestCreateKEKs(t *testing.T) {
 	t.Run("primary only", func(t *testing.T) {
 		t.Parallel()
 
-		keys, err := createKEKs(t.Context(), &config.KeyPolicy{URI: primary}, log, defaultNamespace, newFxTestReporter(t))
+		keys, err := createKEKs(t.Context(), &config.KeyPolicy{URI: primary}, log, defaultNamespace, newFxTestReporter(t), nil)
 		require.NoError(t, err)
 		t.Cleanup(func() { closeKEKs(t, keys) })
 
@@ -112,7 +113,7 @@ func TestCreateKEKs(t *testing.T) {
 	t.Run("bad primary uri errors", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := createKEKs(t.Context(), &config.KeyPolicy{URI: url.URL{Scheme: "bogus", Host: "x"}}, log, defaultNamespace, newFxTestReporter(t))
+		_, err := createKEKs(t.Context(), &config.KeyPolicy{URI: url.URL{Scheme: "bogus", Host: "x"}}, log, defaultNamespace, newFxTestReporter(t), nil)
 		require.Error(t, err)
 	})
 
@@ -120,7 +121,7 @@ func TestCreateKEKs(t *testing.T) {
 		t.Parallel()
 
 		p := &config.KeyPolicy{URI: primary, DecryptURIs: []url.URL{{Scheme: "bogus", Host: "x"}}}
-		_, err := createKEKs(t.Context(), p, log, defaultNamespace, newFxTestReporter(t))
+		_, err := createKEKs(t.Context(), p, log, defaultNamespace, newFxTestReporter(t), nil)
 		require.Error(t, err)
 	})
 }
@@ -137,7 +138,7 @@ func TestKeyPolicyRegistryOpts(t *testing.T) {
 	t.Run("asDefault registers a usable default key", func(t *testing.T) {
 		t.Parallel()
 
-		opts, err := keyPolicyRegistryOpts(t.Context(), &config.KeyPolicy{URI: distinctKeyURL(t, 1)}, log, defaultNamespace, true, newFxTestReporter(t))
+		opts, err := keyPolicyRegistryOpts(t.Context(), &config.KeyPolicy{URI: distinctKeyURL(t, 1)}, log, defaultNamespace, true, newFxTestReporter(t), nil)
 		require.NoError(t, err)
 
 		reg, err := crypto.NewKEKRegistry(opts...)
@@ -148,7 +149,7 @@ func TestKeyPolicyRegistryOpts(t *testing.T) {
 	t.Run("non-default registers only a namespace key", func(t *testing.T) {
 		t.Parallel()
 
-		opts, err := keyPolicyRegistryOpts(t.Context(), &config.KeyPolicy{URI: distinctKeyURL(t, 2)}, log, "other", false, newFxTestReporter(t))
+		opts, err := keyPolicyRegistryOpts(t.Context(), &config.KeyPolicy{URI: distinctKeyURL(t, 2)}, log, "other", false, newFxTestReporter(t), nil)
 		require.NoError(t, err)
 
 		_, err = crypto.NewKEKRegistry(opts...)
@@ -161,7 +162,7 @@ func TestKeyPolicyRegistryOpts(t *testing.T) {
 	t.Run("default namespace with asDefault false is a namespace key", func(t *testing.T) {
 		t.Parallel()
 
-		opts, err := keyPolicyRegistryOpts(t.Context(), &config.KeyPolicy{URI: distinctKeyURL(t, 3)}, log, defaultNamespace, false, newFxTestReporter(t))
+		opts, err := keyPolicyRegistryOpts(t.Context(), &config.KeyPolicy{URI: distinctKeyURL(t, 3)}, log, defaultNamespace, false, newFxTestReporter(t), nil)
 		require.NoError(t, err)
 
 		_, err = crypto.NewKEKRegistry(opts...)
@@ -234,7 +235,7 @@ func TestCreateKEKRegistry(t *testing.T) {
 	lc := fxtest.NewLifecycle(t)
 	cfg := &config.Config{Encryption: config.Encryption{Enabled: true, Default: &config.KeyPolicy{URI: distinctKeyURL(t, 1)}}}
 
-	reg, err := createKEKRegistry(t.Context(), lc, cfg, logger.NewNoopLogger(), newFxTestReporter(t))
+	reg, err := createKEKRegistry(t.Context(), lc, cfg, logger.NewNoopLogger(), newFxTestReporter(t), nil)
 	require.NoError(t, err)
 	require.NotNil(t, reg)
 
@@ -259,7 +260,7 @@ func TestCreateKEKRegistry_OverrideKeySelectedByNamespace(t *testing.T) {
 		},
 	}}
 
-	reg, err := createKEKRegistry(t.Context(), lc, cfg, logger.NewNoopLogger(), newFxTestReporter(t))
+	reg, err := createKEKRegistry(t.Context(), lc, cfg, logger.NewNoopLogger(), newFxTestReporter(t), nil)
 	require.NoError(t, err)
 	lc.RequireStart()
 	t.Cleanup(func() { lc.RequireStop() })
@@ -289,6 +290,7 @@ func TestModule_NoKeys_ProvidesNilVault(t *testing.T) {
 		fx.Supply(&config.Config{Encryption: config.Encryption{Enabled: false}}),
 		fx.Provide(func() logger.Logger { return logger.NewNoopLogger() }),
 		fx.Provide(func() *metrics.Factory { return metrics.New("test", promauto.With(prometheus.NewRegistry())) }),
+		fx.Supply(api.Connections{}),
 		Module,
 		fx.Populate(&v),
 		fx.NopLogger,
@@ -317,6 +319,7 @@ func TestModule_DisabledWithKeys_ProvidesVault(t *testing.T) {
 		fx.Supply(cfg),
 		fx.Provide(func() logger.Logger { return logger.NewNoopLogger() }),
 		fx.Provide(func() *metrics.Factory { return metrics.New("test", promauto.With(prometheus.NewRegistry())) }),
+		fx.Supply(api.Connections{}),
 		Module,
 		fx.Populate(&v),
 	)
@@ -342,6 +345,7 @@ func TestModule_Enabled_ProvidesVaultAndRunsCleanly(t *testing.T) {
 		fx.Supply(cfg),
 		fx.Provide(func() logger.Logger { return logger.NewNoopLogger() }),
 		fx.Provide(func() *metrics.Factory { return metrics.New("test", promauto.With(prometheus.NewRegistry())) }),
+		fx.Supply(api.Connections{}),
 		Module,
 		fx.Populate(&v),
 	)
@@ -367,6 +371,7 @@ func TestModule_Enabled_InvalidURI_FailsConstruction(t *testing.T) {
 		fx.Supply(cfg),
 		fx.Provide(func() logger.Logger { return logger.NewNoopLogger() }),
 		fx.Provide(func() *metrics.Factory { return metrics.New("test", promauto.With(prometheus.NewRegistry())) }),
+		fx.Supply(api.Connections{}),
 		Module,
 		fx.NopLogger,
 	)
@@ -403,4 +408,46 @@ func closeKEKs(t *testing.T, keys []crypto.KEK) {
 func newFxTestReporter(t *testing.T) *Reporter {
 	t.Helper()
 	return NewReporter(metrics.New("test", promauto.With(prometheus.NewRegistry())).ForSubsystem("encryption"))
+}
+
+func TestCreateKEKs_ResolvesExtensionURIs(t *testing.T) {
+	t.Parallel()
+
+	log := logger.NewNoopLogger()
+	conns := extensionConns("audit")
+
+	t.Run("mixes extension and keeper keys in one policy", func(t *testing.T) {
+		t.Parallel()
+
+		p := &config.KeyPolicy{
+			URI:         *mustParse(t, "extension://audit/payments"),
+			DecryptURIs: []url.URL{distinctKeyURL(t, 9), *mustParse(t, "extension://audit/legacy")},
+		}
+
+		keys, err := createKEKs(t.Context(), p, log, defaultNamespace, newFxTestReporter(t), conns)
+		require.NoError(t, err)
+		t.Cleanup(func() { closeKEKs(t, keys) })
+
+		require.Len(t, keys, 3)
+		require.Equal(t, "extension://audit/payments", keys[0].ID())
+		require.Equal(t, "extension://audit/legacy", keys[2].ID())
+	})
+
+	t.Run("an unknown server aborts the policy", func(t *testing.T) {
+		t.Parallel()
+
+		p := &config.KeyPolicy{URI: *mustParse(t, "extension://missing/payments")}
+
+		_, err := createKEKs(t.Context(), p, log, defaultNamespace, newFxTestReporter(t), conns)
+		require.ErrorContains(t, err, `unknown extension server "missing"`)
+	})
+
+	t.Run("without connections an extension uri cannot resolve", func(t *testing.T) {
+		t.Parallel()
+
+		p := &config.KeyPolicy{URI: *mustParse(t, "extension://audit/payments")}
+
+		_, err := createKEKs(t.Context(), p, log, defaultNamespace, newFxTestReporter(t), nil)
+		require.ErrorContains(t, err, `unknown extension server "audit"`)
+	})
 }

--- a/internal/kms/key.go
+++ b/internal/kms/key.go
@@ -3,6 +3,7 @@ package kms
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"strings"
 
 	"gocloud.dev/secrets"
@@ -10,13 +11,56 @@ import (
 	_ "gocloud.dev/secrets/azurekeyvault"
 	_ "gocloud.dev/secrets/gcpkms"
 	_ "gocloud.dev/secrets/localsecrets"
+
+	"github.com/temporalio/temporal-proxy/internal/api"
+	"github.com/temporalio/temporal-proxy/pkg/crypto"
 )
+
+// ExtensionScheme addresses a key served by a configured extension server, as
+// "extension://<server>/<key>". The server names an entry in the config's
+// extensionServers list; the key is a proxy-side identifier that distinguishes
+// several keys hosted by one server. It is never sent to the server, which
+// selects keys by namespace when wrapping and reads the key back out of the
+// self-describing ciphertext when unwrapping.
+const ExtensionScheme = "extension"
 
 // kek adapts a gocloud.dev secrets.Keeper to the crypto.KEK interface. The
 // embedded Keeper supplies Encrypt, Decrypt, and Close; kek adds the ID.
 type kek struct {
 	*secrets.Keeper
 	id string
+}
+
+// newKEKForURI opens the key addressed by uri. An extension URI resolves to a
+// client on a configured extension server's connection; anything else is opened
+// as a cloud KMS keeper.
+func newKEKForURI(ctx context.Context, uri *url.URL, conns api.Connections) (crypto.KEK, error) {
+	if strings.EqualFold(uri.Scheme, ExtensionScheme) {
+		return newExtensionKEK(uri, conns)
+	}
+
+	return newKEK(ctx, uri.String())
+}
+
+// newExtensionKEK resolves an extension URI to a KMS client on the named
+// server's pooled connection. Several keys may share one server, so the whole
+// URI (not the server name) is the KEK identity: it is recorded in every DEK
+// this key wraps and is what selects the key again on the decrypt path.
+//
+// The connection is owned by the pool, so the returned client's Close is a
+// no-op and multiple KEKs may safely share one server.
+func newExtensionKEK(uri *url.URL, conns api.Connections) (crypto.KEK, error) {
+	server := uri.Host
+	if server == "" {
+		return nil, fmt.Errorf("extension key URI must name an extension server: %s", uri)
+	}
+
+	conn, ok := conns[server]
+	if !ok {
+		return nil, fmt.Errorf("unknown extension server %q in key URI: %s", server, uri)
+	}
+
+	return api.NewKMS(uri.String(), conn), nil
 }
 
 // newKEK opens the KMS key addressed by uri as a KEK. The "testing://" scheme

--- a/internal/kms/key_test.go
+++ b/internal/kms/key_test.go
@@ -2,10 +2,16 @@ package kms
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
+	"errors"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	"github.com/temporalio/temporal-proxy/internal/api"
 )
 
 func TestNewKEK_RoundTrip(t *testing.T) {
@@ -43,4 +49,127 @@ func TestNewKEK_InvalidURI(t *testing.T) {
 
 	_, err := newKEK(t.Context(), "bogus://whatever")
 	require.ErrorContains(t, err, "bogus://whatever")
+}
+
+// stubConn stands in for a connection to an extension server. These tests only
+// check how a key URI resolves to a connection, never what travels over it, so
+// both methods are unreachable and say so rather than returning a zero value.
+type stubConn struct{}
+
+func (stubConn) Invoke(context.Context, string, any, any, ...grpc.CallOption) error {
+	return errors.New("unexpected Invoke on a stub connection")
+}
+
+func (stubConn) NewStream(
+	context.Context, *grpc.StreamDesc, string, ...grpc.CallOption,
+) (grpc.ClientStream, error) {
+	return nil, errors.New("unexpected NewStream on a stub connection")
+}
+
+// extensionConns builds a Connections entry per name.
+func extensionConns(names ...string) api.Connections {
+	conns := make(api.Connections, len(names))
+	for _, name := range names {
+		conns[name] = stubConn{}
+	}
+
+	return conns
+}
+
+func mustParse(t *testing.T, raw string) *url.URL {
+	t.Helper()
+
+	u, err := url.Parse(raw)
+	require.NoError(t, err)
+
+	return u
+}
+
+func TestNewKEKForURI_Extension(t *testing.T) {
+	t.Parallel()
+
+	conns := extensionConns("audit", "hsm")
+
+	tests := []struct {
+		name    string
+		uri     string
+		wantID  string
+		wantErr string
+	}{
+		{
+			name:   "resolves a configured server, identified by the whole URI",
+			uri:    "extension://audit/payments",
+			wantID: "extension://audit/payments",
+		},
+		{
+			name:   "a key id is optional",
+			uri:    "extension://audit",
+			wantID: "extension://audit",
+		},
+		{
+			name:   "a dotted key id needs no escaping",
+			uri:    "extension://audit/billing.v2",
+			wantID: "extension://audit/billing.v2",
+		},
+		{
+			// url.Parse normalizes the scheme, so the ID is the lowercased form.
+			name:   "the scheme is matched case-insensitively",
+			uri:    "EXTENSION://hsm/root",
+			wantID: "extension://hsm/root",
+		},
+		{
+			name:    "an unconfigured server is rejected by name",
+			uri:     "extension://missing/payments",
+			wantErr: `unknown extension server "missing"`,
+		},
+		{
+			name:    "a URI with no server is rejected",
+			uri:     "extension:///payments",
+			wantErr: "must name an extension server",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			k, err := newKEKForURI(t.Context(), mustParse(t, tt.uri), conns)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.wantID, k.ID())
+		})
+	}
+}
+
+func TestNewKEKForURI_ExtensionKeysShareAServer(t *testing.T) {
+	t.Parallel()
+
+	// Several keys may live on one extension server. They must be distinct KEKs
+	// (the registry keys decryption off the ID, and DEKs record it) even though
+	// they resolve to the same connection.
+	conns := extensionConns("audit")
+
+	payments, err := newKEKForURI(t.Context(), mustParse(t, "extension://audit/payments"), conns)
+	require.NoError(t, err)
+
+	billing, err := newKEKForURI(t.Context(), mustParse(t, "extension://audit/billing"), conns)
+	require.NoError(t, err)
+
+	require.NotEqual(t, payments.ID(), billing.ID())
+}
+
+func TestNewKEKForURI_NonExtensionFallsThroughToAKeeper(t *testing.T) {
+	t.Parallel()
+
+	key := base64.StdEncoding.EncodeToString(bytes.Repeat([]byte{7}, 32))
+
+	k, err := newKEKForURI(t.Context(), mustParse(t, "testing://"+key), nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = k.Close() })
+
+	require.Equal(t, "base64key://"+key, k.ID())
 }

--- a/internal/kms/metered_test.go
+++ b/internal/kms/metered_test.go
@@ -60,6 +60,9 @@ func TestProviderForScheme(t *testing.T) {
 		"testing":       "testing",
 		"base64key":     "testing",
 		"weird":         "weird",
+		// Every extension server shares one label; per-server labels would make
+		// the metric's cardinality track the configuration.
+		ExtensionScheme: ExtensionScheme,
 	}
 	for scheme, want := range cases {
 		require.Equal(t, want, providerForScheme(scheme), "scheme %q", scheme)

--- a/pkg/validation/combinators.go
+++ b/pkg/validation/combinators.go
@@ -1,6 +1,9 @@
 package validation
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 type (
 	// Validator is satisfied by any type whose Validate method returns an
@@ -76,6 +79,13 @@ func WhenNested(pred func() bool, subject string, v Validator) Rule {
 // empty subject leaves entries unchanged, and any non-validation error is
 // wrapped as a single entry whose Message is err.Error() and whose Subject is
 // subject.
+//
+// A child segment that starts with "[" is an accessor on the segment before it
+// rather than a path component of its own, so it is concatenated instead of
+// dot-joined. That covers both element indexes, where a child Subject of "[0]"
+// composes into "classes[0]", and whole-collection pseudo-fields, where an
+// unattributed child Field of "[name]" composes into "classes[name]" and leaves
+// Subject empty - the failure belongs to the collection, not to any one element.
 func Nested(subject string, v Validator) Rule {
 	return func() Errors {
 		err := v.Validate()
@@ -89,10 +99,13 @@ func Nested(subject string, v Validator) Rule {
 		}
 
 		for i := range errs {
-			if errs[i].Subject == "" {
+			switch {
+			case errs[i].Subject != "":
+				errs[i].Subject = join(subject, errs[i].Subject)
+			case strings.HasPrefix(errs[i].Field, "["):
+				errs[i].Field = subject + errs[i].Field
+			default:
 				errs[i].Subject = subject
-			} else {
-				errs[i].Subject = subject + "." + errs[i].Subject
 			}
 		}
 
@@ -124,3 +137,13 @@ func Children[S ~[]T, T any](name string, items S, validate func(*T) error) Rule
 }
 
 func (f validatorFunc) Validate() error { return f() }
+
+// join appends a child path segment to a parent, concatenating accessor
+// segments ("[0]", "[name]") and dot-joining named ones.
+func join(parent, child string) string {
+	if strings.HasPrefix(child, "[") {
+		return parent + child
+	}
+
+	return parent + "." + child
+}

--- a/pkg/validation/combinators_test.go
+++ b/pkg/validation/combinators_test.go
@@ -291,6 +291,93 @@ func TestNested_PrefixesChildSubjects(t *testing.T) {
 	require.Equal(t, "outer", out[1].Subject, "empty subject must be set to the segment")
 }
 
+func TestNested_AccessorSegments(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		entry       validation.Error
+		wantSubject string
+		wantField   string
+	}{
+		{
+			name:        "indexed child subject concatenates onto the segment",
+			entry:       validation.Error{Subject: "[0]", Field: "name"},
+			wantSubject: "upstreams[0]",
+			wantField:   "name",
+		},
+		{
+			name:        "deeper path under an indexed child keeps its dots",
+			entry:       validation.Error{Subject: "[0].tls", Field: "certFile"},
+			wantSubject: "upstreams[0].tls",
+			wantField:   "certFile",
+		},
+		{
+			name:        "unattributed bracketed field binds to the field, not the subject",
+			entry:       validation.Error{Field: "[name]"},
+			wantSubject: "",
+			wantField:   "upstreams[name]",
+		},
+		{
+			name:        "named child subject still dot-joins",
+			entry:       validation.Error{Subject: "explicit", Field: "x"},
+			wantSubject: "upstreams.explicit",
+			wantField:   "x",
+		},
+		{
+			name:        "unattributed plain field still takes the segment as its subject",
+			entry:       validation.Error{Field: "x"},
+			wantSubject: "upstreams",
+			wantField:   "x",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.entry.Message = "boom"
+			v := &recordingValidator{err: validation.Errors{tt.entry}}
+
+			out := validation.Nested("upstreams", v)()
+			require.Len(t, out, 1)
+			require.Equal(t, tt.wantSubject, out[0].Subject)
+			require.Equal(t, tt.wantField, out[0].Field)
+		})
+	}
+}
+
+func TestNested_OverChildren_ComposesIndexedSubjects(t *testing.T) {
+	t.Parallel()
+
+	// A collection validator names its elements with an empty Children prefix
+	// ("[0]") and its whole-collection checks with a bracketed field
+	// ("[name]"), leaving the parent to supply "upstreams" via Nested.
+	names := []string{"", "ok"}
+	collection := &recordingValidator{err: validation.Validate(
+		"",
+		validation.Field("[name]", names, func([]string) error {
+			return errors.New("contains duplicate value")
+		}),
+		validation.Children("", names, func(name *string) error {
+			if *name == "" {
+				return validation.Errors{{Field: "name", Message: "is required"}}
+			}
+
+			return nil
+		}),
+	)}
+
+	out := validation.Nested("upstreams", collection)()
+	require.Len(t, out, 2)
+
+	require.Equal(t, "", out[0].Subject, "collection-level failure belongs to no element")
+	require.Equal(t, "upstreams[name]", out[0].Field)
+
+	require.Equal(t, "upstreams[0]", out[1].Subject)
+	require.Equal(t, "name", out[1].Field)
+}
+
 func TestNested_SingleValidationError(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Payload encryption can only wrap DEKs with a backend the proxy has compiled in: AWS KMS, Azure Key Vault, GCP KMS, or a local testing key. An operator running an on-prem HSM or an internal key service has no way to participate.

Extension servers close that gap. An operator runs a gRPC service implementing api.kms.v1.EncryptionService, declares it under `extensionServers`, and points a key policy at it with an `extension://<server>/<key>` URI. Only DEK material crosses the wire; payload plaintext never reaches the server.

Extension connections are keyed in the shared pool under an `extension:` prefix. The pool keys by dial address and returns an existing entry while ignoring the options passed with it, so an extension server sharing an upstream's host:port would otherwise silently inherit that upstream's TLS and credentials.

Unlike an upstream, an extension server is dialed at a fixed address, so a templated hostPort is rejected outright rather than deferred to request time. The host:port check alone is not enough: a template carrying a literal port parses as a valid address and would be dialed verbatim.
