### PR TITLE
[router]: Route only allowlisted services

### DIFF
--- a/e2e/harness_test.go
+++ b/e2e/harness_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/temporalio/temporal-proxy/internal/proxy"
 	"github.com/temporalio/temporal-proxy/internal/router"
 	"github.com/temporalio/temporal-proxy/internal/server"
+	"github.com/temporalio/temporal-proxy/internal/services"
 	"github.com/temporalio/temporal-proxy/internal/transport/connect"
 	"github.com/temporalio/temporal-proxy/internal/transport/socket"
 	"github.com/temporalio/temporal-proxy/pkg/crypto"
@@ -89,6 +90,14 @@ func newFullApp(t *testing.T, cfg *config.Config) *fx.App {
 	t.Helper()
 
 	reg := prometheus.NewRegistry()
+
+	// Load applies this default when parsing YAML, which these tests skip in
+	// favour of building a Config directly. Admit everything forwardable so
+	// admission never stands in for the behaviour under test; it has its own
+	// coverage in internal/services and internal/router.
+	if len(cfg.AllowedServices) == 0 {
+		cfg.AllowedServices = config.Services(services.Known())
+	}
 
 	return fx.New(
 		fx.Supply(fx.Annotate(t.Context(), fx.As(new(context.Context)))),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/goccy/go-yaml"
 
+	"github.com/temporalio/temporal-proxy/internal/services"
 	"github.com/temporalio/temporal-proxy/pkg/validation"
 )
 
@@ -16,6 +17,7 @@ type (
 	// Config is the top-level proxy configuration.
 	Config struct {
 		Listen           ListenConfig        `yaml:",inline"`
+		AllowedServices  Services            `yaml:"allowedServices"`
 		Encryption       Encryption          `yaml:"encryption"`
 		ExtensionServers ExtensionServerList `yaml:"extensionServers"`
 		Routing          Routing             `yaml:"routing"`
@@ -25,7 +27,8 @@ type (
 )
 
 // Load reads and parses the YAML config specified in the Reader.
-// Values of the form ${VAR} are replaced with the corresponding environment variable.
+// Values of the form ${VAR} are replaced with the corresponding environment
+// variable. A config that names no allowed services gets the default set.
 func Load(r io.Reader) (*Config, error) {
 	data, err := io.ReadAll(r)
 	if err != nil {
@@ -37,6 +40,13 @@ func Load(r io.Reader) (*Config, error) {
 	var cfg Config
 	if err := yaml.UnmarshalWithOptions([]byte(expanded), &cfg, yaml.CustomUnmarshaler(unmarshalURL)); err != nil {
 		return nil, err
+	}
+
+	// The allowlist defaults here rather than in a Services unmarshaler because
+	// an absent key never reaches one, and an absent allowedServices is how most
+	// configs are written.
+	if len(cfg.AllowedServices) == 0 {
+		cfg.AllowedServices = services.Default()
 	}
 
 	return &cfg, nil
@@ -74,6 +84,7 @@ func (c *Config) Validate() error {
 			return nil
 		}),
 		validation.Nested("", &c.Listen),
+		validation.Nested("", &c.AllowedServices),
 		validation.Nested("encryption", &c.Encryption),
 		validation.Nested("extensionServers", &c.ExtensionServers),
 		validation.Nested("routing", &c.Routing),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/temporalio/temporal-proxy/internal/config"
+	"github.com/temporalio/temporal-proxy/internal/services"
 	"github.com/temporalio/temporal-proxy/pkg/validation"
 )
 
@@ -29,7 +30,10 @@ func TestLoad(t *testing.T) {
 		{
 			name: "valid config",
 			yaml: "hostPort: :8080\n",
-			want: &config.Config{Listen: config.ListenConfig{HostPort: ":8080"}},
+			want: &config.Config{
+				Listen:          config.ListenConfig{HostPort: ":8080"},
+				AllowedServices: config.Services(services.Default()),
+			},
 		},
 		{
 			name:    "invalid YAML",
@@ -39,7 +43,7 @@ func TestLoad(t *testing.T) {
 		{
 			name: "empty hostPort",
 			yaml: "hostPort: \"\"\n",
-			want: &config.Config{},
+			want: &config.Config{AllowedServices: config.Services(services.Default())},
 		},
 	}
 
@@ -136,7 +140,10 @@ func TestLoadFile(t *testing.T) {
 		{
 			name:    "valid file",
 			content: "hostPort: :7233\n",
-			want:    &config.Config{Listen: config.ListenConfig{HostPort: ":7233"}},
+			want: &config.Config{
+				Listen:          config.ListenConfig{HostPort: ":7233"},
+				AllowedServices: config.Services(services.Default()),
+			},
 		},
 		{
 			name:    "invalid YAML in file",

--- a/internal/config/fx_test.go
+++ b/internal/config/fx_test.go
@@ -9,6 +9,7 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/temporalio/temporal-proxy/internal/config"
+	"github.com/temporalio/temporal-proxy/internal/services"
 )
 
 func TestModule_ProvidesConfig(t *testing.T) {
@@ -26,7 +27,10 @@ func TestModule_ProvidesConfig(t *testing.T) {
 	)
 
 	require.NoError(t, app.Err())
-	require.Equal(t, &config.Config{Listen: config.ListenConfig{HostPort: ":7233"}}, got)
+	require.Equal(t, &config.Config{
+		Listen:          config.ListenConfig{HostPort: ":7233"},
+		AllowedServices: config.Services(services.Default()),
+	}, got)
 }
 
 func TestModule_ErrorPropagates(t *testing.T) {

--- a/internal/config/services.go
+++ b/internal/config/services.go
@@ -1,0 +1,67 @@
+package config
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/temporalio/temporal-proxy/internal/services"
+	"github.com/temporalio/temporal-proxy/pkg/validation"
+)
+
+// Services is the set of gRPC services the proxy is allowed to forward, each
+// named by its proto full name (e.g.
+// "temporal.api.workflowservice.v1.WorkflowService").
+type Services []string
+
+// Validate rejects duplicate entries and any name the proxy cannot forward. An
+// empty list is valid. Failures carry the "allowedServices" field and no
+// subject, so Config nests this under an empty subject rather than restating
+// the name.
+func (s *Services) Validate() error {
+	return validation.Validate(
+		"",
+		validation.Field[[]string](
+			"allowedServices",
+			*s,
+			validation.Unique[string](),
+			resolvableServices(),
+		),
+	)
+}
+
+// resolvableServices accepts only names the proxy can actually forward, which
+// is stricter than "registered": services.All is the forwardable set plus its
+// compatibility aliases, while the proto registry knows every descriptor linked
+// into the binary, including ones that arrive transitively through a dependency.
+func resolvableServices() validation.Check[[]string] {
+	return func(names []string) error {
+		forwardable := services.All()
+
+		// Membership is checked against All so a compatibility alias is
+		// accepted, but the hint lists Known: it should steer operators to the
+		// canonical spelling rather than advertise the superseded one. The
+		// wording therefore suggests rather than claims to be exhaustive.
+		hint := strings.Join(services.Known(), ", ")
+
+		var errs validation.Errors
+		for _, name := range names {
+			if slices.Contains(forwardable, name) {
+				continue
+			}
+
+			msg := fmt.Sprintf("%q is registered but not forwardable (choose from: %s)", name, hint)
+			if _, err := services.Resolve(name); err != nil {
+				msg = fmt.Sprintf("%s (choose from: %s)", err, hint)
+			}
+
+			errs = append(errs, validation.Error{Message: msg})
+		}
+
+		if len(errs) == 0 {
+			return nil
+		}
+
+		return errs
+	}
+}

--- a/internal/config/services_test.go
+++ b/internal/config/services_test.go
@@ -1,0 +1,217 @@
+package config_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	// Blank import guarantees a registered service that the proxy does not
+	// forward, so the "registered but not forwardable" branch is exercised
+	// against a real descriptor rather than one that happens to arrive through
+	// a transitive dependency.
+	_ "google.golang.org/grpc/health/grpc_health_v1"
+
+	"github.com/temporalio/temporal-proxy/internal/config"
+	"github.com/temporalio/temporal-proxy/internal/services"
+)
+
+func TestServices_Validate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		svcs       config.Services
+		wantTuples [][2]string
+		wantMsgs   []string
+	}{
+		{
+			name: "nil list yields no error",
+			svcs: nil,
+		},
+		{
+			name: "empty list yields no error",
+			svcs: config.Services{},
+		},
+		{
+			name: "the default set is forwardable",
+			svcs: config.Services(services.Default()),
+		},
+		{
+			name: "every known service is forwardable",
+			svcs: config.Services(services.Known()),
+		},
+		{
+			name: "the reflection alias is forwardable on its own",
+			svcs: config.Services{services.ReflectionV1Alpha},
+		},
+		{
+			name:       "a duplicate entry is rejected",
+			svcs:       config.Services{services.WorkflowService, services.WorkflowService},
+			wantTuples: [][2]string{{"", "allowedServices"}},
+			wantMsgs:   []string{"contains duplicate value"},
+		},
+		{
+			name:       "an unregistered name is rejected as a typo",
+			svcs:       config.Services{"temporal.api.workflowservice.v1.WorkflowServ"},
+			wantTuples: [][2]string{{"", "allowedServices"}},
+			wantMsgs:   []string{`"temporal.api.workflowservice.v1.WorkflowServ" is not registered`},
+		},
+		{
+			name:       "a registered name that is not a service is rejected",
+			svcs:       config.Services{"temporal.api.workflowservice.v1.StartWorkflowExecutionRequest"},
+			wantTuples: [][2]string{{"", "allowedServices"}},
+			wantMsgs:   []string{"is not a service"},
+		},
+		{
+			name:       "a registered service the proxy does not forward is rejected",
+			svcs:       config.Services{"grpc.health.v1.Health"},
+			wantTuples: [][2]string{{"", "allowedServices"}},
+			wantMsgs:   []string{`"grpc.health.v1.Health" is registered but not forwardable`},
+		},
+		{
+			name: "every bad name is reported in one pass",
+			svcs: config.Services{"not.A.Thing", "grpc.health.v1.Health", services.WorkflowService},
+			wantTuples: [][2]string{
+				{"", "allowedServices"},
+				{"", "allowedServices"},
+			},
+			wantMsgs: []string{"not.A.Thing", "grpc.health.v1.Health"},
+		},
+		{
+			// Uniqueness stops at the first duplicate, but resolution does not
+			// short-circuit, so a name that is both duplicated and unknown is
+			// reported once for the duplication and once per occurrence.
+			name: "a duplicate and an unknown name aggregate",
+			svcs: config.Services{"not.A.Thing", "not.A.Thing"},
+			wantTuples: [][2]string{
+				{"", "allowedServices"},
+				{"", "allowedServices"},
+				{"", "allowedServices"},
+			},
+			wantMsgs: []string{"contains duplicate value", "is not registered"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tt.svcs.Validate()
+			assertTuples(t, err, tt.wantTuples)
+
+			for _, msg := range tt.wantMsgs {
+				require.ErrorContains(t, err, msg)
+			}
+		})
+	}
+}
+
+func TestLoad_AllowedServicesDefaults(t *testing.T) {
+	t.Parallel()
+
+	// Every spelling of "I did not choose" resolves to the default set. The
+	// absent-key case is the one that matters most: it is how nearly every
+	// config is written, and it is the case a Services unmarshaler could not
+	// have covered, since the decoder never calls one for a key that is not
+	// there.
+	tests := []struct {
+		name string
+		yaml string
+		want config.Services
+	}{
+		{
+			name: "absent key gets the default set",
+			yaml: `hostPort: ":8080"`,
+			want: config.Services(services.Default()),
+		},
+		{
+			name: "explicit null gets the default set",
+			yaml: "hostPort: \":8080\"\nallowedServices:",
+			want: config.Services(services.Default()),
+		},
+		{
+			name: "explicit empty list gets the default set",
+			yaml: "hostPort: \":8080\"\nallowedServices: []",
+			want: config.Services(services.Default()),
+		},
+		{
+			name: "an explicit list is left alone",
+			yaml: "hostPort: \":8080\"\nallowedServices:\n  - " + services.Reflection,
+			want: config.Services{services.Reflection},
+		},
+		{
+			name: "an explicit list is not merged with the default set",
+			yaml: "hostPort: \":8080\"\nallowedServices:\n  - " + services.WorkflowService,
+			want: config.Services{services.WorkflowService},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg, err := config.Load(strings.NewReader(tt.yaml))
+			require.NoError(t, err)
+			require.Equal(t, tt.want, cfg.AllowedServices)
+		})
+	}
+}
+
+func TestConfig_Validate_AllowedServices(t *testing.T) {
+	t.Parallel()
+
+	base := func(svcs config.Services) *config.Config {
+		return &config.Config{
+			Listen:          config.ListenConfig{HostPort: ":8080"},
+			AllowedServices: svcs,
+			Upstreams: config.UpstreamList{
+				{Name: "primary", Listen: config.ListenConfig{HostPort: "127.0.0.1:7233"}},
+			},
+		}
+	}
+
+	tests := []struct {
+		name       string
+		svcs       config.Services
+		wantTuples [][2]string
+	}{
+		{
+			name: "an unset allowlist is optional",
+			svcs: nil,
+		},
+		{
+			name: "the default set yields no error",
+			svcs: config.Services(services.Default()),
+		},
+		{
+			// Services owns the field name, so Config nests it with an empty
+			// subject and the path reads "allowedServices" rather than
+			// repeating itself.
+			name:       "a bad name surfaces on the bare allowedServices field",
+			svcs:       config.Services{"not.A.Thing"},
+			wantTuples: [][2]string{{"", "allowedServices"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assertTuples(t, base(tt.svcs).Validate(), tt.wantTuples)
+		})
+	}
+}
+
+func TestServices_ValidateNamesTheForwardableSet(t *testing.T) {
+	t.Parallel()
+
+	// The fix for a bad name is only obvious if the error says what the legal
+	// names are, so every failure carries the forwardable set.
+	svcs := config.Services{"not.A.Thing"}
+
+	err := svcs.Validate()
+	require.Error(t, err)
+	for _, name := range services.Known() {
+		require.ErrorContains(t, err, name)
+	}
+}

--- a/internal/protoutil/rpc.go
+++ b/internal/protoutil/rpc.go
@@ -1,0 +1,17 @@
+package protoutil
+
+import "strings"
+
+// ServiceName returns the service portion of a gRPC full method
+// ("/pkg.Service/Method"), with or without the leading slash gRPC supplies. It
+// returns "" when fullMethod carries no method to strip, which callers must
+// treat as "no service" rather than as a name to match on.
+func ServiceName(fullMethod string) string {
+	trimmed := strings.TrimPrefix(fullMethod, "/")
+	slash := strings.LastIndex(trimmed, "/")
+	if slash < 0 {
+		return ""
+	}
+
+	return trimmed[:slash]
+}

--- a/internal/protoutil/rpc_test.go
+++ b/internal/protoutil/rpc_test.go
@@ -1,0 +1,71 @@
+package protoutil_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/temporalio/temporal-proxy/internal/protoutil"
+)
+
+func TestServiceName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "full method as gRPC supplies it",
+			in:   "/temporal.api.workflowservice.v1.WorkflowService/StartWorkflowExecution",
+			want: "temporal.api.workflowservice.v1.WorkflowService",
+		},
+		{
+			name: "full method without a leading slash",
+			in:   "temporal.api.workflowservice.v1.WorkflowService/StartWorkflowExecution",
+			want: "temporal.api.workflowservice.v1.WorkflowService",
+		},
+		{
+			name: "a bare service name has no method to strip",
+			in:   "temporal.api.workflowservice.v1.WorkflowService",
+			want: "",
+		},
+		{
+			name: "an empty method still yields the service",
+			in:   "/temporal.api.workflowservice.v1.WorkflowService/",
+			want: "temporal.api.workflowservice.v1.WorkflowService",
+		},
+		{
+			name: "the empty string yields no service",
+			in:   "",
+			want: "",
+		},
+		{
+			name: "a lone slash yields no service",
+			in:   "/",
+			want: "",
+		},
+		{
+			// Only the leading slash is trimmed, so a doubled one leaves an
+			// empty first segment rather than being silently normalised.
+			name: "a doubled leading slash keeps the empty segment",
+			in:   "//pkg.Service/Method",
+			want: "/pkg.Service",
+		},
+		{
+			// The split is on the last slash, so a method name is never
+			// mistaken for part of the service.
+			name: "only the final segment is treated as the method",
+			in:   "/a/b/c",
+			want: "a/b",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, protoutil.ServiceName(tt.in))
+		})
+	}
+}

