### PR TITLE
[proxy]: Fix silent CrashLoop on scratch image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
-FROM alpine:3.23.4 AS base
-RUN adduser -D -u 1000 proxy
+FROM alpine:3.24.1 AS base
+RUN adduser -D -u 1000 proxy && mkdir -p /rootfs/tmp
 
 FROM scratch
 COPY --from=base /etc/passwd /etc/passwd
 COPY --from=base /etc/group /etc/group
+COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=base --chmod=1777 /rootfs/tmp /tmp
 
 # Copy the pre-built binary (goreleaser will provide this).
 ARG TARGETPLATFORM

--- a/cmd/proxy/serve.go
+++ b/cmd/proxy/serve.go
@@ -7,6 +7,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/urfave/cli/v3"
 	"go.uber.org/fx"
+	"go.uber.org/fx/fxevent"
 	"google.golang.org/protobuf/reflect/protoreflect"
 
 	"github.com/temporalio/temporal-proxy/internal/api"
@@ -22,6 +23,15 @@ import (
 	"github.com/temporalio/temporal-proxy/pkg/logger"
 	"github.com/temporalio/temporal-proxy/pkg/logger/tag"
 )
+
+// fxLogger swallows fx's event stream except for Started/Stopped failures,
+// which it forwards to the app logger. Configuration errors are caught
+// separately via app.Err() so they are visible at startup.
+//
+// The net effect is fx.NopLogger plus visible lifecycle hook failures.
+type fxLogger struct {
+	log logger.Logger
+}
 
 func serve() *cli.Command {
 	return &cli.Command{
@@ -83,7 +93,7 @@ func serve() *cli.Command {
 				proxy.Module,
 				router.Module,
 				server.Module,
-				fx.NopLogger,
+				fx.WithLogger(func(l logger.Logger) fxevent.Logger { return &fxLogger{log: l} }),
 			)
 
 			if err := fxApp.Err(); err != nil {
@@ -94,5 +104,18 @@ func serve() *cli.Command {
 			fxApp.Run()
 			return nil
 		},
+	}
+}
+
+func (l *fxLogger) LogEvent(e fxevent.Event) {
+	switch e := e.(type) {
+	case *fxevent.Started:
+		if e.Err != nil {
+			l.log.Error("Failed to start", tag.Error(e.Err))
+		}
+	case *fxevent.Stopped:
+		if e.Err != nil {
+			l.log.Error("Failed to stop cleanly", tag.Error(e.Err))
+		}
 	}
 }


### PR DESCRIPTION
The published image is FROM scratch and ships neither a writable /tmp nor a CA trust store. Every upstream is re-served on a unix socket under os.TempDir() before the gateway starts, so the bind fails immediately, and any TLS upstream fails system-root verification. Both surfaced as a bare exit 1m which is not great.

Replace NopLogger with a custom fxevent.Logger that forwards only Started and Stopped errors to the app logger. That keeps fx's usual per-constructor chatter off, like NopLogger does, while letting a failed lifecycle hooks explain themselves. Also, add writable /tmp and ca-certificates to the image

Verified by building the image at HEAD and at this commit and running both against a config with a single TLS upstream:

```bash
docker run --rm -v $PWD/config.yaml:/etc/proxy/config.yaml:ro \
         tp:before serve -c /etc/proxy/config.yaml --level debug
{"level":"info","component":"metrics","message":"Starting metrics server"}
{"level":"info","component":"metrics","message":"Shutting down metrics server"}

{"level":"error","error":"failed to start proxy for upstream \"cloud\":
  failed to bind to socket: unix:///tmp/...sock, listen unix /tmp/...sock:
    bind: no such file or directory","message":"Failed to start"}

{"level":"info","addr":"/tmp/...sock","message":"Starting the server"}
{"level":"info","addr":"[::]:7233","message":"Starting the server"}
```

The CA half was isolated the same way, giving the old image a --tmpfs /tmp so the trust store was the only variable. Without it a static TLS upstream fails the eager dial with "upstream connection not ready: not ready (last state: TRANSIENT_FAILURE)"; with it the proxy starts and serves.

Fixes #113