### PR TITLE
[connect]: Open eager connections on start

### DIFF
--- a/internal/api/fx.go
+++ b/internal/api/fx.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"fmt"
 
 	"go.uber.org/fx"
@@ -23,9 +24,11 @@ import (
 const extensionKeyPrefix = "extension:"
 
 // Module provides the pooled connection for every configured extension server,
-// built when the provider runs rather than on first use, so a bad dial target,
-// certificate, or credential surfaces at construction instead of on the first
-// encryption call.
+// built when the provider runs rather than on first use, so a bad dial target
+// surfaces at construction instead of on the first encryption call, and opened on
+// start so an unreachable server (or one whose certificate this proxy will not
+// accept) fails startup. Per-call credentials are still only exercised by a real
+// request.
 var Module = fx.Options(
 	fx.Provide(func(p APIParams) (Connections, error) {
 		// api.Module is wired ahead of server.Module, which is what validates the
@@ -38,6 +41,8 @@ var Module = fx.Options(
 		}
 
 		out := make(Connections, len(p.Config.ExtensionServers))
+		conns := make([]*connect.Conn, 0, len(p.Config.ExtensionServers))
+
 		for i := range p.Config.ExtensionServers {
 			es := &p.Config.ExtensionServers[i]
 
@@ -47,7 +52,20 @@ var Module = fx.Options(
 			}
 
 			out[es.Name] = conn
+			conns = append(conns, conn)
 		}
+
+		// Config rejects a templated extension server hostPort, so every one of
+		// these is static and reachable now or not at all. An extension server backs
+		// payload encryption, so serving without one means failing encrypted
+		// traffic; fail startup instead.
+		p.Lifecycle.Append(fx.StartHook(func(ctx context.Context) error {
+			if err := connect.WaitReady(ctx, conns...); err != nil {
+				return fmt.Errorf("extension server connection not ready: %w", err)
+			}
+
+			return nil
+		}))
 
 		return out, nil
 	}),
@@ -61,8 +79,9 @@ type (
 	APIParams struct {
 		fx.In
 
-		Config *config.Config
-		Pool   *connect.Pool
+		Config    *config.Config
+		Lifecycle fx.Lifecycle
+		Pool      *connect.Pool
 	}
 
 	// Connections maps an extension server name to a connection to that server.
@@ -77,7 +96,8 @@ type (
 
 // extensionConn builds the pooled connection for a single extension server.
 // Config rejects a templated hostPort, so the target is always static: the
-// resolver is fixed and [connect.NewConn] creates the connection eagerly.
+// resolver is fixed and [connect.NewConn] creates the connection here, which the
+// module then opens on start.
 //
 // This is deliberately narrower than the equivalent upstream path in
 // internal/proxy. There is no namespace translation, because an extension

--- a/internal/api/fx_test.go
+++ b/internal/api/fx_test.go
@@ -1,9 +1,12 @@
 package api_test
 
 import (
+	"context"
 	"maps"
+	"net"
 	"slices"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
@@ -32,6 +35,20 @@ func buildModule(t *testing.T, cfg *config.Config, pool *connect.Pool) (api.Conn
 	return out, app.Err()
 }
 
+// deadAddr returns a loopback address with nothing behind it, by taking a port
+// from the kernel and immediately giving it back.
+func deadAddr(t *testing.T) string {
+	t.Helper()
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	addr := lis.Addr().String()
+	require.NoError(t, lis.Close())
+
+	return addr
+}
+
 func extensionServers(servers ...config.ExtensionServer) *config.Config {
 	return &config.Config{
 		Listen:           config.ListenConfig{HostPort: ":8080"},
@@ -40,6 +57,37 @@ func extensionServers(servers ...config.ExtensionServer) *config.Config {
 			{Name: "primary", Listen: config.ListenConfig{HostPort: "127.0.0.1:7233"}},
 		},
 	}
+}
+
+func TestModuleFailsStartWhenExtensionServerUnreachable(t *testing.T) {
+	t.Parallel()
+
+	pool := connect.NewPool()
+	t.Cleanup(func() { require.NoError(t, pool.Close()) })
+
+	var out api.Connections
+	app := fx.New(
+		fx.Supply(
+			extensionServers(config.ExtensionServer{
+				Name:   "audit",
+				Listen: config.ListenConfig{HostPort: deadAddr(t)},
+			}),
+			pool,
+		),
+		api.Module,
+		fx.Populate(&out),
+		fx.NopLogger,
+	)
+
+	// An unreachable server is valid configuration, so it survives construction
+	// (grpc.NewClient does not dial) and fails when the connection is opened on
+	// start.
+	require.NoError(t, app.Err())
+
+	startCtx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
+	defer cancel()
+
+	require.ErrorContains(t, app.Start(startCtx), "extension server connection not ready")
 }
 
 func TestModuleBuildsAConnPerExtensionServer(t *testing.T) {
@@ -156,8 +204,9 @@ func TestModulePoolsConnectionsUnderANamespacedKey(t *testing.T) {
 	), pool)
 	require.NoError(t, err)
 
-	// The connection is created eagerly, under a key distinct from the bare
-	// dial address, so it cannot be handed to a caller resolving that address.
+	// The connection is created during construction, under a key distinct from
+	// the bare dial address, so it cannot be handed to a caller resolving that
+	// address.
 	conn, err := pool.Conn("extension:127.0.0.1:9090")
 	require.NoError(t, err)
 	require.NotNil(t, conn)

--- a/internal/proxy/fx.go
+++ b/internal/proxy/fx.go
@@ -34,6 +34,8 @@ var Module = fx.Options(fx.Invoke(func(p ProxyParams) error {
 		encReporter = NewReporter(p.Factory.ForSubsystem("encryption"))
 	}
 
+	conns := make([]*connect.Conn, 0, len(p.Config.Upstreams))
+
 	for i := range p.Config.Upstreams {
 		up := &p.Config.Upstreams[i]
 		if err := up.Validate(); err != nil {
@@ -83,6 +85,8 @@ var Module = fx.Options(fx.Invoke(func(p ProxyParams) error {
 			return err
 		}
 
+		conns = append(conns, conn)
+
 		var opts []Option
 		if p.Logger != nil {
 			opts = append(opts, WithLogger(p.Logger))
@@ -120,6 +124,20 @@ var Module = fx.Options(fx.Invoke(func(p ProxyParams) error {
 		})
 	}
 
+	// A static upstream's connection is created while the graph is built, but gRPC
+	// does not open a socket until it is used, so open them here: an unreachable
+	// upstream fails startup instead of surfacing as request errors once the proxy
+	// is already serving. Templated upstreams resolve their target per request and
+	// have nothing to open yet, so they are skipped (see [connect.Conn.WaitReady])
+	// and stay unverified until traffic arrives.
+	p.Lifecycle.Append(fx.StartHook(func(ctx context.Context) error {
+		if err := connect.WaitReady(ctx, conns...); err != nil {
+			return fmt.Errorf("upstream connection not ready: %w", err)
+		}
+
+		return nil
+	}))
+
 	return nil
 }))
 
@@ -147,11 +165,11 @@ type ProxyParams struct {
 
 // upstreamResolver builds the [connect.Resolver] for an upstream. When neither
 // the hostPort nor the TLS server name is templated it returns a static
-// resolver whose connection is constructed eagerly (and reused for every
-// request); otherwise it returns a DynamicResolver that renders the target and
-// server name, and rebuilds credentials, per request. opts holds the
-// request-independent dial options (namespace translation and outbound
-// credentials).
+// resolver, whose connection is constructed while the graph is built, opened on
+// start, and reused for every request; otherwise it returns a DynamicResolver
+// that renders the target and server name, and rebuilds credentials, per request.
+// opts holds the request-independent dial options (namespace translation and
+// outbound credentials).
 func upstreamResolver(upstream *config.Upstream, opts []grpc.DialOption) (connect.Resolver, error) {
 	// One Dialer per upstream owns the TLS-mode decision and parses its
 	// certificate material once, so a templated upstream reuses it across every

--- a/internal/proxy/fx_test.go
+++ b/internal/proxy/fx_test.go
@@ -2,6 +2,7 @@ package proxy_test
 
 import (
 	"context"
+	"net"
 	"testing"
 	"time"
 
@@ -29,7 +30,7 @@ func TestModule(t *testing.T) {
 	t.Run("wires defaults and runs the lifecycle", func(t *testing.T) {
 		t.Parallel()
 
-		const upstream = "127.0.0.1:47233"
+		upstream := serveUpstream(t)
 
 		app := newProxyApp(t, &config.Config{
 			Upstreams: []config.Upstream{{Name: "primary", Listen: config.ListenConfig{HostPort: upstream}}},
@@ -42,7 +43,7 @@ func TestModule(t *testing.T) {
 	t.Run("uses the supplied logger", func(t *testing.T) {
 		t.Parallel()
 
-		const upstream = "127.0.0.1:57233"
+		upstream := serveUpstream(t)
 
 		log := logger.NewTestLogger()
 		app := newProxyApp(
@@ -76,10 +77,7 @@ func TestModule(t *testing.T) {
 func TestModuleMultipleUpstreams(t *testing.T) {
 	t.Parallel()
 
-	const (
-		a = "127.0.0.1:47234"
-		b = "127.0.0.1:47235"
-	)
+	a, b := serveUpstream(t), serveUpstream(t)
 
 	app := newProxyApp(t, &config.Config{
 		Upstreams: []config.Upstream{
@@ -181,7 +179,8 @@ func TestModuleAcceptsTemplatedUpstream(t *testing.T) {
 	// Previously this failed with "templated upstreams are not yet supported".
 	// A templated hostPort is now resolved per-request via a templatedPlan, so
 	// construction (and the full start/stop lifecycle) succeeds without ever
-	// dialing the upstream.
+	// dialing the upstream. Nothing here is listening, so this also covers the
+	// start hook that opens static upstreams skipping templated ones.
 	require.NoError(t, app.Err())
 
 	startCtx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
@@ -196,7 +195,7 @@ func TestModuleAcceptsTemplatedUpstream(t *testing.T) {
 func TestModuleInstallsNamespaceTranslation(t *testing.T) {
 	t.Parallel()
 
-	const upstream = "127.0.0.1:47241"
+	upstream := serveUpstream(t)
 
 	// An upstream that configures namespace rules wires translation from the
 	// injected Translator and must still build and serve.
@@ -210,6 +209,25 @@ func TestModuleInstallsNamespaceTranslation(t *testing.T) {
 	require.NoError(t, app.Err())
 
 	startServeStop(t, app, upstream)
+}
+
+func TestModuleFailsStartWhenStaticUpstreamUnreachable(t *testing.T) {
+	t.Parallel()
+
+	app := newProxyApp(t, &config.Config{
+		Upstreams: []config.Upstream{{Name: "primary", Listen: config.ListenConfig{HostPort: deadUpstream(t)}}},
+	})
+
+	// An unreachable upstream is valid configuration, so it survives construction
+	// (grpc.NewClient does not dial) and fails when the connection is opened on
+	// start.
+	require.NoError(t, app.Err())
+
+	startCtx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
+	defer cancel()
+
+	err := app.Start(startCtx)
+	require.ErrorContains(t, err, "upstream connection not ready")
 }
 
 func TestModuleFailsFastWhenEncryptionEnabledWithoutVault(t *testing.T) {
@@ -243,6 +261,38 @@ func TestModuleRequiresTranslator(t *testing.T) {
 	)
 
 	require.Error(t, app.Err())
+}
+
+// serveUpstream starts a plaintext gRPC server on a loopback port and returns
+// its address, for use as an upstream hostPort. A static upstream's connection
+// is opened on start, so an upstream pointing at nothing fails the lifecycle.
+// The ephemeral port also keeps the proxy's derived socket path unique across
+// parallel tests.
+func serveUpstream(t *testing.T) string {
+	t.Helper()
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	svr := grpc.NewServer()
+	go func() { _ = svr.Serve(lis) }()
+	t.Cleanup(svr.Stop)
+
+	return lis.Addr().String()
+}
+
+// deadUpstream returns a loopback address with nothing behind it, by taking a
+// port from the kernel and immediately giving it back.
+func deadUpstream(t *testing.T) string {
+	t.Helper()
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	addr := lis.Addr().String()
+	require.NoError(t, lis.Close())
+
+	return addr
 }
 
 func newProxyApp(t *testing.T, cfg *config.Config, opts ...fx.Option) *fx.App {

--- a/internal/transport/connect/conn.go
+++ b/internal/transport/connect/conn.go
@@ -2,10 +2,20 @@ package connect
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"sync"
+	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
 )
+
+// readyMargin is how far short of its context's deadline [WaitReady] stops, so
+// that the error it returns survives (see [WaitReady]). It only needs to cover
+// unwinding back to the caller, so it is small enough to be irrelevant next to
+// any sane start timeout.
+const readyMargin = 100 * time.Millisecond
 
 type (
 	// Conn is a [grpc.ClientConnInterface] that resolves its dial target per
@@ -28,8 +38,9 @@ type (
 	// Resolver decides, per request, which connection a Conn should use. Resolve
 	// returns the pool cache key, the dial target, and the dial options for that
 	// connection. IsStatic reports whether the resolution is fixed for the life
-	// of the Conn: a static resolver is dialed eagerly when the Conn is created;
-	// a dynamic one is resolved lazily on every call.
+	// of the Conn: a static resolver has its connection created when the Conn is,
+	// and opened up front by [Conn.WaitReady]; a dynamic one is resolved lazily on
+	// every call.
 	Resolver interface {
 		IsStatic() bool
 		Resolve(context.Context) (string, string, []grpc.DialOption, error)
@@ -49,17 +60,17 @@ type (
 
 // NewConn returns a Conn that resolves through r and dials through f. When r is
 // static the pooled connection is created eagerly here, so a malformed target
-// or bad dial option surfaces at construction rather than on the first request;
-// the socket itself is not opened until first use (gRPC connects lazily). A
-// dynamic resolver defers creation to the first call that resolves a given
-// target.
+// or bad dial option surfaces at construction rather than on the first request.
+// Creating it is not the same as opening it: gRPC connects on demand, so no
+// socket exists until [Conn.WaitReady] or the first request. A dynamic resolver
+// defers creation to the first call that resolves a given target.
 func NewConn(f ConnFactory, r Resolver) (*Conn, error) {
 	cc := &Conn{
 		factory:  f,
 		resolver: r,
 	}
 
-	// Static resolvers are eager loaded
+	// Static resolvers create their connection up front
 	if r.IsStatic() {
 		if _, err := cc.conn(context.Background()); err != nil {
 			return nil, fmt.Errorf("failed to initialize connection: %w", err)
@@ -77,6 +88,36 @@ func StaticResolver(hostPort string, opts ...grpc.DialOption) Resolver {
 		addr: hostPort,
 		opts: opts,
 	}
+}
+
+// WaitReady opens conns and blocks until each is ready or ctx is done,
+// whichever comes first. They are waited on concurrently, so they share ctx's
+// deadline rather than consuming it in turn, and every target that never came up
+// is reported rather than only the first, so one unreachable address cannot mask
+// another.
+//
+// When ctx has a deadline this stops just short of it. Callers are fx start
+// hooks, and fx prefers its start context's error over what a hook returns
+// (app.go, withTimeout), so a wait that runs to the deadline is reported as a
+// bare "context deadline exceeded" and the target names are lost. Returning
+// early is what keeps them.
+func WaitReady(ctx context.Context, conns ...*Conn) error {
+	if deadline, ok := ctx.Deadline(); ok && time.Until(deadline) > 2*readyMargin {
+		var cancel context.CancelFunc
+
+		ctx, cancel = context.WithDeadline(ctx, deadline.Add(-readyMargin))
+		defer cancel()
+	}
+
+	errs := make([]error, len(conns))
+
+	var wg sync.WaitGroup
+	for i, conn := range conns {
+		wg.Go(func() { errs[i] = conn.WaitReady(ctx) })
+	}
+
+	wg.Wait()
+	return errors.Join(errs...)
 }
 
 // Invoke resolves the connection for this call and forwards the unary RPC to
@@ -105,6 +146,58 @@ func (c *Conn) NewStream(
 	}
 
 	return cc.NewStream(ctx, desc, method, opts...)
+}
+
+// WaitReady opens the underlying connection and blocks until it is ready or ctx
+// is done, whichever comes first. [NewConn] creates a static Conn's connection
+// but grpc.NewClient only dials on demand, so nothing is open until this runs (or
+// the first request arrives); this is what makes the connection real ahead of
+// serving traffic.
+//
+// A refused connection is not on its own fatal: gRPC retries with backoff, so a
+// target still coming up passes as long as it answers before ctx expires. gRPC
+// keeps the underlying dial error private, so one that never answers is reported
+// by the state it was stuck in, wrapping ctx's error.
+//
+// A dynamic Conn holds no connection until a request resolves one, so there is
+// nothing to open and this does nothing. Callers can pass a mixed set of conns
+// without sorting them first.
+func (c *Conn) WaitReady(ctx context.Context) error {
+	if !c.resolver.IsStatic() {
+		return nil
+	}
+
+	// Resolved here rather than through conn so the target is in hand to name any
+	// error; the factory hands back the connection built in NewConn.
+	key, target, opts, err := c.resolver.Resolve(ctx)
+	if err != nil {
+		return err
+	}
+
+	cc, err := c.factory(key, target, opts...)
+	if err != nil {
+		return err
+	}
+
+	// Connect moves the connection out of idle. It does not wait for the attempt
+	// to begin, let alone finish, so the state changes are awaited below.
+	cc.Connect()
+
+	for {
+		switch state := cc.GetState(); state {
+		case connectivity.Ready:
+			return nil
+		case connectivity.Shutdown:
+			return fmt.Errorf("%s: connection is closed", target)
+		default:
+			// WaitForStateChange only reports false once ctx is done, so ctx.Err()
+			// says whether the wait ran out of time or was cancelled (fx cancels the
+			// start context when another hook fails).
+			if !cc.WaitForStateChange(ctx, state) {
+				return fmt.Errorf("%s: not ready (last state: %s): %w", target, state, ctx.Err())
+			}
+		}
+	}
 }
 
 // conn resolves the request and returns the pooled connection for it.

--- a/internal/transport/connect/conn_test.go
+++ b/internal/transport/connect/conn_test.go
@@ -3,21 +3,35 @@ package connect_test
 import (
 	"context"
 	"errors"
+	"net"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/temporalio/temporal-proxy/internal/transport/connect"
 )
 
-type fakeResolver struct {
-	static      bool
-	key, target string
-	opts        []grpc.DialOption
-	err         error
-}
+type (
+	fakeResolver struct {
+		static      bool
+		key, target string
+		opts        []grpc.DialOption
+		err         error
+	}
+
+	// flakyResolver is static and resolves cleanly exactly once, for
+	// [connect.NewConn], then fails. It is the only way to reach the resolve
+	// failure inside [connect.Conn.WaitReady], since a resolver that fails outright
+	// never yields a Conn to call it on.
+	flakyResolver struct {
+		err   error
+		calls int
+	}
+)
 
 func TestStaticResolver(t *testing.T) {
 	t.Parallel()
@@ -106,10 +120,200 @@ func TestConnFactoryErrorPropagates(t *testing.T) {
 	require.Equal(t, 2, calls, "both Invoke and NewStream resolve through the factory")
 }
 
+func TestConnWaitReady(t *testing.T) {
+	t.Parallel()
+
+	t.Run("opens a static connection", func(t *testing.T) {
+		t.Parallel()
+
+		pool := connect.NewPool()
+		t.Cleanup(func() { require.NoError(t, pool.Close()) })
+
+		addr := serveTCP(t)
+		c, err := connect.NewConn(pool.ConnOrCreate, connect.StaticResolver(addr, insecureOpt()))
+		require.NoError(t, err)
+
+		cc, err := pool.Conn(addr)
+		require.NoError(t, err)
+		require.Equal(t, connectivity.Idle, cc.GetState(), "grpc.NewClient does not dial on its own")
+
+		// Bounded so a connection that never leaves idle fails the test rather
+		// than hanging it.
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+		defer cancel()
+
+		require.NoError(t, c.WaitReady(ctx))
+		require.Equal(t, connectivity.Ready, cc.GetState())
+	})
+
+	t.Run("reports the target that never becomes ready", func(t *testing.T) {
+		t.Parallel()
+
+		pool := connect.NewPool()
+		t.Cleanup(func() { require.NoError(t, pool.Close()) })
+
+		addr := deadAddr(t)
+		c, err := connect.NewConn(pool.ConnOrCreate, connect.StaticResolver(addr, insecureOpt()))
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+		defer cancel()
+
+		err = c.WaitReady(ctx)
+		require.ErrorContains(t, err, addr)
+		require.ErrorContains(t, err, "not ready")
+		require.ErrorIs(t, err, context.DeadlineExceeded, "the context's cause is wrapped, not just described")
+	})
+
+	t.Run("reports a cancelled wait as cancelled", func(t *testing.T) {
+		t.Parallel()
+
+		pool := connect.NewPool()
+		t.Cleanup(func() { require.NoError(t, pool.Close()) })
+
+		c, err := connect.NewConn(pool.ConnOrCreate, connect.StaticResolver(deadAddr(t), insecureOpt()))
+		require.NoError(t, err)
+
+		// fx cancels the start context when another hook fails, so a cancelled wait
+		// must not be reported as having run out of time.
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		err = c.WaitReady(ctx)
+		require.ErrorIs(t, err, context.Canceled)
+		require.NotErrorIs(t, err, context.DeadlineExceeded)
+	})
+
+	t.Run("propagates a resolve failure", func(t *testing.T) {
+		t.Parallel()
+
+		boom := errors.New("resolve failed")
+		r := &flakyResolver{err: boom}
+
+		c, err := connect.NewConn(func(string, string, ...grpc.DialOption) (*grpc.ClientConn, error) {
+			return newConn(t), nil
+		}, r)
+		require.NoError(t, err)
+
+		require.ErrorIs(t, c.WaitReady(t.Context()), boom)
+	})
+
+	t.Run("propagates a factory failure", func(t *testing.T) {
+		t.Parallel()
+
+		boom := errors.New("dial failed")
+		calls := 0
+
+		// The factory has to succeed for NewConn and fail afterwards, since a
+		// static Conn that could not be created never reaches WaitReady.
+		c, err := connect.NewConn(func(string, string, ...grpc.DialOption) (*grpc.ClientConn, error) {
+			if calls++; calls > 1 {
+				return nil, boom
+			}
+
+			return newConn(t), nil
+		}, connect.StaticResolver("passthrough:///x", insecureOpt()))
+		require.NoError(t, err)
+
+		require.ErrorIs(t, c.WaitReady(t.Context()), boom)
+	})
+
+	t.Run("does nothing for a dynamic connection", func(t *testing.T) {
+		t.Parallel()
+
+		// A dynamic Conn has no connection to open, so this must neither dial nor
+		// resolve. t.Context has no deadline, so a regression that waits on
+		// something hangs the test rather than passing quietly.
+		calls := 0
+		c, err := connect.NewConn(countingFactory(&calls, nil, nil), fakeResolver{static: false})
+		require.NoError(t, err)
+
+		require.NoError(t, c.WaitReady(t.Context()))
+		require.Zero(t, calls)
+	})
+
+	t.Run("fails fast on a closed connection", func(t *testing.T) {
+		t.Parallel()
+
+		// A closed connection never changes state again, so without the shutdown
+		// guard this would block until ctx expired.
+		pool := connect.NewPool()
+
+		addr := deadAddr(t)
+		c, err := connect.NewConn(pool.ConnOrCreate, connect.StaticResolver(addr, insecureOpt()))
+		require.NoError(t, err)
+		require.NoError(t, pool.Close())
+
+		require.ErrorContains(t, c.WaitReady(t.Context()), addr+": connection is closed")
+	})
+}
+
+func TestWaitReady(t *testing.T) {
+	t.Parallel()
+
+	t.Run("waits for every connection", func(t *testing.T) {
+		t.Parallel()
+
+		pool := connect.NewPool()
+		t.Cleanup(func() { require.NoError(t, pool.Close()) })
+
+		conns := make([]*connect.Conn, 0, 3)
+		for range 3 {
+			c, err := connect.NewConn(pool.ConnOrCreate, connect.StaticResolver(serveTCP(t), insecureOpt()))
+			require.NoError(t, err)
+			conns = append(conns, c)
+		}
+
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+		defer cancel()
+		require.NoError(t, connect.WaitReady(ctx, conns...))
+	})
+
+	t.Run("reports every unreachable target", func(t *testing.T) {
+		t.Parallel()
+
+		pool := connect.NewPool()
+		t.Cleanup(func() { require.NoError(t, pool.Close()) })
+
+		alpha, bravo := deadAddr(t), deadAddr(t)
+		conns := make([]*connect.Conn, 0, 2)
+		for _, addr := range []string{alpha, bravo} {
+			c, err := connect.NewConn(pool.ConnOrCreate, connect.StaticResolver(addr, insecureOpt()))
+			require.NoError(t, err)
+			conns = append(conns, c)
+		}
+
+		ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+		defer cancel()
+
+		// Both are named: one unreachable target does not mask another. They are
+		// waited on concurrently, so a single deadline covers both.
+		err := connect.WaitReady(ctx, conns...)
+		require.ErrorContains(t, err, alpha)
+		require.ErrorContains(t, err, bravo)
+	})
+
+	t.Run("returns nil with no connections", func(t *testing.T) {
+		t.Parallel()
+
+		require.NoError(t, connect.WaitReady(t.Context()))
+	})
+}
+
 func (f fakeResolver) IsStatic() bool { return f.static }
 
 func (f fakeResolver) Resolve(context.Context) (string, string, []grpc.DialOption, error) {
 	return f.key, f.target, f.opts, f.err
+}
+
+func (r *flakyResolver) IsStatic() bool { return true }
+
+func (r *flakyResolver) Resolve(context.Context) (string, string, []grpc.DialOption, error) {
+	if r.calls++; r.calls > 1 {
+		return "", "", nil, r.err
+	}
+
+	return "key", "passthrough:///flaky", []grpc.DialOption{insecureOpt()}, nil
 }
 
 // countingFactory returns a ConnFactory that records how many times it is
@@ -123,4 +327,33 @@ func countingFactory(calls *int, conn *grpc.ClientConn, err error) connect.ConnF
 
 func insecureOpt() grpc.DialOption {
 	return grpc.WithTransportCredentials(insecure.NewCredentials())
+}
+
+// serveTCP starts a gRPC server on a loopback port and returns its address, so a
+// connection to it can actually reach ready.
+func serveTCP(t *testing.T) string {
+	t.Helper()
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	svr := grpc.NewServer()
+	go func() { _ = svr.Serve(lis) }()
+	t.Cleanup(svr.Stop)
+
+	return lis.Addr().String()
+}
+
+// deadAddr returns a loopback address with nothing behind it, by taking a port
+// from the kernel and immediately giving it back.
+func deadAddr(t *testing.T) string {
+	t.Helper()
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	addr := lis.Addr().String()
+	require.NoError(t, lis.Close())
+
+	return addr
 }

--- a/internal/transport/connect/doc.go
+++ b/internal/transport/connect/doc.go
@@ -7,4 +7,9 @@
 // Conn wraps that pool as a [grpc.ClientConnInterface] whose dial target is
 // chosen per call by a Resolver: StaticResolver for a fixed upstream, or a
 // caller-supplied dynamic Resolver that varies the target with the request.
+//
+// Creating a connection does not open one, since gRPC connects on demand. Use
+// WaitReady to open a fixed-target Conn (or several at once) before serving
+// traffic, so an unreachable target is reported up front rather than as a
+// request error later.
 package connect

--- a/internal/transport/connect/fx.go
+++ b/internal/transport/connect/fx.go
@@ -4,11 +4,15 @@ import "go.uber.org/fx"
 
 // Module provides a *Pool and binds its lifecycle to the application, closing
 // every pooled connection on shutdown via an fx stop hook.
+//
+// The pool is deliberately not opened as a whole on start. It also holds the
+// router's loopback connections to sockets this application binds itself, which
+// do not exist until the proxy start hooks run; waiting on those here would
+// block on work a later hook has yet to do. Opening eager connections is the job
+// of whoever owns one, through [WaitReady].
 var Module = fx.Options(
 	fx.Provide(NewPool),
 	fx.Invoke(func(p *Pool, lc fx.Lifecycle) {
-		lc.Append(fx.StopHook(func() error {
-			return p.Close()
-		}))
+		lc.Append(fx.StopHook(p.Close))
 	}),
 )


### PR DESCRIPTION
Several comments claimed static upstreams and extension servers were connected eagerly at startup. They were only created eagerly, not opened: grpc.NewClient never dials on its own, so no socket existed until the first request. An unreachable upstream, or one presenting a certificate this proxy will not accept, surfaced as a request error well after startup had reported success.

Conn.WaitReady calls ClientConn.Connect and waits for connectivity.Ready, and connect.WaitReady fans out over several of them so they share one deadline and every unreachable target is named rather than just the first. internal/proxy and internal/api each call it from a start hook, so an unreachable static upstream or extension server now fails startup. Templated upstreams have nothing to open until a request resolves a target, so Resolver.IsStatic skips them and they stay unverified until traffic arrives.

Readiness lives on Conn rather than Pool on purpose. The pool also holds the router's loopback connections to the unix sockets internal/proxy binds in its own start hooks, so waiting on every pooled connection would block on work a later hook has yet to do.

A refused connection is not fatal by itself, since gRPC retries with backoff and an upstream that has not finished starting should not fail a restart; only the deadline ends the wait. That deadline is fx's start timeout, and fx prefers its context's error over whatever a hook returns, so WaitReady stops just short of it to keep the error that names the target. gRPC keeps the underlying dial error private, so a target that never answers can only be reported by the connectivity state it was stuck in.
