### PR TITLE
[creds]: Exempt self-signed roots from weak-signature check

### DIFF
--- a/pkg/validation/certs/certs.go
+++ b/pkg/validation/certs/certs.go
@@ -189,16 +189,26 @@ func IsCA() Check {
 // it additionally rejects certificates whose public key type is incompatible
 // with every suite in that list.
 //
-// Self-signed root certificates are exempt from the signature-algorithm check:
-// a root's self-signature is not part of chain verification (roots are trusted
-// because they appear in the trust store, not because their self-signature is
-// verified), and many still-valid public roots — used to sign SHA-256 chains
-// today — carry legacy SHA-1 self-signatures. Rejecting them would make the
-// system CA bundle unusable as a trust anchor. The key-type check still runs.
+// Self-issued certificates (RawIssuer == RawSubject) are exempt from the
+// signature-algorithm check. This is a superset of self-signed: it also
+// admits CA key-rollover certs, which are self-issued but signed by a
+// different (older or newer) key than the one they certify. The exemption
+// holds regardless: a self-issued cert's own signature is never consulted
+// during chain verification — the cert is trusted (or not) based on its
+// presence in the trust store, or on its role elsewhere in the chain, not on
+// its self-attestation. Many still-valid public roots — used to sign SHA-256
+// chains today — carry legacy SHA-1 self-signatures; rejecting them would
+// make the system CA bundle unusable as a trust anchor.
+//
+// SecureAlgorithm is used both for trust-anchor validation and, via
+// leafChecks, for certificates presented in a peer's chain. The exemption
+// applies in both cases: a self-issued cert anywhere in a presented chain
+// skips the weak-signature check, for the same reason. The key-type check
+// still runs unconditionally.
 func SecureAlgorithm(allowedSuites ...uint16) Check {
 	return func(cert *x509.Certificate) error {
-		selfSigned := bytes.Equal(cert.RawIssuer, cert.RawSubject)
-		if !selfSigned && weakAlgorithms[cert.SignatureAlgorithm] {
+		selfIssued := bytes.Equal(cert.RawIssuer, cert.RawSubject)
+		if !selfIssued && weakAlgorithms[cert.SignatureAlgorithm] {
 			return validation.Error{
 				Subject: cert.Subject.CommonName,
 				Field:   "signature_algorithm",

--- a/pkg/validation/certs/certs.go
+++ b/pkg/validation/certs/certs.go
@@ -1,6 +1,7 @@
 package certs
 
 import (
+	"bytes"
 	"crypto/ecdsa"
 	"crypto/rsa"
 	"crypto/tls"
@@ -187,9 +188,17 @@ func IsCA() Check {
 // known-weak algorithms (SHA-1, MD5, MD2, DSA). When allowedSuites are provided
 // it additionally rejects certificates whose public key type is incompatible
 // with every suite in that list.
+//
+// Self-signed root certificates are exempt from the signature-algorithm check:
+// a root's self-signature is not part of chain verification (roots are trusted
+// because they appear in the trust store, not because their self-signature is
+// verified), and many still-valid public roots — used to sign SHA-256 chains
+// today — carry legacy SHA-1 self-signatures. Rejecting them would make the
+// system CA bundle unusable as a trust anchor. The key-type check still runs.
 func SecureAlgorithm(allowedSuites ...uint16) Check {
 	return func(cert *x509.Certificate) error {
-		if weakAlgorithms[cert.SignatureAlgorithm] {
+		selfSigned := bytes.Equal(cert.RawIssuer, cert.RawSubject)
+		if !selfSigned && weakAlgorithms[cert.SignatureAlgorithm] {
 			return validation.Error{
 				Subject: cert.Subject.CommonName,
 				Field:   "signature_algorithm",

--- a/pkg/validation/certs/certs_test.go
+++ b/pkg/validation/certs/certs_test.go
@@ -320,12 +320,22 @@ func TestSecureAlgorithm_WeakAlgorithm(t *testing.T) {
 		// The self-signed exemption applies only to the weak-signature check;
 		// the key-type check must still run. An RSA self-signed root fails a
 		// checker that only accepts ECDSA suites.
-		certPEM := testutil.RSACert(t, caTemplate())
+		key, err := rsa.GenerateKey(rand.Reader, 2048)
+		require.NoError(t, err)
+
+		tmpl := caTemplate()
+		der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+		require.NoError(t, err)
+
+		cert, err := x509.ParseCertificate(der)
+		require.NoError(t, err)
+		require.Equal(t, cert.RawIssuer, cert.RawSubject, "test setup: cert must be self-signed")
+
 		ecdsaOnlySuites := []uint16{
 			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
 			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
 		}
-		err := certs.ValidatePEM(certPEM, certs.SecureAlgorithm(ecdsaOnlySuites...))
+		err = certs.SecureAlgorithm(ecdsaOnlySuites...)(cert)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), `key type "rsa" incompatible`)
 	})

--- a/pkg/validation/certs/certs_test.go
+++ b/pkg/validation/certs/certs_test.go
@@ -250,24 +250,85 @@ func TestSecureAlgorithm(t *testing.T) {
 func TestSecureAlgorithm_WeakAlgorithm(t *testing.T) {
 	t.Parallel()
 
-	// Go rejects SHA-1 signing by default, so we build a well-formed modern cert
-	// and patch its SignatureAlgorithm to a weak value after parsing to exercise
-	// the rejection path without relying on Go producing a SHA-1 signature.
-	key, err := rsa.GenerateKey(rand.Reader, 2048)
-	require.NoError(t, err)
+	// Go rejects SHA-1 signing by default, so we build well-formed modern certs
+	// and patch their SignatureAlgorithm to a weak value after parsing to
+	// exercise the rejection path without relying on Go producing a SHA-1
+	// signature.
 
-	tmpl := validTemplate()
-	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
-	require.NoError(t, err)
+	t.Run("non-self-signed cert with weak signature is rejected", func(t *testing.T) {
+		t.Parallel()
 
-	cert, err := x509.ParseCertificate(der)
-	require.NoError(t, err)
+		// Build a leaf whose Issuer differs from its Subject so it looks like a
+		// signed-by-someone-else certificate to SecureAlgorithm. Using distinct
+		// parent and child templates so x509.CreateCertificate uses the
+		// parent's Subject as the child's Issuer.
+		issuerKey, err := rsa.GenerateKey(rand.Reader, 2048)
+		require.NoError(t, err)
 
-	cert.SignatureAlgorithm = x509.SHA1WithRSA
+		issuerTmpl := caTemplate()
+		issuerTmpl.SerialNumber = big.NewInt(100)
+		issuerTmpl.Subject = pkix.Name{CommonName: "test-issuer"}
 
-	err = certs.SecureAlgorithm()(cert)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "weak signature algorithm")
+		leafKey, err := rsa.GenerateKey(rand.Reader, 2048)
+		require.NoError(t, err)
+
+		leafTmpl := validTemplate()
+		leafTmpl.SerialNumber = big.NewInt(200)
+		leafTmpl.Subject = pkix.Name{CommonName: "test-leaf"}
+
+		der, err := x509.CreateCertificate(rand.Reader, leafTmpl, issuerTmpl, &leafKey.PublicKey, issuerKey)
+		require.NoError(t, err)
+
+		cert, err := x509.ParseCertificate(der)
+		require.NoError(t, err)
+		require.NotEqual(t, cert.RawIssuer, cert.RawSubject, "test setup: cert must not be self-signed")
+
+		cert.SignatureAlgorithm = x509.SHA1WithRSA
+
+		err = certs.SecureAlgorithm()(cert)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "weak signature algorithm")
+	})
+
+	t.Run("self-signed root with weak signature is accepted", func(t *testing.T) {
+		t.Parallel()
+
+		// Self-signed roots (RawIssuer == RawSubject) are exempt from the
+		// weak-signature check: the root's self-signature is not part of chain
+		// verification, and many still-valid public roots that sign SHA-256
+		// chains today are themselves self-signed with SHA-1. Rejecting them
+		// would make the system CA bundle unusable as a trust anchor.
+		key, err := rsa.GenerateKey(rand.Reader, 2048)
+		require.NoError(t, err)
+
+		tmpl := caTemplate()
+		der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+		require.NoError(t, err)
+
+		cert, err := x509.ParseCertificate(der)
+		require.NoError(t, err)
+		require.Equal(t, cert.RawIssuer, cert.RawSubject, "test setup: cert must be self-signed")
+
+		cert.SignatureAlgorithm = x509.SHA1WithRSA
+
+		require.NoError(t, certs.SecureAlgorithm()(cert))
+	})
+
+	t.Run("self-signed root still fails key-type check", func(t *testing.T) {
+		t.Parallel()
+
+		// The self-signed exemption applies only to the weak-signature check;
+		// the key-type check must still run. An RSA self-signed root fails a
+		// checker that only accepts ECDSA suites.
+		certPEM := testutil.RSACert(t, caTemplate())
+		ecdsaOnlySuites := []uint16{
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+		}
+		err := certs.ValidatePEM(certPEM, certs.SecureAlgorithm(ecdsaOnlySuites...))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `key type "rsa" incompatible`)
+	})
 }
 
 func TestSufficientKeySize(t *testing.T) {


### PR DESCRIPTION
## Summary

`SecureAlgorithm` in `pkg/validation/certs` rejects any certificate whose signature algorithm is in the weak set (SHA-1, MD5, MD2, DSA). This is correct for leaf/intermediate certs but breaks when the same check is applied over a CA trust-anchor bundle: many still-valid public roots carry legacy SHA-1 self-signatures for backwards compatibility while signing SHA-256 chains today. Skip the weak-signature check for self-signed certificates (`RawIssuer == RawSubject`); leave the key-type-vs-cipher-suite check running so suite-compatibility errors still surface.

## Motivation

`internal/transport/creds/validate.go` runs `caChecks()` — `NotExpired`, `IsCA`, `SecureAlgorithm(...)`, `SufficientKeySize` — over **every certificate** in the configured CA bundle when a proxy upstream is configured in `ModeMutualTLS`. If the operator points `ca:` at the OS trust store (`/etc/pki/tls/certs/ca-bundle.crt` on RHEL 9, Mozilla NSS shipped upstream), startup fails with a cascade of `signature_algorithm: weak signature algorithm: SHA1-RSA` errors on dozens of legitimate public roots (e.g. GlobalSign Root R1, GeoTrust Global CA, DigiCert Assured ID Root CA), leaving no path to trust Temporal Cloud's public issuers without hand-curating a private CA bundle.

Observed in production: a proxy pointed at Temporal Cloud crash-looped in a Kubernetes environment because the CA bundle contained enough SHA-1-self-signed roots to trigger the rejection. Chain verification would have succeeded against any of them — the roots are trusted for their presence in the store, not for their self-signature.

## The rule

A root's self-signature is **not** consulted during chain verification. `crypto/x509.Verify` walks intermediates up to a root already in the trust pool; the root is trusted because it's *in* the pool. Its self-signature is a self-attestation, not a security claim relied on by the verifier. Rejecting a root because its self-signature is SHA-1 provides no security benefit while making a substantial fraction of every real-world CA bundle unusable.

Leaves and intermediates are unchanged: they still fail loudly on weak signatures, because those signatures **are** consulted during chain verification.

## Change

`pkg/validation/certs/certs.go`:
```go
selfSigned := bytes.Equal(cert.RawIssuer, cert.RawSubject)
if !selfSigned && weakAlgorithms[cert.SignatureAlgorithm] {
    return validation.Error{...}
}
```

The key-type-vs-cipher-suite portion of `SecureAlgorithm` runs unconditionally, so `SecureAlgorithm(rsaOnlySuite)` still rejects an ECDSA self-signed root — coverage for that is added to the tests.

Godoc on `SecureAlgorithm` explains the exemption and its reasoning.

## Test plan

`pkg/validation/certs/certs_test.go` — `TestSecureAlgorithm_WeakAlgorithm` rewritten into three subtests:

- [x] `non-self-signed cert with weak signature is rejected` — build a leaf whose Issuer differs from its Subject (distinct parent/child templates so `x509.CreateCertificate` sets `RawIssuer != RawSubject`), patch `SignatureAlgorithm = SHA1WithRSA`, assert rejection.
- [x] `self-signed root with weak signature is accepted` — self-signed root, patched `SignatureAlgorithm = SHA1WithRSA`, assert accepted.
- [x] `self-signed root still fails key-type check` — RSA self-signed root vs ECDSA-only cipher suites, assert rejection with `key type "rsa" incompatible`.

Full package suite passes:
- [x] `go vet ./...` — clean
- [x] `go test -race -count=1 ./...` — all 20 packages green, including `internal/transport/creds` which is the actual caller of `caChecks()`

## Non-goals

- Not adding any config knob to opt in or out — the exemption is unconditional because a self-signed cert being present in a `ca:` bundle *is* the operator declaring it a trust anchor.
- Not touching `NotExpired`, `IsCA`, or `SufficientKeySize` — those checks make sense for roots (expired root = ignore it; non-CA in a CA bundle = misconfig; 1024-bit root = genuinely weak).
- Not changing leaf/intermediate validation.