### PR TITLE
[crypto]: Report envelope and rotation events from the Vault

### DIFF
--- a/internal/kms/doc.go
+++ b/internal/kms/doc.go
@@ -18,4 +18,14 @@
 // disabled the module provides a nil *crypto.Vault and starts no background
 // work; when enabled it also runs a goroutine that periodically refreshes the
 // vault so DEKs rotate ahead of expiry.
+//
+// The package also reports encryption telemetry to Prometheus under the
+// "encryption" subsystem. A [Reporter] implements [crypto.Observer] to record
+// DEK cache behavior, the AES-step duration and result of each envelope
+// operation as dek_ops_duration_secs and dek_ops_total, and DEK rotations by
+// reason; the metered keys above record their KMS wraps and unwraps against a
+// provider as kek_ops_total and kek_ops_duration_secs. This package owns the
+// DEK and KEK operations themselves; internal/proxy owns the end-to-end envelope
+// operation, timing its own Seal and Open calls and reporting them as
+// vault_ops_total and vault_ops_duration_secs, labeled by namespace.
 package kms

--- a/internal/kms/reporter.go
+++ b/internal/kms/reporter.go
@@ -183,25 +183,19 @@ func (r *Reporter) Observe(e crypto.Event) {
 // kek_ops_total already reports, and counting it here would blame the wrong
 // actor.
 func (r *Reporter) envelopeOp(e crypto.EnvelopeEvent) {
-	// Whether AES ran is decided by both fields, not by the duration alone. A
-	// zero Crypto with no CryptoErr is the only combination that means AES was
-	// never reached, so there is no DEK operation to record. A non-nil CryptoErr
-	// means AES ran and failed, and that must still be counted even if its
-	// measured duration read as zero: the outcome lives in CryptoErr, so testing
-	// the duration alone would silently drop the failure.
-	if e.Crypto <= 0 && e.CryptoErr == nil {
+	// No AES step, no DEK operation to record. CryptoAttempted is the only sound
+	// test for that: a zero Crypto cannot distinguish a step that never ran from
+	// one that finished inside the clock's resolution, so treating a zero as
+	// "never ran" would undercount both fast successes and fast failures.
+	if !e.CryptoAttempted {
 		return
 	}
 
+	// Every observation from here is a real measurement, including a zero, which
+	// belongs in the lowest bucket rather than being withheld.
 	op := e.Op.String()
 	r.countDEKOp(op, resultLabel(e.CryptoErr))
-
-	// Observe only a real measurement. A zero would drag the quantiles toward
-	// nothing, which is why this is a separate condition from counting the
-	// operation rather than one guard over both.
-	if e.Crypto > 0 {
-		r.observeDEKDur(op, e.Crypto.Seconds())
-	}
+	r.observeDEKDur(op, e.Crypto.Seconds())
 }
 
 // cacheAccess records a DEK cache hit or miss, distinguished by e.Hit, and

--- a/internal/kms/reporter.go
+++ b/internal/kms/reporter.go
@@ -9,20 +9,29 @@ import (
 
 type (
 	// Reporter records encryption telemetry to Prometheus: KEK wrap/unwrap
-	// calls and DEK cache behavior. It implements crypto.Observer so a Vault can
-	// notify it of cache events, and exposes KEKOp for the KEK decorator. Handles
-	// for the low-cardinality KEK label combinations are pre-resolved so the emit
-	// path is a lock-free map read; an unexpected combination falls back to
-	// WithLabelValues. A Reporter is safe for concurrent use.
+	// calls, the AES-step duration of DEK operations, and DEK cache behavior. It
+	// implements crypto.Observer so a Vault can notify it of those events, and
+	// exposes KEKOp for the KEK decorator. The end-to-end envelope operation is
+	// owned by internal/proxy, which times its own Seal and Open calls and
+	// labels them by namespace. Handles for the low-cardinality label
+	// combinations are pre-resolved so the emit path is a lock-free map read; an
+	// unexpected combination falls back to WithLabelValues. A Reporter is safe
+	// for concurrent use.
 	Reporter struct {
-		kekOps      *prometheus.CounterVec
-		kekOpDur    *prometheus.HistogramVec
-		cacheHits   prometheus.Counter
-		cacheMisses prometheus.Counter
-		cacheSize   prometheus.Gauge
+		kekOps       *prometheus.CounterVec
+		kekOpDur     *prometheus.HistogramVec
+		cacheHits    prometheus.Counter
+		cacheMisses  prometheus.Counter
+		cacheSize    prometheus.Gauge
+		dekOps       *prometheus.CounterVec
+		dekOpDur     *prometheus.HistogramVec
+		dekRotations *prometheus.CounterVec
 
-		kekOpHandle  map[kekOpKey]prometheus.Counter
-		kekDurHandle map[kekDurKey]prometheus.Observer
+		kekOpHandle       map[kekOpKey]prometheus.Counter
+		kekDurHandle      map[kekDurKey]prometheus.Observer
+		dekOpHandle       map[dekOpKey]prometheus.Counter
+		dekDurHandle      map[string]prometheus.Observer
+		dekRotationHandle map[string]prometheus.Counter
 	}
 
 	kekOpKey struct {
@@ -34,6 +43,11 @@ type (
 	kekDurKey struct {
 		provider  string
 		operation string
+	}
+
+	dekOpKey struct {
+		operation string
+		result    string
 	}
 )
 
@@ -51,9 +65,32 @@ func NewReporter(f *metrics.Factory) *Reporter {
 		Help: "Duration of KEK operations in seconds, labeled by provider and operation.",
 	}, []string{"provider", "operation"})
 
+	dekOpDur := f.NewHistogram(prometheus.HistogramOpts{
+		Name: "dek_ops_duration_secs",
+		Help: "Duration of the AES-256-GCM step alone in seconds, excluding any KEK wrap or unwrap, labeled by operation.",
+		// Explicit buckets because the Prometheus defaults start at 5ms, which
+		// would put nearly every observation in the first bucket: this measures
+		// symmetric encryption of a payload, not a KMS round trip. Spans 10us to
+		// 41ms. kek_ops_duration_secs keeps the defaults for the opposite reason.
+		Buckets: prometheus.ExponentialBuckets(0.00001, 4, 7),
+	}, []string{"operation"})
+
+	dekOps := f.NewCounter(prometheus.CounterOpts{
+		Name: "dek_ops_total",
+		Help: "Total DEK operations (payload encrypt/decrypt), labeled by operation and result. The result is the AES-256-GCM step's own outcome, not the surrounding envelope operation's.",
+	}, []string{"operation", "result"})
+
+	dekRotations := f.NewCounter(prometheus.CounterOpts{
+		Name: "dek_rotations_total",
+		Help: "Total DEK rotations, labeled by reason. A rising on_demand rate means Refresh is falling behind.",
+	}, []string{"reason"})
+
 	r := &Reporter{
-		kekOps:   kekOps,
-		kekOpDur: kekOpDur,
+		kekOps:       kekOps,
+		kekOpDur:     kekOpDur,
+		dekOps:       dekOps,
+		dekOpDur:     dekOpDur,
+		dekRotations: dekRotations,
 		cacheHits: f.NewCounter(prometheus.CounterOpts{
 			Name: "dek_cache_hits_total",
 			Help: "Total DEK cache hits.",
@@ -66,8 +103,11 @@ func NewReporter(f *metrics.Factory) *Reporter {
 			Name: "dek_cache_size",
 			Help: "Current number of entries in the DEK cache.",
 		}),
-		kekOpHandle:  make(map[kekOpKey]prometheus.Counter),
-		kekDurHandle: make(map[kekDurKey]prometheus.Observer),
+		kekOpHandle:       make(map[kekOpKey]prometheus.Counter),
+		kekDurHandle:      make(map[kekDurKey]prometheus.Observer),
+		dekOpHandle:       make(map[dekOpKey]prometheus.Counter),
+		dekDurHandle:      make(map[string]prometheus.Observer),
+		dekRotationHandle: make(map[string]prometheus.Counter),
 	}
 
 	providers := []string{"aws", "gcp", "azure", "testing"}
@@ -80,6 +120,17 @@ func NewReporter(f *metrics.Factory) *Reporter {
 				r.kekOpHandle[kekOpKey{p, op, res}] = kekOps.WithLabelValues(p, op, res)
 			}
 		}
+	}
+
+	for _, op := range []string{"encrypt", "decrypt"} {
+		r.dekDurHandle[op] = dekOpDur.WithLabelValues(op)
+		for _, res := range results {
+			r.dekOpHandle[dekOpKey{op, res}] = dekOps.WithLabelValues(op, res)
+		}
+	}
+
+	for _, reason := range []string{"scheduled", "on_demand", "initial"} {
+		r.dekRotationHandle[reason] = dekRotations.WithLabelValues(reason)
 	}
 
 	return r
@@ -100,14 +151,104 @@ func (r *Reporter) KEKOp(provider, operation, result string, seconds float64) {
 	}
 }
 
-// CacheHit records a DEK cache hit and updates the cache-size gauge.
-func (r *Reporter) CacheHit(e crypto.CacheEvent) {
-	r.cacheHits.Inc()
+// Observe records e against the metric its type owns. There is no default
+// case: an event type this switch does not recognize means this binary's
+// pkg/crypto is newer than this Reporter. Dropping it is deliberate, not an
+// oversight. Metric emission must never alter behaviour, so panicking or
+// returning an error on an unrecognized event is not available here; a
+// missing metric is a missing signal, not corrupted data.
+func (r *Reporter) Observe(e crypto.Event) {
+	switch ev := e.(type) {
+	case crypto.EnvelopeEvent:
+		r.envelopeOp(ev)
+	case crypto.CacheEvent:
+		r.cacheAccess(ev)
+	case crypto.RotationEvent:
+		r.rotated(ev)
+	}
+}
+
+// envelopeOp records the AES-256-GCM portion of one envelope operation: its
+// duration and, via dek_ops_total, its own result.
+//
+// Total and Namespace are deliberately unused. internal/proxy already records
+// the end-to-end duration and operation counts, labeled by namespace, around
+// its own Seal and Open calls as vault_ops_duration_secs and vault_ops_total;
+// recording them here would duplicate those series and collide with them on
+// the shared "encryption" subsystem. Err is likewise unused here for a
+// reason, not an oversight: the envelope result already lives on
+// internal/proxy's vault_ops_total. The result label instead comes from
+// CryptoErr, the AES step's own outcome, deliberately not Err: a Seal that
+// encrypts successfully and then fails to wrap its DEK is a KEK failure that
+// kek_ops_total already reports, and counting it here would blame the wrong
+// actor.
+func (r *Reporter) envelopeOp(e crypto.EnvelopeEvent) {
+	// Whether AES ran is decided by both fields, not by the duration alone. A
+	// zero Crypto with no CryptoErr is the only combination that means AES was
+	// never reached, so there is no DEK operation to record. A non-nil CryptoErr
+	// means AES ran and failed, and that must still be counted even if its
+	// measured duration read as zero: the outcome lives in CryptoErr, so testing
+	// the duration alone would silently drop the failure.
+	if e.Crypto <= 0 && e.CryptoErr == nil {
+		return
+	}
+
+	op := e.Op.String()
+	r.countDEKOp(op, resultLabel(e.CryptoErr))
+
+	// Observe only a real measurement. A zero would drag the quantiles toward
+	// nothing, which is why this is a separate condition from counting the
+	// operation rather than one guard over both.
+	if e.Crypto > 0 {
+		r.observeDEKDur(op, e.Crypto.Seconds())
+	}
+}
+
+// cacheAccess records a DEK cache hit or miss, distinguished by e.Hit, and
+// updates the cache-size gauge.
+func (r *Reporter) cacheAccess(e crypto.CacheEvent) {
+	if e.Hit {
+		r.cacheHits.Inc()
+	} else {
+		r.cacheMisses.Inc()
+	}
+
 	r.cacheSize.Set(float64(e.Size))
 }
 
-// CacheMiss records a DEK cache miss and updates the cache-size gauge.
-func (r *Reporter) CacheMiss(e crypto.CacheEvent) {
-	r.cacheMisses.Inc()
-	r.cacheSize.Set(float64(e.Size))
+// rotated counts a DEK rotation by reason. The namespace is deliberately
+// unused, for the same cardinality reason the cache metrics carry no namespace
+// label.
+func (r *Reporter) rotated(e crypto.RotationEvent) {
+	reason := e.Reason.String()
+	if c, ok := r.dekRotationHandle[reason]; ok {
+		c.Inc()
+		return
+	}
+
+	r.dekRotations.WithLabelValues(reason).Inc()
+}
+
+// countDEKOp increments dek_ops_total for op and result, using the
+// pre-resolved handle when the combination is one of the four expected ones
+// and falling back to WithLabelValues otherwise.
+func (r *Reporter) countDEKOp(op, result string) {
+	if c, ok := r.dekOpHandle[dekOpKey{op, result}]; ok {
+		c.Inc()
+		return
+	}
+
+	r.dekOps.WithLabelValues(op, result).Inc()
+}
+
+// observeDEKDur records seconds against dek_ops_duration_secs for op, using
+// the pre-resolved handle when op is one of the two expected operations and
+// falling back to WithLabelValues otherwise.
+func (r *Reporter) observeDEKDur(op string, seconds float64) {
+	if o, ok := r.dekDurHandle[op]; ok {
+		o.Observe(seconds)
+		return
+	}
+
+	r.dekOpDur.WithLabelValues(op).Observe(seconds)
 }

--- a/internal/kms/reporter_test.go
+++ b/internal/kms/reporter_test.go
@@ -1,8 +1,10 @@
 package kms_test
 
 import (
+	"errors"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -35,9 +37,9 @@ func TestReporterCacheEvents(t *testing.T) {
 	t.Parallel()
 
 	r, reg := newTestReporter(t)
-	r.CacheMiss(crypto.CacheEvent{Size: 0})
-	r.CacheHit(crypto.CacheEvent{Size: 1})
-	r.CacheHit(crypto.CacheEvent{Size: 2})
+	r.Observe(crypto.CacheEvent{Hit: false, Size: 0})
+	r.Observe(crypto.CacheEvent{Hit: true, Size: 1})
+	r.Observe(crypto.CacheEvent{Hit: true, Size: 2})
 
 	hits := gather(t, reg, "proxy_encryption_dek_cache_hits_total")
 	require.NotNil(t, hits)
@@ -50,6 +52,114 @@ func TestReporterCacheEvents(t *testing.T) {
 	size := gather(t, reg, "proxy_encryption_dek_cache_size")
 	require.NotNil(t, size)
 	require.Equal(t, 2.0, size.GetMetric()[0].GetGauge().GetValue()) // last Set wins
+}
+
+func TestReporterEnvelopeOp(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		event         crypto.EnvelopeEvent
+		operation     string
+		wantDurCount  uint64
+		wantSuccesses float64
+		wantErrors    float64
+	}{
+		{
+			name:          "encrypt records the AES step",
+			event:         crypto.EnvelopeEvent{Op: crypto.OpEncrypt, Crypto: 250 * time.Microsecond, Total: 3 * time.Millisecond},
+			operation:     "encrypt",
+			wantDurCount:  1,
+			wantSuccesses: 1,
+		},
+		{
+			name: "decrypt with a CryptoErr counts as a failed AES step",
+			// AES was attempted and timed even though it failed, so the histogram
+			// still records it and the counter reports the failure.
+			event:        crypto.EnvelopeEvent{Op: crypto.OpDecrypt, Crypto: 100 * time.Microsecond, Total: time.Millisecond, CryptoErr: crypto.ErrMalformedCipherText, Err: crypto.ErrMalformedCipherText},
+			operation:    "decrypt",
+			wantDurCount: 1,
+			wantErrors:   1,
+		},
+		{
+			name: "encrypt whose KEK fails to wrap still counts as an AES success",
+			// Err is set because the overall Seal failed, but CryptoErr is nil
+			// because AES itself succeeded: the KEK wrap is what failed, and that
+			// failure belongs to kek_ops_total, not here.
+			event:         crypto.EnvelopeEvent{Op: crypto.OpEncrypt, Crypto: 250 * time.Microsecond, Total: 3 * time.Millisecond, Err: errors.New("kms unavailable")},
+			operation:     "encrypt",
+			wantDurCount:  1,
+			wantSuccesses: 1,
+		},
+		{
+			name: "a failure before AES records nothing",
+			// Crypto is zero and CryptoErr is nil, the only combination meaning AES
+			// was never reached. Recording that zero would drag the quantiles toward
+			// nothing, and there is no AES result to count either.
+			event:        crypto.EnvelopeEvent{Op: crypto.OpDecrypt, Err: errors.New("unknown key"), Total: 2 * time.Millisecond},
+			operation:    "decrypt",
+			wantDurCount: 0,
+		},
+		{
+			name: "an AES failure counts even with an unmeasurably short duration",
+			// Whether AES ran is decided by CryptoErr, not by the duration, so this
+			// failure is counted. Its duration is still withheld from the histogram,
+			// which is why the count and the histogram's sample count can differ.
+			event:        crypto.EnvelopeEvent{Op: crypto.OpDecrypt, CryptoErr: crypto.ErrMalformedCipherText, Err: crypto.ErrMalformedCipherText, Total: time.Millisecond},
+			operation:    "decrypt",
+			wantDurCount: 0,
+			wantErrors:   1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			r, reg := newTestReporter(t)
+			r.Observe(tt.event)
+
+			mf := gather(t, reg, "proxy_encryption_dek_ops_duration_secs")
+			require.NotNil(t, mf)
+			m := findMetric(t, mf, map[string]string{"operation": tt.operation})
+			require.Equal(t, tt.wantDurCount, m.GetHistogram().GetSampleCount())
+
+			ops := gather(t, reg, "proxy_encryption_dek_ops_total")
+			require.NotNil(t, ops)
+			success := findMetric(t, ops, map[string]string{"operation": tt.operation, "result": "success"})
+			require.Equal(t, tt.wantSuccesses, success.GetCounter().GetValue())
+			failure := findMetric(t, ops, map[string]string{"operation": tt.operation, "result": "error"})
+			require.Equal(t, tt.wantErrors, failure.GetCounter().GetValue())
+		})
+	}
+}
+
+func TestReporterRotated(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		reason crypto.RotationReason
+		want   string
+	}{
+		{name: "scheduled", reason: crypto.RotationScheduled, want: "scheduled"},
+		{name: "on demand", reason: crypto.RotationOnDemand, want: "on_demand"},
+		{name: "initial", reason: crypto.RotationInitial, want: "initial"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			r, reg := newTestReporter(t)
+			r.Observe(crypto.RotationEvent{Namespace: "ns1", Reason: tt.reason})
+
+			mf := gather(t, reg, "proxy_encryption_dek_rotations_total")
+			require.NotNil(t, mf)
+			m := findMetric(t, mf, map[string]string{"reason": tt.want})
+			require.Equal(t, 1.0, m.GetCounter().GetValue())
+		})
+	}
 }
 
 func gather(t *testing.T, reg *prometheus.Registry, name string) *dto.MetricFamily {

--- a/internal/kms/reporter_test.go
+++ b/internal/kms/reporter_test.go
@@ -67,7 +67,7 @@ func TestReporterEnvelopeOp(t *testing.T) {
 	}{
 		{
 			name:          "encrypt records the AES step",
-			event:         crypto.EnvelopeEvent{Op: crypto.OpEncrypt, Crypto: 250 * time.Microsecond, Total: 3 * time.Millisecond},
+			event:         crypto.EnvelopeEvent{Op: crypto.OpEncrypt, CryptoAttempted: true, Crypto: 250 * time.Microsecond, Total: 3 * time.Millisecond},
 			operation:     "encrypt",
 			wantDurCount:  1,
 			wantSuccesses: 1,
@@ -76,7 +76,7 @@ func TestReporterEnvelopeOp(t *testing.T) {
 			name: "decrypt with a CryptoErr counts as a failed AES step",
 			// AES was attempted and timed even though it failed, so the histogram
 			// still records it and the counter reports the failure.
-			event:        crypto.EnvelopeEvent{Op: crypto.OpDecrypt, Crypto: 100 * time.Microsecond, Total: time.Millisecond, CryptoErr: crypto.ErrMalformedCipherText, Err: crypto.ErrMalformedCipherText},
+			event:        crypto.EnvelopeEvent{Op: crypto.OpDecrypt, CryptoAttempted: true, Crypto: 100 * time.Microsecond, Total: time.Millisecond, CryptoErr: crypto.ErrMalformedCipherText, Err: crypto.ErrMalformedCipherText},
 			operation:    "decrypt",
 			wantDurCount: 1,
 			wantErrors:   1,
@@ -86,28 +86,35 @@ func TestReporterEnvelopeOp(t *testing.T) {
 			// Err is set because the overall Seal failed, but CryptoErr is nil
 			// because AES itself succeeded: the KEK wrap is what failed, and that
 			// failure belongs to kek_ops_total, not here.
-			event:         crypto.EnvelopeEvent{Op: crypto.OpEncrypt, Crypto: 250 * time.Microsecond, Total: 3 * time.Millisecond, Err: errors.New("kms unavailable")},
+			event:         crypto.EnvelopeEvent{Op: crypto.OpEncrypt, CryptoAttempted: true, Crypto: 250 * time.Microsecond, Total: 3 * time.Millisecond, Err: errors.New("kms unavailable")},
 			operation:     "encrypt",
 			wantDurCount:  1,
 			wantSuccesses: 1,
 		},
 		{
 			name: "a failure before AES records nothing",
-			// Crypto is zero and CryptoErr is nil, the only combination meaning AES
-			// was never reached. Recording that zero would drag the quantiles toward
-			// nothing, and there is no AES result to count either.
+			// CryptoAttempted is false, so no DEK operation happened.
 			event:        crypto.EnvelopeEvent{Op: crypto.OpDecrypt, Err: errors.New("unknown key"), Total: 2 * time.Millisecond},
 			operation:    "decrypt",
 			wantDurCount: 0,
 		},
 		{
-			name: "an AES failure counts even with an unmeasurably short duration",
-			// Whether AES ran is decided by CryptoErr, not by the duration, so this
-			// failure is counted. Its duration is still withheld from the histogram,
-			// which is why the count and the histogram's sample count can differ.
-			event:        crypto.EnvelopeEvent{Op: crypto.OpDecrypt, CryptoErr: crypto.ErrMalformedCipherText, Err: crypto.ErrMalformedCipherText, Total: time.Millisecond},
+			name: "a fast success is recorded despite a zero duration",
+			// A step that ran but finished inside the clock's resolution. Whether AES
+			// ran is decided by CryptoAttempted, never by the duration, so this is
+			// counted and its zero lands in the lowest bucket. Testing the duration
+			// instead would silently undercount successful DEK operations.
+			event:         crypto.EnvelopeEvent{Op: crypto.OpEncrypt, CryptoAttempted: true, Total: time.Millisecond},
+			operation:     "encrypt",
+			wantDurCount:  1,
+			wantSuccesses: 1,
+		},
+		{
+			name: "a fast failure is recorded despite a zero duration",
+			// The same, for a step that ran and failed.
+			event:        crypto.EnvelopeEvent{Op: crypto.OpDecrypt, CryptoAttempted: true, CryptoErr: crypto.ErrMalformedCipherText, Err: crypto.ErrMalformedCipherText, Total: time.Millisecond},
 			operation:    "decrypt",
-			wantDurCount: 0,
+			wantDurCount: 1,
 			wantErrors:   1,
 		},
 	}

--- a/internal/proxy/encryption.go
+++ b/internal/proxy/encryption.go
@@ -43,8 +43,9 @@ type Vault interface {
 // back only payloads this interceptor sealed (identified by the
 // encryptionEncoding marker) are opened; anything else passes through
 // untouched. Search attributes are skipped so they stay queryable upstream. r
-// records the duration and result of every seal/open through DEKOp. It returns
-// an error only if the underlying visitor interceptor cannot be constructed.
+// records the duration and result of every seal/open through VaultOp. It
+// returns an error only if the underlying visitor interceptor cannot be
+// constructed.
 func EncryptionInterceptor(enabled bool, v Vault, r *Reporter) (grpc.UnaryClientInterceptor, error) {
 	var outbound *proxy.VisitPayloadsOptions
 	if enabled {
@@ -69,8 +70,8 @@ func EncryptionInterceptor(enabled bool, v Vault, r *Reporter) (grpc.UnaryClient
 // the bytes under v for the context's namespace, and replaces it with a payload
 // whose data is the ciphertext and whose metadata carries the wrapped DEK
 // needed to open it. The entire original payload (metadata included) is sealed,
-// so decryptPayloads can restore it exactly. Each Seal call is timed and
-// recorded via r.DEKOp, regardless of outcome.
+// so decryptPayloads can restore it exactly. Each Seal call is timed end to
+// end and recorded via r.VaultOp, regardless of outcome.
 func encryptPayloads(v Vault, r *Reporter) func(*proxy.VisitPayloadsContext, []*common.Payload) ([]*common.Payload, error) {
 	return func(ctx *proxy.VisitPayloadsContext, payloads []*common.Payload) ([]*common.Payload, error) {
 		ns := meta.NamespaceFrom(ctx)
@@ -84,7 +85,7 @@ func encryptPayloads(v Vault, r *Reporter) func(*proxy.VisitPayloadsContext, []*
 
 			start := time.Now()
 			msg, err := v.Seal(ctx, ns, data)
-			r.DEKOp("encrypt", resultLabel(err), ns, time.Since(start).Seconds())
+			r.VaultOp("encrypt", resultLabel(err), ns, time.Since(start).Seconds())
 			if err != nil {
 				return nil, fmt.Errorf("failed to encrypt payload: %w", err)
 			}
@@ -107,7 +108,8 @@ func encryptPayloads(v Vault, r *Reporter) func(*proxy.VisitPayloadsContext, []*
 // payloads carrying the encryptionEncoding marker are opened and unmarshaled
 // back into their original form, while any others pass through unchanged so
 // payloads produced elsewhere survive the round trip. Only payloads actually
-// opened are timed and recorded via r.DEKOp; pass-through payloads are not.
+// opened are timed end to end and recorded via r.VaultOp; pass-through
+// payloads are not.
 func decryptPayloads(v Vault, r *Reporter) func(*proxy.VisitPayloadsContext, []*common.Payload) ([]*common.Payload, error) {
 	return func(ctx *proxy.VisitPayloadsContext, payloads []*common.Payload) ([]*common.Payload, error) {
 		ns := meta.NamespaceFrom(ctx)
@@ -128,7 +130,7 @@ func decryptPayloads(v Vault, r *Reporter) func(*proxy.VisitPayloadsContext, []*
 					EncryptedDEK: string(p.Metadata[metadataEncryptionDEK]),
 				},
 			})
-			r.DEKOp("decrypt", resultLabel(err), ns, time.Since(start).Seconds())
+			r.VaultOp("decrypt", resultLabel(err), ns, time.Since(start).Seconds())
 			if err != nil {
 				return nil, fmt.Errorf("failed to decrypt payload: %w", err)
 			}

--- a/internal/proxy/encryption_test.go
+++ b/internal/proxy/encryption_test.go
@@ -126,7 +126,7 @@ func TestEncryptionInterceptorDisabledSkipsOutbound(t *testing.T) {
 	require.Empty(t, v.namespaces, "interceptor must not seal when disabled")
 }
 
-func TestEncryptionInterceptorRecordsDEKOps(t *testing.T) {
+func TestEncryptionInterceptorRecordsVaultOps(t *testing.T) {
 	t.Parallel()
 
 	reg := prometheus.NewRegistry()
@@ -154,12 +154,12 @@ func TestEncryptionInterceptorRecordsDEKOps(t *testing.T) {
 	}
 	require.NoError(t, interceptor(ctx, "/method", req, resp, nil, invoker))
 
-	ops := gatherFamily(t, reg, "proxy_encryption_dek_ops_total")
+	ops := gatherFamily(t, reg, "proxy_encryption_vault_ops_total")
 	require.NotNil(t, ops)
 	require.True(t, hasLabels(ops, map[string]string{"operation": "encrypt", "result": "success", "namespace": "ns1"}))
 	require.True(t, hasLabels(ops, map[string]string{"operation": "decrypt", "result": "success", "namespace": "ns1"}))
 
-	dur := gatherFamily(t, reg, "proxy_encryption_dek_ops_duration_secs")
+	dur := gatherFamily(t, reg, "proxy_encryption_vault_ops_duration_secs")
 	require.NotNil(t, dur)
 	require.True(t, hasLabels(dur, map[string]string{"operation": "encrypt", "namespace": "ns1"}))
 	require.True(t, hasLabels(dur, map[string]string{"operation": "decrypt", "namespace": "ns1"}))
@@ -194,7 +194,7 @@ func TestEncryptionInterceptorSkipsMetricsForPassThrough(t *testing.T) {
 
 	require.Equal(t, 0, vault.opens)
 
-	ops := gatherFamily(t, reg, "proxy_encryption_dek_ops_total")
+	ops := gatherFamily(t, reg, "proxy_encryption_vault_ops_total")
 	require.NotNil(t, ops)
 	require.True(t, hasLabels(ops, map[string]string{"operation": "encrypt", "result": "success", "namespace": "ns1"}))
 	require.False(t, hasLabels(ops, map[string]string{"operation": "decrypt", "result": "success", "namespace": "ns1"}))

--- a/internal/proxy/reporter.go
+++ b/internal/proxy/reporter.go
@@ -6,33 +6,34 @@ import (
 	"github.com/temporalio/temporal-proxy/internal/metrics"
 )
 
-// Reporter records DEK payload-operation telemetry to Prometheus: each seal
-// (encrypt) and open (decrypt) the encryption interceptor performs. The
-// namespace label is unbounded, so handles are resolved per call via
-// WithLabelValues rather than pre-computed. A Reporter is safe for concurrent
-// use.
+// Reporter records envelope-operation telemetry to Prometheus: each seal
+// (encrypt) and open (decrypt) the encryption interceptor performs, timed end
+// to end, including any KEK wrap or unwrap and any DEK cache lookup along the
+// way. The AES-step duration alone is owned by internal/kms. The namespace
+// label is unbounded, so handles are resolved per call via WithLabelValues
+// rather than pre-computed. A Reporter is safe for concurrent use.
 type Reporter struct {
 	ops      *prometheus.CounterVec
 	duration *prometheus.HistogramVec
 }
 
-// NewReporter builds the Prometheus-backed DEK-operation Reporter. f must
+// NewReporter builds the Prometheus-backed vault-operation Reporter. f must
 // already be scoped to the "encryption" subsystem by the caller.
 func NewReporter(f *metrics.Factory) *Reporter {
 	return &Reporter{
 		ops: f.NewCounter(prometheus.CounterOpts{
-			Name: "dek_ops_total",
-			Help: "Total DEK payload operations (encrypt/decrypt), labeled by operation, result, and namespace.",
+			Name: "vault_ops_total",
+			Help: "Total envelope operations (encrypt/decrypt), labeled by operation, result, and namespace.",
 		}, []string{"operation", "result", "namespace"}),
 		duration: f.NewHistogram(prometheus.HistogramOpts{
-			Name: "dek_ops_duration_secs",
-			Help: "Duration of DEK payload operations in seconds, labeled by operation and namespace.",
+			Name: "vault_ops_duration_secs",
+			Help: "Duration of envelope operations in seconds end to end, including any KEK wrap or unwrap, labeled by operation and namespace.",
 		}, []string{"operation", "namespace"}),
 	}
 }
 
-// DEKOp records a single DEK payload operation and its duration.
-func (r *Reporter) DEKOp(operation, result, namespace string, seconds float64) {
+// VaultOp records a single envelope operation and its duration.
+func (r *Reporter) VaultOp(operation, result, namespace string, seconds float64) {
 	r.ops.WithLabelValues(operation, result, namespace).Inc()
 	r.duration.WithLabelValues(operation, namespace).Observe(seconds)
 }

--- a/pkg/crypto/doc.go
+++ b/pkg/crypto/doc.go
@@ -10,4 +10,15 @@
 // key by namespace for encryption and by key ID for decryption. KEKs themselves
 // are opened from key URIs by a [KeyFactory], which handles the cloud KMS
 // schemes directly and can be extended with schemes of the caller's own.
+//
+// A [Vault] reports what it does to an [Observer] as one of a closed set of
+// [Event] types: a [CacheEvent] for a DEK cache hit or miss, one
+// [EnvelopeEvent] per Seal and Open carrying both the end-to-end and the
+// AES-only duration and distinguishing a failure inside AES from a failure
+// elsewhere in the operation, and a [RotationEvent] whenever a namespace's DEK
+// is replaced. Observers are always called outside the Vault's internal lock,
+// so an implementation may call back into the Vault, but it must not block,
+// and it must not re-enter the operation that produced the event: calling
+// Seal from Observe, for example, recurses without bound and a stack overflow
+// cannot be recovered from.
 package crypto

--- a/pkg/crypto/observer.go
+++ b/pkg/crypto/observer.go
@@ -55,9 +55,14 @@ type (
 		Namespace string
 		// Err is the error the operation returned, or nil.
 		Err error
+		// CryptoAttempted reports whether the AES-256-GCM step ran. It is the
+		// only reliable signal for that, and Crypto is not: a small payload can
+		// complete inside the clock's resolution, so a step that did run can
+		// still report a zero duration. Crypto and CryptoErr are meaningful only
+		// when this is true.
+		CryptoAttempted bool
 		// CryptoErr is the error from the AES-256-GCM step alone, or nil when
-		// that step succeeded or was never reached. It is non-nil only when
-		// Crypto is nonzero. Err, by contrast, is the whole operation's error,
+		// that step succeeded. Err, by contrast, is the whole operation's error,
 		// which may come from a KEK wrap or a cache-miss unwrap rather than from
 		// AES, so the two differ whenever a Seal encrypts successfully and then
 		// fails to wrap its DEK.
@@ -65,10 +70,9 @@ type (
 		// Total covers the whole operation, including any KEK wrap on the first
 		// Seal after a rotation and any unwrap on a cache miss.
 		Total time.Duration
-		// Crypto covers only the AES-256-GCM step. It is nonzero if and only if
-		// that step was attempted, so a failure inside AES still reports a
-		// duration while a failure before it reports zero. Total minus Crypto is
-		// meaningful only when Crypto is nonzero.
+		// Crypto covers only the AES-256-GCM step, and may be zero for a step
+		// that ran. Total minus Crypto is the cost of everything around AES, and
+		// is meaningful only when CryptoAttempted is true.
 		Crypto time.Duration
 	}
 

--- a/pkg/crypto/observer.go
+++ b/pkg/crypto/observer.go
@@ -1,25 +1,134 @@
 package crypto
 
+import "time"
+
+const (
+	// OpEncrypt is a Seal: the DEK encrypting a payload.
+	OpEncrypt Operation = iota
+	// OpDecrypt is an Open: the DEK decrypting a payload.
+	OpDecrypt
+)
+
+const (
+	// RotationScheduled is a rotation performed by [Vault.Refresh], off the
+	// request path.
+	RotationScheduled RotationReason = iota
+	// RotationOnDemand is a rotation [Vault.Seal] performed because it found the
+	// DEK already expired, which means Refresh has fallen behind.
+	RotationOnDemand
+	// RotationInitial is the first DEK for a namespace that had no explicit
+	// [WithKeyConfig], created on its first Seal.
+	RotationInitial
+)
+
 type (
-	// CacheEvent describes a DEK cache access. Fields may be added over time
-	// without breaking implementers, so callers accept the struct by value.
+	// Operation names the envelope operation an [EnvelopeEvent] describes.
+	Operation uint8
+
+	// RotationReason says why a namespace's DEK was replaced.
+	RotationReason uint8
+
+	// Event is one thing a Vault reports to an [Observer]. The set is closed:
+	// only this package can define one, so an Observer's type switch can be
+	// written against a known set of cases.
+	Event interface {
+		internalMarker()
+	}
+
+	// CacheEvent describes a DEK cache access.
 	CacheEvent struct {
+		// Hit is true when the wrapped DEK was already cached.
+		Hit bool
 		// Size is the number of entries in the DEK cache after the access.
 		Size int
 	}
 
-	// Observer receives notifications about Vault-internal events for telemetry.
-	// Implementations must be safe for concurrent use and must not block: a
-	// Vault calls these on the Open path. A nil Observer is never used; the
-	// Vault substitutes a no-op (see WithObserver).
-	Observer interface {
-		CacheHit(CacheEvent)
-		CacheMiss(CacheEvent)
+	// EnvelopeEvent describes one completed envelope operation, successful or
+	// not. Exactly one is reported per [Vault.Seal] and per [Vault.Open], on
+	// every path including early failures.
+	EnvelopeEvent struct {
+		// Op is OpEncrypt for Seal, OpDecrypt for Open.
+		Op Operation
+		// Namespace is set on OpEncrypt. It is always empty on OpDecrypt: Open
+		// selects its KEK by ID from the message material and never learns a
+		// namespace.
+		Namespace string
+		// Err is the error the operation returned, or nil.
+		Err error
+		// CryptoErr is the error from the AES-256-GCM step alone, or nil when
+		// that step succeeded or was never reached. It is non-nil only when
+		// Crypto is nonzero. Err, by contrast, is the whole operation's error,
+		// which may come from a KEK wrap or a cache-miss unwrap rather than from
+		// AES, so the two differ whenever a Seal encrypts successfully and then
+		// fails to wrap its DEK.
+		CryptoErr error
+		// Total covers the whole operation, including any KEK wrap on the first
+		// Seal after a rotation and any unwrap on a cache miss.
+		Total time.Duration
+		// Crypto covers only the AES-256-GCM step. It is nonzero if and only if
+		// that step was attempted, so a failure inside AES still reports a
+		// duration while a failure before it reports zero. Total minus Crypto is
+		// meaningful only when Crypto is nonzero.
+		Crypto time.Duration
 	}
 
-	// nopObserver is the default Observer; it drops every event.
+	// RotationEvent reports that a namespace's DEK was replaced.
+	RotationEvent struct {
+		Namespace string
+		Reason    RotationReason
+	}
+
+	// Observer receives notifications about Vault-internal events for
+	// telemetry. It is called with a CacheEvent from Open only, an
+	// EnvelopeEvent from both Seal and Open, and a RotationEvent from both
+	// Seal and Refresh. Implementations must be safe for concurrent use, must
+	// not block, and must not re-enter the operation that produced the event.
+	// A nil Observer is never used; the Vault substitutes a no-op (see
+	// WithObserver).
+	Observer interface {
+		Observe(Event)
+	}
+
+	// nopObserver implements Observer by dropping every event. It is the
+	// Vault's default when no Observer is supplied, and what a nil Observer
+	// passed to WithObserver is replaced with.
 	nopObserver struct{}
 )
 
-func (nopObserver) CacheHit(CacheEvent)  {}
-func (nopObserver) CacheMiss(CacheEvent) {}
+// String returns the metric label value for o. An unrecognized value returns
+// "unknown" so a label is never blank if a value is added without updating this
+// method.
+func (o Operation) String() string {
+	switch o {
+	case OpEncrypt:
+		return "encrypt"
+	case OpDecrypt:
+		return "decrypt"
+	default:
+		return "unknown"
+	}
+}
+
+// String returns the metric label value for r. An unrecognized value returns
+// "unknown" so a label is never blank if a value is added without updating this
+// method.
+func (r RotationReason) String() string {
+	switch r {
+	case RotationScheduled:
+		return "scheduled"
+	case RotationOnDemand:
+		return "on_demand"
+	case RotationInitial:
+		return "initial"
+	default:
+		return "unknown"
+	}
+}
+
+func (CacheEvent) internalMarker() {}
+
+func (EnvelopeEvent) internalMarker() {}
+
+func (RotationEvent) internalMarker() {}
+
+func (nopObserver) Observe(Event) {}

--- a/pkg/crypto/observer_test.go
+++ b/pkg/crypto/observer_test.go
@@ -508,7 +508,13 @@ func TestObserverDEKOpEvents(t *testing.T) {
 				require.NoError(t, got.Err)
 			}
 
+			require.Equal(t, tt.wantCrypto, got.CryptoAttempted)
 			if tt.wantCrypto {
+				// Every row that reaches AES seals a payload large enough that the
+				// step cannot finish inside the clock's resolution, so a positive
+				// duration is safe to assert here. That is a property of these
+				// fixtures, not of the API: Crypto may legitimately be zero for a
+				// step that ran, which is why CryptoAttempted exists.
 				require.Positive(t, got.Crypto)
 			} else {
 				require.Zero(t, got.Crypto)
@@ -520,10 +526,10 @@ func TestObserverDEKOpEvents(t *testing.T) {
 				require.NoError(t, got.CryptoErr)
 			}
 
-			// A non-nil CryptoErr is only meaningful if AES ran, so it must imply
-			// a positive Crypto duration.
+			// CryptoErr describes the AES step, so it can only be set when that
+			// step ran. Note this implies nothing about the duration.
 			if got.CryptoErr != nil {
-				require.Positive(t, got.Crypto)
+				require.True(t, got.CryptoAttempted)
 			}
 		})
 	}

--- a/pkg/crypto/observer_test.go
+++ b/pkg/crypto/observer_test.go
@@ -1,6 +1,12 @@
 package crypto_test
 
 import (
+	"bytes"
+	"context"
+	"errors"
+	"slices"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -9,10 +15,56 @@ import (
 	"github.com/temporalio/temporal-proxy/pkg/crypto"
 )
 
-type spyObserver struct {
-	hits   []int
-	misses []int
-}
+// reentrancyDeadline bounds how long a reentrant Seal is allowed to take.
+// Generous enough not to flake on a loaded machine, but far faster and far
+// clearer than waiting for the package timeout to report a deadlock.
+const reentrancyDeadline = 5 * time.Second
+
+type (
+	spyObserver struct {
+		mu        sync.Mutex
+		hits      []int
+		misses    []int
+		ops       []crypto.EnvelopeEvent
+		rotations []crypto.RotationEvent
+	}
+
+	// reentrantRefreshObserver seals through the Vault from inside the
+	// RotationScheduled callback fired by Refresh, which deadlocks if Refresh
+	// reports while still holding v.mu. It reenters once only: the nested Seal
+	// can itself rotate, and unbounded recursion would mask the deadlock this
+	// exists to detect.
+	//
+	// fired is a CompareAndSwap guard rather than a sync.Once, and rather than
+	// the mutex-guarded bool this codebase would otherwise prefer, because both
+	// of those deadlock on reentry. sync.Once.Do deadlocks by contract if f
+	// causes Do to be called again on the same Once before the first call
+	// returns, and a mutex fails the same way: the nested Observe would block
+	// re-taking a lock the outer call still holds. An atomic is the only guard
+	// here that a reentrant caller can pass through.
+	reentrantRefreshObserver struct {
+		vault     *crypto.Vault
+		ctx       context.Context
+		fired     atomic.Bool
+		reentered bool
+		err       error
+	}
+
+	// reentrantSealObserver seals a second, unconfigured namespace through the
+	// Vault from inside the RotationInitial callback fired by createDefaultKey,
+	// which deadlocks if that report runs while still holding v.mu. It reenters
+	// once only, and guards that with an atomic for the same reason as
+	// reentrantRefreshObserver: the nested Seal creates ns-b's own default key
+	// and so reports its own RotationInitial back through this same observer,
+	// which neither a sync.Once nor a mutex could tolerate.
+	reentrantSealObserver struct {
+		vault     *crypto.Vault
+		ctx       context.Context
+		fired     atomic.Bool
+		reentered bool
+		err       error
+	}
+)
 
 func TestObserverMissThenHit(t *testing.T) {
 	t.Parallel()
@@ -32,8 +84,8 @@ func TestObserverMissThenHit(t *testing.T) {
 	_, err = v.Open(t.Context(), msg)
 	require.NoError(t, err)
 
-	require.Equal(t, []int{0}, spy.misses)
-	require.Equal(t, []int{1}, spy.hits)
+	require.Equal(t, []int{0}, spy.cacheMissSizes())
+	require.Equal(t, []int{1}, spy.cacheHitSizes())
 }
 
 func TestObserverDisabledCache(t *testing.T) {
@@ -49,23 +101,82 @@ func TestObserverDisabledCache(t *testing.T) {
 	_, err = v.Open(t.Context(), msg)
 	require.NoError(t, err)
 
-	require.Empty(t, spy.hits)
-	require.Empty(t, spy.misses)
+	require.Empty(t, spy.cacheHitSizes())
+	require.Empty(t, spy.cacheMissSizes())
 }
 
 func TestObserverDefaultNoPanic(t *testing.T) {
 	t.Parallel()
 
-	v := newTestVault(t) // no WithObserver
+	clock := &testClock{}
+	v := newVault(t, &countingKEK{id: "default"}, // no WithObserver
+		crypto.WithNowFunc(clock.Now),
+		crypto.WithKeyConfig("ns1", crypto.KeyConfig{Duration: time.Hour}))
 
 	msg, err := v.Seal(t.Context(), "ns1", []byte("hello"))
 	require.NoError(t, err)
-	_, err = v.Open(t.Context(), msg)
-	require.NoError(t, err) // must not panic on the nil-default path
+
+	_, err = v.Open(t.Context(), msg) // must not panic on the nil-default path
+	require.NoError(t, err)
+
+	// Reach the rotation path so the default Observer's Observe is actually
+	// called with a RotationEvent.
+	clock.advance(2 * time.Hour)
+	require.NoError(t, v.Refresh())
 }
 
-func (s *spyObserver) CacheHit(e crypto.CacheEvent)  { s.hits = append(s.hits, e.Size) }
-func (s *spyObserver) CacheMiss(e crypto.CacheEvent) { s.misses = append(s.misses, e.Size) }
+// Observe records e, distinguishing a cache hit from a miss by e.Hit rather
+// than by which method was called.
+func (s *spyObserver) Observe(e crypto.Event) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	switch ev := e.(type) {
+	case crypto.CacheEvent:
+		if ev.Hit {
+			s.hits = append(s.hits, ev.Size)
+		} else {
+			s.misses = append(s.misses, ev.Size)
+		}
+	case crypto.EnvelopeEvent:
+		s.ops = append(s.ops, ev)
+	case crypto.RotationEvent:
+		s.rotations = append(s.rotations, ev)
+	}
+}
+
+// reset drops everything recorded so far, so a test can set a Vault up and then
+// assert on a single operation. It nils the slices rather than truncating them,
+// because tests compare against a nil expectation.
+func (s *spyObserver) reset() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.hits, s.misses, s.ops, s.rotations = nil, nil, nil, nil
+}
+
+func (s *spyObserver) cacheHitSizes() []int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return slices.Clone(s.hits)
+}
+
+func (s *spyObserver) cacheMissSizes() []int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return slices.Clone(s.misses)
+}
+
+func (s *spyObserver) envelopeOps() []crypto.EnvelopeEvent {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return slices.Clone(s.ops)
+}
+
+func (s *spyObserver) rotationEvents() []crypto.RotationEvent {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return slices.Clone(s.rotations)
+}
 
 func newTestVault(t *testing.T, opts ...crypto.VaultOption) *crypto.Vault {
 	t.Helper()
@@ -78,4 +189,486 @@ func newTestVault(t *testing.T, opts ...crypto.VaultOption) *crypto.Vault {
 	v, err := crypto.NewVault(reg, append(base, opts...)...)
 	require.NoError(t, err)
 	return v
+}
+
+func TestOperationString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		op   crypto.Operation
+		want string
+	}{
+		{name: "encrypt", op: crypto.OpEncrypt, want: "encrypt"},
+		{name: "decrypt", op: crypto.OpDecrypt, want: "decrypt"},
+		{name: "out of range", op: crypto.Operation(99), want: "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, tt.op.String())
+		})
+	}
+}
+
+func TestRotationReasonString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		reason crypto.RotationReason
+		want   string
+	}{
+		{name: "scheduled", reason: crypto.RotationScheduled, want: "scheduled"},
+		{name: "on demand", reason: crypto.RotationOnDemand, want: "on_demand"},
+		{name: "initial", reason: crypto.RotationInitial, want: "initial"},
+		{name: "out of range", reason: crypto.RotationReason(99), want: "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, tt.reason.String())
+		})
+	}
+}
+
+func TestObserverRotationEvents(t *testing.T) {
+	t.Parallel()
+
+	// Expiry follows the injected clock while durations follow time.Now, so
+	// jumping the clock forces a rotation without disturbing any timing.
+	newClockedVault := func(t *testing.T, spy *spyObserver, clock *testClock) *crypto.Vault {
+		t.Helper()
+		return newVault(t, &countingKEK{id: "default"},
+			crypto.WithObserver(spy),
+			crypto.WithNowFunc(clock.Now),
+			crypto.WithKeyConfig("ns1", crypto.KeyConfig{Duration: time.Hour}))
+	}
+
+	tests := []struct {
+		name string
+		run  func(t *testing.T, spy *spyObserver)
+		want []crypto.RotationEvent
+	}{
+		{
+			name: "refresh rotates an expired key",
+			run: func(t *testing.T, spy *spyObserver) {
+				clock := &testClock{}
+				v := newClockedVault(t, spy, clock)
+
+				clock.advance(2 * time.Hour)
+				require.NoError(t, v.Refresh())
+			},
+			want: []crypto.RotationEvent{{Namespace: "ns1", Reason: crypto.RotationScheduled}},
+		},
+		{
+			name: "refresh rotates two expired keys",
+			run: func(t *testing.T, spy *spyObserver) {
+				clock := &testClock{}
+				v := newVault(t, &countingKEK{id: "default"},
+					crypto.WithObserver(spy),
+					crypto.WithNowFunc(clock.Now),
+					crypto.WithKeyConfig("ns1", crypto.KeyConfig{Duration: time.Hour}),
+					crypto.WithKeyConfig("ns2", crypto.KeyConfig{Duration: time.Hour}))
+
+				clock.advance(2 * time.Hour)
+				require.NoError(t, v.Refresh())
+			},
+			// Refresh builds its rotated list by ranging a map, so the order
+			// callers observe is not part of the contract.
+			want: []crypto.RotationEvent{
+				{Namespace: "ns1", Reason: crypto.RotationScheduled},
+				{Namespace: "ns2", Reason: crypto.RotationScheduled},
+			},
+		},
+		{
+			name: "refresh with nothing expired",
+			run: func(t *testing.T, spy *spyObserver) {
+				clock := &testClock{}
+				v := newClockedVault(t, spy, clock)
+
+				require.NoError(t, v.Refresh())
+			},
+			want: nil,
+		},
+		{
+			name: "seal finds the key already expired",
+			run: func(t *testing.T, spy *spyObserver) {
+				clock := &testClock{}
+				v := newClockedVault(t, spy, clock)
+
+				clock.advance(2 * time.Hour)
+				_, err := v.Seal(t.Context(), "ns1", []byte("data"))
+				require.NoError(t, err)
+			},
+			want: []crypto.RotationEvent{{Namespace: "ns1", Reason: crypto.RotationOnDemand}},
+		},
+		{
+			name: "first seal on an unconfigured namespace",
+			run: func(t *testing.T, spy *spyObserver) {
+				v := newVault(t, &countingKEK{id: "default"},
+					crypto.WithObserver(spy),
+					crypto.WithDefaultKeyConfig(crypto.KeyConfig{Duration: time.Hour}))
+
+				_, err := v.Seal(t.Context(), "new-ns", []byte("data"))
+				require.NoError(t, err)
+			},
+			want: []crypto.RotationEvent{{Namespace: "new-ns", Reason: crypto.RotationInitial}},
+		},
+		{
+			name: "second seal on that namespace",
+			run: func(t *testing.T, spy *spyObserver) {
+				v := newVault(t, &countingKEK{id: "default"},
+					crypto.WithObserver(spy),
+					crypto.WithDefaultKeyConfig(crypto.KeyConfig{Duration: time.Hour}))
+
+				_, err := v.Seal(t.Context(), "new-ns", []byte("data"))
+				require.NoError(t, err)
+
+				spy.reset()
+				_, err = v.Seal(t.Context(), "new-ns", []byte("data"))
+				require.NoError(t, err)
+			},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			spy := &spyObserver{}
+			tt.run(t, spy)
+			require.ElementsMatch(t, tt.want, spy.rotationEvents())
+		})
+	}
+}
+
+func TestObserverDEKOpEvents(t *testing.T) {
+	t.Parallel()
+
+	// Large enough that the AES step is comfortably longer than the clock's
+	// resolution, so the Crypto assertions test the documented invariant rather
+	// than timer granularity.
+	payload := bytes.Repeat([]byte("payload"), 8192)
+
+	newSealed := func(t *testing.T, spy *spyObserver) (*crypto.Vault, *crypto.Message) {
+		t.Helper()
+		v := newVault(t, &countingKEK{id: "default"},
+			crypto.WithObserver(spy),
+			crypto.WithKeyConfig("ns1", crypto.KeyConfig{Duration: time.Hour}))
+
+		msg, err := v.Seal(t.Context(), "ns1", payload)
+		require.NoError(t, err)
+
+		return v, msg
+	}
+
+	tests := []struct {
+		name          string
+		run           func(t *testing.T, spy *spyObserver)
+		wantOp        crypto.Operation
+		wantNS        string
+		wantErr       bool
+		wantCrypto    bool
+		wantCryptoErr bool
+	}{
+		{
+			name: "successful seal",
+			run: func(t *testing.T, spy *spyObserver) {
+				v := newVault(t, &countingKEK{id: "default"},
+					crypto.WithObserver(spy),
+					crypto.WithKeyConfig("ns1", crypto.KeyConfig{Duration: time.Hour}))
+
+				_, err := v.Seal(t.Context(), "ns1", payload)
+				require.NoError(t, err)
+			},
+			wantOp:     crypto.OpEncrypt,
+			wantNS:     "ns1",
+			wantCrypto: true,
+		},
+		{
+			name: "successful open",
+			run: func(t *testing.T, spy *spyObserver) {
+				v, msg := newSealed(t, spy)
+
+				spy.reset()
+				_, err := v.Open(t.Context(), msg)
+				require.NoError(t, err)
+			},
+			wantOp:     crypto.OpDecrypt,
+			wantCrypto: true,
+		},
+		{
+			name: "seal whose KEK fails to wrap",
+			run: func(t *testing.T, spy *spyObserver) {
+				kek := &countingKEK{id: "default", encErr: errors.New("kms unavailable")}
+				v := newVault(t, kek,
+					crypto.WithObserver(spy),
+					crypto.WithKeyConfig("ns1", crypto.KeyConfig{Duration: time.Hour}))
+
+				_, err := v.Seal(t.Context(), "ns1", payload)
+				require.Error(t, err)
+			},
+			// AES ran to completion before the wrap was attempted, so Err is set
+			// but CryptoErr, the AES step's own outcome, is not: this is a KEK
+			// failure, not a DEK failure.
+			wantOp:     crypto.OpEncrypt,
+			wantNS:     "ns1",
+			wantErr:    true,
+			wantCrypto: true,
+		},
+		{
+			name: "seal on an unconfigured namespace with no default config",
+			run: func(t *testing.T, spy *spyObserver) {
+				v := newVault(t, &countingKEK{id: "default"}, crypto.WithObserver(spy))
+
+				_, err := v.Seal(t.Context(), "ns1", payload)
+				require.Error(t, err)
+			},
+			// getOrRefreshKey rejects the namespace before AES is ever reached.
+			wantOp:  crypto.OpEncrypt,
+			wantNS:  "ns1",
+			wantErr: true,
+		},
+		{
+			name: "open with an unknown KEK id",
+			run: func(t *testing.T, spy *spyObserver) {
+				v, msg := newSealed(t, spy)
+
+				// Copy before tampering: msg.KeyMaterial is the same pointer the
+				// Vault holds in its sliding-key state, and mutating it in place
+				// would corrupt that state for any later use of the Vault.
+				tampered := *msg
+				material := *msg.KeyMaterial
+				material.KEKID = "nope"
+				tampered.KeyMaterial = &material
+
+				// Nothing has been opened yet, so the cache is empty and this
+				// reaches the registry, which rejects the ID before AES.
+				spy.reset()
+				_, err := v.Open(t.Context(), &tampered)
+				require.Error(t, err)
+			},
+			wantOp:  crypto.OpDecrypt,
+			wantErr: true,
+		},
+		{
+			name: "open with a nil message",
+			run: func(t *testing.T, spy *spyObserver) {
+				v := newVault(t, &countingKEK{id: "default"},
+					crypto.WithObserver(spy),
+					crypto.WithKeyConfig("ns1", crypto.KeyConfig{Duration: time.Hour}))
+
+				_, err := v.Open(t.Context(), nil)
+				require.Error(t, err)
+			},
+			wantOp:  crypto.OpDecrypt,
+			wantErr: true,
+		},
+		{
+			name: "open with tampered ciphertext",
+			run: func(t *testing.T, spy *spyObserver) {
+				v, msg := newSealed(t, spy)
+
+				spy.reset()
+				msg.Ciphertext[len(msg.Ciphertext)-1] ^= 0xff
+				_, err := v.Open(t.Context(), msg)
+				require.ErrorIs(t, err, crypto.ErrMalformedCipherText)
+			},
+			// AES was attempted and failed, so it still reports a duration, and
+			// CryptoErr is set because the failure is AES's own.
+			wantOp:        crypto.OpDecrypt,
+			wantErr:       true,
+			wantCrypto:    true,
+			wantCryptoErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			spy := &spyObserver{}
+			tt.run(t, spy)
+
+			ops := spy.envelopeOps()
+			require.Len(t, ops, 1)
+
+			got := ops[0]
+			require.Equal(t, tt.wantOp, got.Op)
+			require.Equal(t, tt.wantNS, got.Namespace)
+			require.GreaterOrEqual(t, got.Total, got.Crypto)
+
+			if tt.wantErr {
+				require.Error(t, got.Err)
+			} else {
+				require.NoError(t, got.Err)
+			}
+
+			if tt.wantCrypto {
+				require.Positive(t, got.Crypto)
+			} else {
+				require.Zero(t, got.Crypto)
+			}
+
+			if tt.wantCryptoErr {
+				require.ErrorIs(t, got.CryptoErr, crypto.ErrMalformedCipherText)
+			} else {
+				require.NoError(t, got.CryptoErr)
+			}
+
+			// A non-nil CryptoErr is only meaningful if AES ran, so it must imply
+			// a positive Crypto duration.
+			if got.CryptoErr != nil {
+				require.Positive(t, got.Crypto)
+			}
+		})
+	}
+}
+
+func TestObserverRotationReportedOutsideLockOnRefresh(t *testing.T) {
+	t.Parallel()
+
+	// An Observer must never run while the Vault holds v.mu. If it does, the
+	// reentrant Seal below blocks on that lock forever: Refresh's own report
+	// call is the only path in, since its own goroutine still holds the write
+	// lock. The reentrant call runs on a deadline rather than in a synctest
+	// bubble: synctest does not count mutex contention as durably blocked, so
+	// a bubble would hang exactly as a plain test does.
+	clock := &testClock{}
+	obs := &reentrantRefreshObserver{ctx: t.Context()}
+	v := newVault(t, &countingKEK{id: "default"},
+		crypto.WithObserver(obs),
+		crypto.WithNowFunc(clock.Now),
+		crypto.WithKeyConfig("ns1", crypto.KeyConfig{Duration: time.Hour}),
+		crypto.WithKeyConfig("ns2", crypto.KeyConfig{Duration: time.Hour}))
+	obs.vault = v
+
+	clock.advance(2 * time.Hour)
+
+	var refreshErr error
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		refreshErr = v.Refresh()
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(reentrancyDeadline):
+		t.Fatal("rotation reported while holding v.mu: reentrant Seal deadlocked")
+	}
+
+	require.NoError(t, refreshErr)
+	require.True(t, obs.reentered)
+	require.NoError(t, obs.err)
+}
+
+// Observe acts only on a RotationEvent, ignoring every other event type.
+func (o *reentrantRefreshObserver) Observe(e crypto.Event) {
+	if _, ok := e.(crypto.RotationEvent); !ok {
+		return
+	}
+
+	if !o.fired.CompareAndSwap(false, true) {
+		return
+	}
+
+	o.reentered = true
+	// ns1 was just rotated, so this Seal finds a current key and does not
+	// rotate again.
+	_, o.err = o.vault.Seal(o.ctx, "ns1", []byte("reentrant"))
+}
+
+func TestObserverRotationReportedOutsideLockOnSeal(t *testing.T) {
+	t.Parallel()
+
+	// getOrRefreshKey's report must land after createDefaultKey's deferred
+	// unlock too: a first Seal into an unconfigured namespace rotates from
+	// inside createDefaultKey, not lookupKey's own rotation branch, and the
+	// nested Seal below deadlocks if that report runs under the lock.
+	obs := &reentrantSealObserver{ctx: t.Context()}
+	v := newVault(t, &countingKEK{id: "default"},
+		crypto.WithObserver(obs),
+		crypto.WithDefaultKeyConfig(crypto.KeyConfig{Duration: time.Hour}))
+	obs.vault = v
+
+	var sealErr error
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, sealErr = v.Seal(t.Context(), "ns-a", []byte("data"))
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(reentrancyDeadline):
+		t.Fatal("rotation reported while holding v.mu: reentrant Seal deadlocked")
+	}
+
+	require.NoError(t, sealErr)
+	require.True(t, obs.reentered)
+	require.NoError(t, obs.err)
+}
+
+// Observe acts only on a RotationEvent, ignoring every other event type.
+func (o *reentrantSealObserver) Observe(e crypto.Event) {
+	if _, ok := e.(crypto.RotationEvent); !ok {
+		return
+	}
+
+	if !o.fired.CompareAndSwap(false, true) {
+		return
+	}
+
+	o.reentered = true
+	// ns-b is also unconfigured, so this Seal creates its own default key
+	// through the same createDefaultKey path as ns-a, reporting its own
+	// RotationInitial back through this same observer. The CompareAndSwap
+	// above makes that a no-op instead of a second reentrant Seal.
+	_, o.err = o.vault.Seal(o.ctx, "ns-b", []byte("reentrant"))
+}
+
+func TestObserverConcurrentSealEvents(t *testing.T) {
+	t.Parallel()
+
+	// One EnvelopeEvent per Seal even when callers race across a rotation boundary,
+	// and no data race on the Observer itself. Also covers the singleflight
+	// coalescing path with an Observer attached.
+	const callers = 16
+
+	clock := &testClock{}
+	spy := &spyObserver{}
+	v := newVault(t, &countingKEK{id: "default"},
+		crypto.WithObserver(spy),
+		crypto.WithNowFunc(clock.Now),
+		crypto.WithKeyConfig("ns1", crypto.KeyConfig{Duration: time.Hour}))
+
+	clock.advance(2 * time.Hour)
+
+	errs := make([]error, callers)
+
+	var wg sync.WaitGroup
+	for i := range callers {
+		wg.Go(func() {
+			_, errs[i] = v.Seal(t.Context(), "ns1", []byte("payload"))
+		})
+	}
+	wg.Wait()
+
+	for _, err := range errs {
+		require.NoError(t, err)
+	}
+
+	require.Len(t, spy.envelopeOps(), callers)
+
+	// Exactly one caller wins the rotation race. Losers split into two groups:
+	// those already past the read-path expiry check when the winner rotates
+	// re-check under the write lock, find a current key, and report nothing;
+	// those that arrive later see a current key on the RLock fast path and
+	// never reach the write lock at all. Either way, only the winner reports.
+	require.Len(t, spy.rotationEvents(), 1)
 }

--- a/pkg/crypto/vault.go
+++ b/pkg/crypto/vault.go
@@ -72,10 +72,16 @@ type (
 		before   time.Duration
 	}
 
-	// cryptoStep records what the AES-256-GCM step cost and whether it failed.
-	// Its zero value means the step was never reached, which is what an early
-	// failure returns.
+	// cryptoStep records whether the AES-256-GCM step ran, what it cost, and
+	// whether it failed. Its zero value means the step was never reached, which
+	// is what an early failure returns.
+	//
+	// ran is tracked explicitly rather than inferred from dur being nonzero,
+	// because a small payload can complete inside the clock's resolution: a step
+	// that did run can measure as zero, so dur cannot distinguish "never ran"
+	// from "ran very fast".
 	cryptoStep struct {
+		ran bool
 		dur time.Duration
 		err error
 	}
@@ -221,12 +227,13 @@ func (v *Vault) Seal(ctx context.Context, ns string, data []byte) (*Message, err
 	msg, step, err := v.seal(ctx, ns, data)
 
 	v.observer.Observe(EnvelopeEvent{
-		Op:        OpEncrypt,
-		Namespace: ns,
-		Err:       err,
-		CryptoErr: step.err,
-		Total:     time.Since(start),
-		Crypto:    step.dur,
+		Op:              OpEncrypt,
+		Namespace:       ns,
+		Err:             err,
+		CryptoAttempted: step.ran,
+		CryptoErr:       step.err,
+		Total:           time.Since(start),
+		Crypto:          step.dur,
 	})
 
 	return msg, err
@@ -245,11 +252,12 @@ func (v *Vault) Open(ctx context.Context, msg *Message) ([]byte, error) {
 	pt, step, err := v.open(ctx, msg)
 
 	v.observer.Observe(EnvelopeEvent{
-		Op:        OpDecrypt,
-		Err:       err,
-		CryptoErr: step.err,
-		Total:     time.Since(start),
-		Crypto:    step.dur,
+		Op:              OpDecrypt,
+		Err:             err,
+		CryptoAttempted: step.ran,
+		CryptoErr:       step.err,
+		Total:           time.Since(start),
+		Crypto:          step.dur,
 	})
 
 	return pt, err
@@ -341,7 +349,7 @@ func (v *Vault) seal(ctx context.Context, ns string, data []byte) (*Message, cry
 
 	cryptoStart := time.Now()
 	ct, err := dek.Encrypt(ctx, data)
-	step := cryptoStep{dur: time.Since(cryptoStart), err: err}
+	step := cryptoStep{ran: true, dur: time.Since(cryptoStart), err: err}
 	if err != nil {
 		return nil, step, err
 	}
@@ -419,7 +427,7 @@ func (v *Vault) open(ctx context.Context, msg *Message) ([]byte, cryptoStep, err
 	cryptoStart := time.Now()
 	pt, err := dek.Decrypt(ctx, msg.Ciphertext)
 
-	return pt, cryptoStep{dur: time.Since(cryptoStart), err: err}, err
+	return pt, cryptoStep{ran: true, dur: time.Since(cryptoStart), err: err}, err
 }
 
 // getOrRefreshKey returns the sliding DEK for ns, creating or rotating it on

--- a/pkg/crypto/vault.go
+++ b/pkg/crypto/vault.go
@@ -71,6 +71,14 @@ type (
 		dur      time.Duration
 		before   time.Duration
 	}
+
+	// cryptoStep records what the AES-256-GCM step cost and whether it failed.
+	// Its zero value means the step was never reached, which is what an early
+	// failure returns.
+	cryptoStep struct {
+		dur time.Duration
+		err error
+	}
 )
 
 // NewVault constructs a Vault backed by r, applying opts in order. A DEK is
@@ -186,9 +194,11 @@ func WithCacheSize(n int) VaultOption {
 	}
 }
 
-// WithObserver sets the Observer notified of Vault-internal events such as DEK
-// cache hits and misses. A nil Observer is replaced with a no-op, so Open never
-// needs to nil-check. Without this option no events are emitted.
+// WithObserver sets the Observer notified of Vault-internal events: a
+// CacheEvent from Open, an EnvelopeEvent from both Seal and Open, and a
+// RotationEvent from Seal and Refresh. A nil Observer is replaced with a
+// no-op, so no Vault call site needs to nil-check. Without this option no
+// events are emitted.
 func WithObserver(o Observer) VaultOption {
 	return func(e *vaultOptions) {
 		if o == nil {
@@ -203,102 +213,54 @@ func WithObserver(o Observer) VaultOption {
 // DEK required to Open it. The active DEK for ns is created or rotated on demand.
 // Concurrent first-time seals holding the same DEK are coalesced into a single
 // KEK (KMS) call.
+//
+// Exactly one [EnvelopeEvent] is reported to the Observer, on every path
+// including failures.
 func (v *Vault) Seal(ctx context.Context, ns string, data []byte) (*Message, error) {
-	sd, err := v.getOrRefreshKey(ns)
-	if err != nil {
-		return nil, err
-	}
+	start := time.Now()
+	msg, step, err := v.seal(ctx, ns, data)
 
-	// Snapshot key and material under RLock; release immediately so the
-	// encryption work happens outside the lock.
-	v.mu.RLock()
-	dek := sd.key
-	material := sd.material
-	v.mu.RUnlock()
-
-	ct, err := dek.Encrypt(ctx, data)
-	if err != nil {
-		return nil, err
-	}
-
-	if material != nil {
-		return &Message{Ciphertext: ct, KeyMaterial: material}, nil
-	}
-
-	// First Seal after a rotation: coalesce concurrent callers for the same namespace
-	// into a single KMS call so bursts don't trigger rate limiting in the Cloud provider.
-	//
-	// Key on both the namespace and the DEK pointer. If the KMS call is slow and
-	// Refresh rotates the DEK while it is in-flight, a goroutine that snapshotted
-	// the new DEK must not join the old call as it would receive material for DEK1
-	// while its ciphertext was encrypted with DEK2, causing Open to fail. Callers
-	// holding the same DEK pointer still coalesce as intended.
-	sfKey := fmt.Sprintf("%s:%p", ns, dek)
-	res, err, _ := v.encryptor.Do(sfKey, func() (any, error) {
-		return v.registry.Encrypt(ctx, ns, dek)
+	v.observer.Observe(EnvelopeEvent{
+		Op:        OpEncrypt,
+		Namespace: ns,
+		Err:       err,
+		CryptoErr: step.err,
+		Total:     time.Since(start),
+		Crypto:    step.dur,
 	})
-	if err != nil {
-		return nil, err
-	}
-	m := res.(*DEKMaterial)
 
-	// Store under write lock.
-	// Only touch sd.material when sd.key == dek: if the key was rotated between
-	// our snapshot and now we must not read or write material that belongs to a
-	// different DEK. The envelope we built (ct + m) is still correct for this call.
-	// When sd.key == dek, prefer an already-stored value so all concurrent callers
-	// for the same DEK return identical material.
-	v.mu.Lock()
-	if sd.key == dek {
-		if sd.material == nil {
-			sd.material = m
-		} else {
-			m = sd.material
-		}
-	}
-	v.mu.Unlock()
-
-	return &Message{Ciphertext: ct, KeyMaterial: m}, nil
+	return msg, err
 }
 
 // Open decrypts msg, which must have been produced by [Vault.Seal] (or
 // [NamespacedVault.Seal]). The wrapped DEK is unwrapped via the [KEKRegistry]
 // using the KEK identified by the material carried in msg, served from the
 // decrypted-DEK cache when it is enabled.
+//
+// Exactly one [EnvelopeEvent] is reported to the Observer, on every path
+// including failures. It carries no namespace: the KEK is selected by ID from
+// the material, so Open never learns one.
 func (v *Vault) Open(ctx context.Context, msg *Message) ([]byte, error) {
-	if msg == nil || msg.KeyMaterial == nil {
-		return nil, errors.New("message and key material must not be nil")
-	}
+	start := time.Now()
+	pt, step, err := v.open(ctx, msg)
 
-	var dek *DEK
-	if v.cache != nil {
-		if cached, ok := v.cache.Get(msg.KeyMaterial.EncryptedDEK); ok {
-			dek = cached
-			v.observer.CacheHit(CacheEvent{Size: v.cache.Len()})
-		} else {
-			v.observer.CacheMiss(CacheEvent{Size: v.cache.Len()})
-		}
-	}
+	v.observer.Observe(EnvelopeEvent{
+		Op:        OpDecrypt,
+		Err:       err,
+		CryptoErr: step.err,
+		Total:     time.Since(start),
+		Crypto:    step.dur,
+	})
 
-	if dek == nil {
-		var err error
-		dek, err = v.registry.Decrypt(ctx, msg.KeyMaterial)
-		if err != nil {
-			return nil, err
-		}
-
-		if v.cache != nil {
-			v.cache.Add(msg.KeyMaterial.EncryptedDEK, dek)
-		}
-	}
-
-	return dek.Decrypt(ctx, msg.Ciphertext)
+	return pt, err
 }
 
 // Refresh rotates every namespace DEK that has reached its renewal threshold.
 // It is meant to be called periodically. Seal also rotates an expired DEK on
 // demand, so Refresh is an optimization that keeps rotation off the request
 // path rather than a correctness requirement.
+//
+// One [RotationEvent] with [RotationScheduled] is reported per key rotated.
 func (v *Vault) Refresh() error {
 	// Find expired keys without acquiring a write lock.
 	v.mu.RLock()
@@ -321,15 +283,33 @@ func (v *Vault) Refresh() error {
 		updates[k] = dek
 	}
 
-	v.mu.Lock()
-	defer v.mu.Unlock()
-	for k, d := range updates {
-		// Re-check: a concurrent Seal (or Refresh) may have rotated this key
-		// between the scan above and this write lock. Rotating again would
-		// discard that fresh DEK and force an extra KEK wrap on the next Seal.
-		if v.keys[k].isExpired(v.nowFn) {
-			v.keys[k].rotate(d, v.nowFn)
+	// Collect what actually rotated under the lock and report it after the
+	// closure returns and its deferred unlock has run: an Observer must never
+	// run while v.mu is held, or a slow one stalls every Seal and one that
+	// calls back into the Vault deadlocks. The locked region is a closure
+	// rather than inline code so a panic partway through still unlocks; an
+	// explicit Unlock placed after the loop would skip that on a panic and
+	// leave v.mu write-locked forever.
+	rotated := func() []string {
+		v.mu.Lock()
+		defer v.mu.Unlock()
+
+		rotated := make([]string, 0, len(updates))
+		for k, d := range updates {
+			// Re-check: a concurrent Seal (or Refresh) may have rotated this key
+			// between the scan above and this write lock. Rotating again would
+			// discard that fresh DEK and force an extra KEK wrap on the next Seal.
+			if v.keys[k].isExpired(v.nowFn) {
+				v.keys[k].rotate(d, v.nowFn)
+				rotated = append(rotated, k)
+			}
 		}
+
+		return rotated
+	}()
+
+	for _, ns := range rotated {
+		v.observer.Observe(RotationEvent{Namespace: ns, Reason: RotationScheduled})
 	}
 
 	return nil
@@ -343,13 +323,129 @@ func (v *Vault) ForNamespace(ns string) *NamespacedVault {
 	}
 }
 
+// seal is Seal's body. The middle return value describes what the AES-256-GCM
+// step cost and whether it failed, or is the zero value if it was never
+// reached.
+func (v *Vault) seal(ctx context.Context, ns string, data []byte) (*Message, cryptoStep, error) {
+	sd, err := v.getOrRefreshKey(ns)
+	if err != nil {
+		return nil, cryptoStep{}, err
+	}
+
+	// Snapshot key and material under RLock; release immediately so the
+	// encryption work happens outside the lock.
+	v.mu.RLock()
+	dek := sd.key
+	material := sd.material
+	v.mu.RUnlock()
+
+	cryptoStart := time.Now()
+	ct, err := dek.Encrypt(ctx, data)
+	step := cryptoStep{dur: time.Since(cryptoStart), err: err}
+	if err != nil {
+		return nil, step, err
+	}
+
+	if material != nil {
+		return &Message{Ciphertext: ct, KeyMaterial: material}, step, nil
+	}
+
+	// First Seal after a rotation: coalesce concurrent callers for the same namespace
+	// into a single KMS call so bursts don't trigger rate limiting in the Cloud provider.
+	//
+	// Key on both the namespace and the DEK pointer. If the KMS call is slow and
+	// Refresh rotates the DEK while it is in-flight, a goroutine that snapshotted
+	// the new DEK must not join the old call as it would receive material for DEK1
+	// while its ciphertext was encrypted with DEK2, causing Open to fail. Callers
+	// holding the same DEK pointer still coalesce as intended.
+	sfKey := fmt.Sprintf("%s:%p", ns, dek)
+	res, err, _ := v.encryptor.Do(sfKey, func() (any, error) {
+		return v.registry.Encrypt(ctx, ns, dek)
+	})
+	if err != nil {
+		return nil, step, err
+	}
+	m := res.(*DEKMaterial)
+
+	// Store under write lock.
+	// Only touch sd.material when sd.key == dek: if the key was rotated between
+	// our snapshot and now we must not read or write material that belongs to a
+	// different DEK. The envelope we built (ct + m) is still correct for this call.
+	// When sd.key == dek, prefer an already-stored value so all concurrent callers
+	// for the same DEK return identical material.
+	v.mu.Lock()
+	if sd.key == dek {
+		if sd.material == nil {
+			sd.material = m
+		} else {
+			m = sd.material
+		}
+	}
+	v.mu.Unlock()
+
+	return &Message{Ciphertext: ct, KeyMaterial: m}, step, nil
+}
+
+// open is Open's body. The middle return value describes what the AES-256-GCM
+// step cost and whether it failed, or is the zero value if it was never
+// reached.
+func (v *Vault) open(ctx context.Context, msg *Message) ([]byte, cryptoStep, error) {
+	if msg == nil || msg.KeyMaterial == nil {
+		return nil, cryptoStep{}, errors.New("message and key material must not be nil")
+	}
+
+	var dek *DEK
+	if v.cache != nil {
+		if cached, ok := v.cache.Get(msg.KeyMaterial.EncryptedDEK); ok {
+			dek = cached
+			v.observer.Observe(CacheEvent{Hit: true, Size: v.cache.Len()})
+		} else {
+			v.observer.Observe(CacheEvent{Hit: false, Size: v.cache.Len()})
+		}
+	}
+
+	if dek == nil {
+		var err error
+		dek, err = v.registry.Decrypt(ctx, msg.KeyMaterial)
+		if err != nil {
+			return nil, cryptoStep{}, err
+		}
+
+		if v.cache != nil {
+			v.cache.Add(msg.KeyMaterial.EncryptedDEK, dek)
+		}
+	}
+
+	cryptoStart := time.Now()
+	pt, err := dek.Decrypt(ctx, msg.Ciphertext)
+
+	return pt, cryptoStep{dur: time.Since(cryptoStart), err: err}, err
+}
+
+// getOrRefreshKey returns the sliding DEK for ns, creating or rotating it on
+// demand, and reports any rotation to the Observer. The report happens here
+// rather than inside lookupKey so that it lands after lookupKey's deferred
+// unlock: an Observer must never run while v.mu is held.
 func (v *Vault) getOrRefreshKey(ns string) (*slidingDEK, error) {
+	sd, rotated, err := v.lookupKey(ns)
+	if rotated != nil {
+		v.observer.Observe(*rotated)
+	}
+
+	return sd, err
+}
+
+// lookupKey is getOrRefreshKey's body. The middle return value describes a
+// rotation it performed, or nil if the key it returns was already current. Any
+// event it produces, including one bubbled up from createDefaultKey, is reported
+// by its caller.
+func (v *Vault) lookupKey(ns string) (*slidingDEK, *RotationEvent, error) {
 	v.mu.RLock()
 	key := v.keys[ns]
 	if key == nil {
 		v.mu.RUnlock()
 		if v.defaultConfig == nil {
-			return nil, fmt.Errorf("key not found, ns: %s", ns)
+			return nil, nil, fmt.Errorf("key not found, ns: %s", ns)
 		}
 
 		return v.createDefaultKey(ns)
@@ -357,7 +453,7 @@ func (v *Vault) getOrRefreshKey(ns string) (*slidingDEK, error) {
 
 	if !key.isExpired(v.nowFn) {
 		v.mu.RUnlock()
-		return key, nil
+		return key, nil, nil
 	}
 	v.mu.RUnlock()
 
@@ -365,32 +461,35 @@ func (v *Vault) getOrRefreshKey(ns string) (*slidingDEK, error) {
 	v.mu.Lock()
 	defer v.mu.Unlock()
 
-	// Re-check: Refresh (or another Seal) may have already rotated this key.
+	// Re-check: Refresh (or another Seal) may have already rotated this key. It
+	// reports nothing, so a contended rotation yields exactly one event.
 	if !key.isExpired(v.nowFn) {
-		return key, nil
+		return key, nil, nil
 	}
 
 	k, err := NewDEK()
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate DEK for %s: %w", ns, err)
+		return nil, nil, fmt.Errorf("failed to generate DEK for %s: %w", ns, err)
 	}
 
 	key.rotate(k, v.nowFn)
-	return key, nil
+
+	return key, &RotationEvent{Namespace: ns, Reason: RotationOnDemand}, nil
 }
 
-func (v *Vault) createDefaultKey(ns string) (*slidingDEK, error) {
+func (v *Vault) createDefaultKey(ns string) (*slidingDEK, *RotationEvent, error) {
 	v.mu.Lock()
 	defer v.mu.Unlock()
 
-	// Re-check: another goroutine may have created this slot while we waited for the lock.
+	// Re-check: another goroutine may have created this slot while we waited for
+	// the lock. It reports nothing, so a namespace is only ever announced once.
 	if key := v.keys[ns]; key != nil {
-		return key, nil
+		return key, nil, nil
 	}
 
 	dek, err := NewDEK()
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate DEK for %s: %w", ns, err)
+		return nil, nil, fmt.Errorf("failed to generate DEK for %s: %w", ns, err)
 	}
 
 	sd := &slidingDEK{
@@ -401,7 +500,7 @@ func (v *Vault) createDefaultKey(ns string) (*slidingDEK, error) {
 	sd.rotate(dek, v.nowFn)
 	v.keys[ns] = sd
 
-	return sd, nil
+	return sd, &RotationEvent{Namespace: ns, Reason: RotationInitial}, nil
 }
 
 // Seal encrypts data within the bound namespace. See [Vault.Seal].


### PR DESCRIPTION
crypto.Observer reported only DEK cache hits and misses, so two things a Vault knows about its own work went unrecorded. Nothing said that a namespace's DEK had been replaced, let alone whether Refresh rotated it off the request path or a Seal found it already expired, and the latter means Refresh has fallen behind. Separately, the only timing available folded the KEK round trip into the same number as the symmetric encryption, so slow encryption could not be attributed to KMS rather than to payload size.

Observer is now a single Observe(Event) over a sealed event set: CacheEvent, EnvelopeEvent, and RotationEvent.

EnvelopeEvent carries both durations. Total covers the whole Seal or Open, including any KEK wrap and any cache-miss unwrap, while Crypto covers the AES step alone, so Total minus Crypto is the KMS overhead. It also separates Err, the whole operation's error, from CryptoErr, the AES step's own. That distinction is meaningful since DEK.Encrypt can only fail on rand.Read, so a Seal reporting an error with a nonzero Crypto has almost always failed its KEK wrap, and keying a DEK result label off Err would blame the DEK for a KMS outage that kek_ops_total already reports correctly.