--- a/internal/router/fx.go
+++ b/internal/router/fx.go
@@ -14,6 +14,7 @@ import (
 	"github.com/temporalio/temporal-proxy/internal/config"
 	"github.com/temporalio/temporal-proxy/internal/metrics"
 	"github.com/temporalio/temporal-proxy/internal/protoutil"
+	"github.com/temporalio/temporal-proxy/internal/services"
 	"github.com/temporalio/temporal-proxy/internal/transport/connect"
 	"github.com/temporalio/temporal-proxy/internal/transport/socket"
 	"github.com/temporalio/temporal-proxy/pkg/match"
@@ -25,9 +26,13 @@ import (
 // handler dials one connection per configured upstream from the shared
 // [connect.Pool] (each unix socket path derived from that upstream's
 // host:port), then routes every request to an upstream by matching it with the
-// Mux.
+// Mux. Requests are admitted through a [Gate] built from the configured
+// allowlist before any of that happens.
 var Module = fx.Options(fx.Provide(
 	Codec,
+	func(c *config.Config) Gate {
+		return services.NewAllowlist(c.AllowedServices)
+	},
 	func(p RouterParams) (grpc.StreamHandler, error) {
 		conns := make(map[string]*grpc.ClientConn, len(p.Config.Upstreams))
 		for i := range p.Config.Upstreams {
@@ -53,6 +58,7 @@ var Module = fx.Options(fx.Provide(
 				reporter: p.Reporter,
 			},
 			p.Extractor,
+			p.Gate,
 			p.Reporter,
 		), nil
 	},
@@ -120,6 +126,7 @@ type (
 
 		Config    *config.Config
 		Extractor *protoutil.Extractor
+		Gate      Gate
 		Mux       *Mux
 		Pool      *connect.Pool
 		Reporter  *Reporter

--- a/internal/router/fx_test.go
+++ b/internal/router/fx_test.go
@@ -37,7 +37,10 @@ func TestModule(t *testing.T) {
 
 		app := fx.New(
 			fx.Supply(&config.Config{
-				Upstreams: []config.Upstream{{Name: "primary", Listen: config.ListenConfig{HostPort: "127.0.0.1:7233"}}},
+				// The module builds its Gate from this, so the stub service these
+				// tests forward has to be on it.
+				AllowedServices: config.Services{"test.v1.Echo"},
+				Upstreams:       []config.Upstream{{Name: "primary", Listen: config.ListenConfig{HostPort: "127.0.0.1:7233"}}},
 			}),
 			fx.Provide(func() *metrics.Factory { return metrics.New("tmprl_proxy", promauto.With(prometheus.NewRegistry())) }),
 			connect.Module,
@@ -104,8 +107,9 @@ func TestModule(t *testing.T) {
 		)
 		app := fx.New(
 			fx.Supply(&config.Config{
-				Routing:   config.Routing{DefaultUpstream: "primary"},
-				Upstreams: []config.Upstream{{Name: "primary", Listen: config.ListenConfig{HostPort: upstream}}},
+				AllowedServices: config.Services{"test.v1.Echo"},
+				Routing:         config.Routing{DefaultUpstream: "primary"},
+				Upstreams:       []config.Upstream{{Name: "primary", Listen: config.ListenConfig{HostPort: upstream}}},
 			}),
 			fx.Provide(func() *metrics.Factory { return metrics.New("tmprl_proxy", promauto.With(prometheus.NewRegistry())) }),
 			connect.Module,

--- a/internal/router/handler.go
+++ b/internal/router/handler.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
+	"github.com/temporalio/temporal-proxy/internal/protoutil"
 	"github.com/temporalio/temporal-proxy/internal/transport/meta"
 )
 
@@ -38,16 +39,26 @@ type (
 	Reflector interface {
 		Namespace(string, []byte) string
 	}
+
+	// Gate reports whether the proxy will forward the named service. Allows
+	// receives a service full name, never a full method; the Module wires a
+	// services.Allowlist built from the configured allowlist.
+	Gate interface {
+		Allows(string) bool
+	}
 )
 
 // Handler returns a grpc.StreamHandler suitable for grpc.UnknownServiceHandler,
 // reporting a stream_setup forwarding error via rep when opening the upstream
-// stream fails. It buffers the first request frame so r can peek the request
+// stream fails. A method whose service g does not allow is rejected with
+// Unimplemented before any upstream work, so the proxy answers as a server that
+// does not implement it rather than revealing that an upstream might.
+// It buffers the first request frame so r can peek the request
 // namespace, asks d for the upstream connection, then transparently forwards
 // the stream to that upstream using the same full method name: it replays the
 // buffered first frame, pumps raw frames in both directions, and propagates
 // header, trailer, and status verbatim.
-func Handler(d Director, r Reflector, rep *Reporter) grpc.StreamHandler {
+func Handler(d Director, r Reflector, g Gate, rep *Reporter) grpc.StreamHandler {
 	return func(_ any, serverStream grpc.ServerStream) error {
 		ctx := serverStream.Context()
 		sts := grpc.ServerTransportStreamFromContext(ctx)
@@ -55,8 +66,12 @@ func Handler(d Director, r Reflector, rep *Reporter) grpc.StreamHandler {
 			return status.Error(codes.Internal, "router: no server transport stream in context")
 		}
 
-		var md map[string][]string
 		method := sts.Method()
+		if svc := protoutil.ServiceName(method); !g.Allows(svc) {
+			return status.Errorf(codes.Unimplemented, "unknown service %q", svc)
+		}
+
+		var md map[string][]string
 		outCtx := ctx
 		if inMD, ok := metadata.FromIncomingContext(ctx); ok {
 			outCtx = metadata.NewOutgoingContext(ctx, inMD.Copy())

--- a/internal/router/handler_test.go
+++ b/internal/router/handler_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/temporalio/temporal-proxy/internal/metrics"
 	"github.com/temporalio/temporal-proxy/internal/router"
 	"github.com/temporalio/temporal-proxy/internal/server"
+	"github.com/temporalio/temporal-proxy/internal/services"
 	"github.com/temporalio/temporal-proxy/internal/transport/meta"
 )
 
@@ -62,6 +63,12 @@ type (
 	}
 
 	stubReflector struct{}
+
+	// stubGate admits everything. The handler tests dial a mix of stub services
+	// and the generated health client, so enumerating them here would silently
+	// deny a test the day someone adds another. Admission has its own test, and
+	// the real gate is covered in the services package.
+	stubGate struct{}
 )
 
 func TestHandlerForwardsUnary(t *testing.T) {
@@ -107,6 +114,44 @@ func TestHandlerPropagatesError(t *testing.T) {
 	)
 	require.Error(t, err)
 	require.Equal(t, codes.NotFound, status.Code(err))
+}
+
+func TestHandlerRejectsDisallowedService(t *testing.T) {
+	t.Parallel()
+
+	// Admission runs before any routing work, so a denied method never reaches
+	// the Director and the client is told the service is not implemented rather
+	// than that it could not be routed.
+	director := &recordingDirector{}
+	m, _ := newTestReporter(t)
+
+	relayLis := bufconn.Listen(1024 * 1024)
+	relay := grpc.NewServer(
+		grpc.ForceServerCodecV2(router.Codec()),
+		grpc.UnknownServiceHandler(router.Handler(
+			director,
+			stubReflector{},
+			services.NewAllowlist([]string{services.WorkflowService}),
+			m,
+		)),
+	)
+	serve(t, relay, relayLis)
+
+	relayConn := dialBufconn(t, relayLis)
+	t.Cleanup(func() { _ = relayConn.Close() })
+
+	err := relayConn.Invoke(
+		t.Context(),
+		"/test.v1.Echo/Ping",
+		&grpc_health_v1.HealthCheckRequest{},
+		new(grpc_health_v1.HealthCheckResponse),
+	)
+	require.Error(t, err)
+	require.Equal(t, codes.Unimplemented, status.Code(err))
+	require.Contains(t, status.Convert(err).Message(), "test.v1.Echo")
+
+	calls, _, _, _ := director.snapshot()
+	require.Zero(t, calls, "a denied method must not reach the Director")
 }
 
 func TestHandlerRoutesUsingReflectorAndDirector(t *testing.T) {
@@ -343,7 +388,7 @@ func TestHandlerCoHostsLocalHealthWithForwarding(t *testing.T) {
 
 	m, _ := newTestReporter(t)
 	svr, err := server.New(
-		server.WithUnknownServiceHandler(router.Handler(stubDirector{cc: upstreamConn}, stubReflector{}, m)),
+		server.WithUnknownServiceHandler(router.Handler(stubDirector{cc: upstreamConn}, stubReflector{}, stubGate{}, m)),
 		server.WithServerCodec(router.Codec()),
 	)
 	require.NoError(t, err)
@@ -397,7 +442,7 @@ func TestHandlerRecordsStreamSetupError(t *testing.T) {
 	relayLis := bufconn.Listen(1024 * 1024)
 	relay := grpc.NewServer(
 		grpc.ForceServerCodecV2(router.Codec()),
-		grpc.UnknownServiceHandler(router.Handler(stubDirector{upstream: "primary", cc: brokenConn}, stubReflector{}, m)),
+		grpc.UnknownServiceHandler(router.Handler(stubDirector{upstream: "primary", cc: brokenConn}, stubReflector{}, stubGate{}, m)),
 	)
 	serve(t, relay, relayLis)
 
@@ -430,7 +475,7 @@ func TestHandlerRelayedUpstreamErrorIsNotAForwardingError(t *testing.T) {
 
 	relay := grpc.NewServer(
 		grpc.ForceServerCodecV2(router.Codec()),
-		grpc.UnknownServiceHandler(router.Handler(stubDirector{upstream: "primary", cc: upstreamConn}, stubReflector{}, m)),
+		grpc.UnknownServiceHandler(router.Handler(stubDirector{upstream: "primary", cc: upstreamConn}, stubReflector{}, stubGate{}, m)),
 	)
 	serve(t, relay, relayLis)
 
@@ -459,7 +504,7 @@ func TestHandlerStampsNamespace(t *testing.T) {
 	relayLis := bufconn.Listen(1024 * 1024)
 	relay := grpc.NewServer(
 		grpc.ForceServerCodecV2(router.Codec()),
-		grpc.UnknownServiceHandler(router.Handler(stubDirector{upstream: "u", cc: upstream}, &recordingReflector{ns: "orders"}, m)),
+		grpc.UnknownServiceHandler(router.Handler(stubDirector{upstream: "u", cc: upstream}, &recordingReflector{ns: "orders"}, stubGate{}, m)),
 	)
 	serve(t, relay, relayLis)
 
@@ -512,6 +557,8 @@ func (s stubDirector) Resolve(context.Context, string, string, map[string][]stri
 }
 
 func (stubReflector) Namespace(string, []byte) string { return "" }
+
+func (stubGate) Allows(string) bool { return true }
 
 func (r *recordingReflector) Namespace(method string, payload []byte) string {
 	r.mu.Lock()
@@ -635,7 +682,7 @@ func newRelayWith(
 	relayLis := bufconn.Listen(1024 * 1024)
 	relay := grpc.NewServer(
 		grpc.ForceServerCodecV2(router.Codec()),
-		grpc.UnknownServiceHandler(router.Handler(makeDirector(upstreamConn), reflector, reporter)),
+		grpc.UnknownServiceHandler(router.Handler(makeDirector(upstreamConn), reflector, stubGate{}, reporter)),
 	)
 	serve(t, relay, relayLis)
 

--- a/internal/services/allowlist.go
+++ b/internal/services/allowlist.go
@@ -1,0 +1,28 @@
+package services
+
+// Allowlist is the set of services the proxy will forward, keyed by proto full
+// name. It admits the names it was built from plus their compatibility aliases,
+// and does no registry lookup, since configuration validation has already
+// rejected names that cannot be forwarded.
+type Allowlist map[string]struct{}
+
+// NewAllowlist builds an Allowlist admitting names and their compatibility
+// aliases, so allowing a service also allows the spellings a client may fall
+// back to.
+func NewAllowlist(names []string) Allowlist {
+	exp := expand(names)
+	set := make(Allowlist, len(exp))
+	for _, name := range exp {
+		set[name] = struct{}{}
+	}
+
+	return set
+}
+
+// Allows reports whether name was admitted. It matches a service full name
+// only, so a caller holding a gRPC full method must strip the method first. An
+// Allowlist built from no names allows nothing.
+func (a Allowlist) Allows(name string) bool {
+	_, ok := a[name]
+	return ok
+}

--- a/internal/services/allowlist_test.go
+++ b/internal/services/allowlist_test.go
@@ -1,0 +1,117 @@
+package services_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/temporalio/temporal-proxy/internal/services"
+)
+
+func TestAllowlistAllows(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		allowed []string
+		want    map[string]bool
+	}{
+		{
+			name:    "the default set admits the two default services and nothing else",
+			allowed: services.Default(),
+			want: map[string]bool{
+				services.WorkflowService:   true,
+				services.OperatorService:   true,
+				services.Reflection:        false,
+				services.ReflectionV1Alpha: false,
+			},
+		},
+		{
+			name:    "allowing reflection also allows its alias",
+			allowed: []string{services.Reflection},
+			want: map[string]bool{
+				services.Reflection:        true,
+				services.ReflectionV1Alpha: true,
+				services.WorkflowService:   false,
+			},
+		},
+		{
+			// The alias relation is one-way: naming the superseded spelling does
+			// not admit the current one.
+			name:    "allowing only the alias does not allow the current spelling",
+			allowed: []string{services.ReflectionV1Alpha},
+			want: map[string]bool{
+				services.ReflectionV1Alpha: true,
+				services.Reflection:        false,
+			},
+		},
+		{
+			name:    "the full known set admits every forwardable name",
+			allowed: services.Known(),
+			want: map[string]bool{
+				services.WorkflowService:   true,
+				services.OperatorService:   true,
+				services.Reflection:        true,
+				services.ReflectionV1Alpha: true,
+			},
+		},
+		{
+			name:    "a nil list admits nothing",
+			allowed: nil,
+			want: map[string]bool{
+				services.WorkflowService: false,
+				"":                       false,
+			},
+		},
+		{
+			name:    "an empty list admits nothing",
+			allowed: []string{},
+			want: map[string]bool{
+				services.WorkflowService: false,
+			},
+		},
+		{
+			// Names are matched literally, so a caller holding a full method
+			// must strip it first.
+			name:    "a full method does not match the service it names",
+			allowed: []string{services.WorkflowService},
+			want: map[string]bool{
+				services.WorkflowService:                                   true,
+				"/" + services.WorkflowService + "/StartWorkflowExecution": false,
+			},
+		},
+		{
+			// The allowlist trusts its input: rejecting unforwardable names is
+			// configuration validation's job.
+			name:    "an unregistered name is admitted verbatim",
+			allowed: []string{"not.A.Thing"},
+			want: map[string]bool{
+				"not.A.Thing":            true,
+				services.WorkflowService: false,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			allowlist := services.NewAllowlist(tt.allowed)
+			for name, want := range tt.want {
+				require.Equal(t, want, allowlist.Allows(name), "Allows(%q)", name)
+			}
+		})
+	}
+}
+
+func TestNewAllowlistCollapsesDuplicates(t *testing.T) {
+	t.Parallel()
+
+	// Validation rejects a duplicated allowlist, but one is also constructible
+	// in code, so collapsing duplicates must not change what it admits.
+	allowlist := services.NewAllowlist([]string{services.WorkflowService, services.WorkflowService})
+
+	require.Len(t, allowlist, 1)
+	require.True(t, allowlist.Allows(services.WorkflowService))
+	require.False(t, allowlist.Allows(services.OperatorService))
+}

--- a/internal/services/doc.go
+++ b/internal/services/doc.go
@@ -1,0 +1,10 @@
+// Package services names the gRPC services the proxy can forward and resolves
+// their descriptors.
+//
+// Importing this package links each service's generated code into the binary,
+// which is what registers its descriptors with protoregistry.GlobalFiles.
+// Resolution elsewhere in the proxy (namespace extraction, the reflective
+// forwarder, configuration validation) reads that global registry, so a service
+// absent here cannot be routed or forwarded no matter what configuration asks
+// for.
+package services

--- a/internal/services/services.go
+++ b/internal/services/services.go
@@ -1,0 +1,94 @@
+package services
+
+import (
+	"fmt"
+	"slices"
+
+	// Blank imports register each forwardable service's descriptors with
+	// protoregistry.GlobalFiles. Without them Resolve fails and the forwarder
+	// cannot type a request, so these imports are load-bearing rather than
+	// incidental.
+	_ "go.temporal.io/api/operatorservice/v1"
+	_ "go.temporal.io/api/workflowservice/v1"
+	_ "google.golang.org/grpc/reflection/grpc_reflection_v1"
+	_ "google.golang.org/grpc/reflection/grpc_reflection_v1alpha"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+)
+
+const (
+	// WorkflowService is the Temporal service every client, worker, and UI uses.
+	WorkflowService = "temporal.api.workflowservice.v1.WorkflowService"
+
+	// OperatorService backs `temporal operator ...` and the UI's search
+	// attribute and Nexus endpoint views.
+	OperatorService = "temporal.api.operatorservice.v1.OperatorService"
+
+	// Reflection is the current gRPC server reflection service.
+	Reflection = "grpc.reflection.v1.ServerReflection"
+
+	// ReflectionV1Alpha is the superseded reflection service. Clients such as
+	// grpcurl probe v1 and fall back to it, so allowing one allows both.
+	ReflectionV1Alpha = "grpc.reflection.v1alpha.ServerReflection"
+)
+
+// aliases maps a service name to the additional names allowing it implies.
+// Callers name the service they mean; Expand supplies the compatibility
+// spellings so configuration does not have to.
+var aliases = map[string][]string{
+	Reflection: {ReflectionV1Alpha},
+}
+
+// Default returns the services exposed when configuration names none: the two a
+// normal client, worker, CLI, or UI needs. Reflection is excluded because
+// service discovery is opt-in.
+func Default() []string {
+	return []string{WorkflowService, OperatorService}
+}
+
+// Known returns every service the proxy can forward, which is every service
+// whose descriptors this package links in. It is the universe configuration may
+// select from, and the set the namespace completeness guard audits.
+func Known() []string {
+	return []string{WorkflowService, OperatorService, Reflection}
+}
+
+// All returns every forwardable service name, including each service's
+// compatibility alias: the full set a name might need to be checked against, as
+// opposed to Known's plain spelling of it. A caller checking membership against
+// "the complete set of names that count as forwardable" should use All.
+func All() []string {
+	return expand(Known())
+}
+
+// Resolve returns the descriptor for the named service, failing when the name
+// is not registered (its package is not linked in) or names something other
+// than a service.
+func Resolve(name string) (protoreflect.ServiceDescriptor, error) {
+	d, err := protoregistry.GlobalFiles.FindDescriptorByName(protoreflect.FullName(name))
+	if err != nil {
+		return nil, fmt.Errorf("service %q is not registered: %w", name, err)
+	}
+
+	sd, ok := d.(protoreflect.ServiceDescriptor)
+	if !ok {
+		return nil, fmt.Errorf("%q is not a service", name)
+	}
+
+	return sd, nil
+}
+
+// expand returns names plus the alias of every name that has one, with
+// duplicates removed. Order is not significant to callers, which build sets.
+func expand(names []string) []string {
+	out := slices.Clone(names)
+	for _, name := range names {
+		for _, alias := range aliases[name] {
+			if !slices.Contains(out, alias) {
+				out = append(out, alias)
+			}
+		}
+	}
+
+	return out
+}

--- a/internal/services/services_test.go
+++ b/internal/services/services_test.go
@@ -1,0 +1,64 @@
+package services_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/temporalio/temporal-proxy/internal/services"
+)
+
+func TestResolveKnownServices(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range services.All() {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			sd, err := services.Resolve(name)
+			require.NoError(t, err)
+			require.Equal(t, name, string(sd.FullName()))
+			require.Positive(t, sd.Methods().Len(), "a forwardable service must have methods")
+		})
+	}
+}
+
+func TestResolveUnknownService(t *testing.T) {
+	t.Parallel()
+
+	_, err := services.Resolve("temporal.api.nope.v1.NopeService")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "temporal.api.nope.v1.NopeService")
+}
+
+func TestResolveRejectsNonService(t *testing.T) {
+	t.Parallel()
+
+	// A message type resolves in the registry but is not a service.
+	_, err := services.Resolve("temporal.api.common.v1.Payload")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not a service")
+}
+
+func TestDefaultIsForwardableSubsetOfKnown(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, []string{services.WorkflowService, services.OperatorService}, services.Default())
+	require.Subset(t, services.Known(), services.Default())
+}
+
+func TestAllCarriesAliasesWithoutDuplicates(t *testing.T) {
+	t.Parallel()
+
+	all := services.All()
+	require.Subset(t, all, services.Known())
+	require.Contains(t, all, services.ReflectionV1Alpha,
+		"All must carry the alias Known omits, since it is what admission checks against")
+
+	seen := make(map[string]struct{}, len(all))
+	for _, name := range all {
+		_, dup := seen[name]
+		require.False(t, dup, "All must not repeat %q", name)
+		seen[name] = struct{}{}
+	}
+}


### PR DESCRIPTION
The proxy forwards every unknown method straight to an upstream, so any service that upstream implements is reachable through it. Operators had no way to narrow that surface.

Add an allowedServices list to the config. It defaults to WorkflowService and OperatorService, the two a normal client, worker, CLI, or UI needs, leaving reflection out so service discovery stays opt-in. The router's handler now rejects a method whose service is not admitted with Unimplemented, before any routing work, so the proxy answers as a server that does not implement the method rather than revealing that an upstream might.