### PR TITLE
Add debug logging for routing decisions

### DIFF
--- a/internal/proxy/fx.go
+++ b/internal/proxy/fx.go
@@ -15,6 +15,7 @@ import (
 	"github.com/temporalio/temporal-proxy/internal/transport/connect"
 	"github.com/temporalio/temporal-proxy/pkg/crypto"
 	"github.com/temporalio/temporal-proxy/pkg/logger"
+	"github.com/temporalio/temporal-proxy/pkg/logger/tag"
 )
 
 // Module is the fx module that constructs the proxy [Server] from [ProxyParams]
@@ -75,7 +76,7 @@ var Module = fx.Options(fx.Invoke(func(p ProxyParams) error {
 			dialOpts = append(dialOpts, grpc.WithChainUnaryInterceptor(enc))
 		}
 
-		res, err := upstreamResolver(up, dialOpts)
+		res, err := upstreamResolver(up, dialOpts, p.Logger)
 		if err != nil {
 			return err
 		}
@@ -169,8 +170,9 @@ type ProxyParams struct {
 // start, and reused for every request; otherwise it returns a DynamicResolver
 // that renders the target and server name, and rebuilds credentials, per request.
 // opts holds the request-independent dial options (namespace translation and
-// outbound credentials).
-func upstreamResolver(upstream *config.Upstream, opts []grpc.DialOption) (connect.Resolver, error) {
+// outbound credentials). log, when non-nil, is threaded into the DynamicResolver
+// for per-request debug entries.
+func upstreamResolver(upstream *config.Upstream, opts []grpc.DialOption, log logger.Logger) (connect.Resolver, error) {
 	// One Dialer per upstream owns the TLS-mode decision and parses its
 	// certificate material once, so a templated upstream reuses it across every
 	// per-request dial (only the rendered server name varies).
@@ -182,8 +184,7 @@ func upstreamResolver(upstream *config.Upstream, opts []grpc.DialOption) (connec
 			translator = upstream.Namespaces.Rules.Remote
 		}
 
-		return NewDynamicResolver(
-			upstream,
+		resolverOpts := []ResolverOption{
 			WithRemoteNamespacer(translator),
 			WithOptionsFactory(func(data RouteData) ([]grpc.DialOption, error) {
 				cred, err := dialer.DialOption(data.ResolvedServerName)
@@ -193,7 +194,12 @@ func upstreamResolver(upstream *config.Upstream, opts []grpc.DialOption) (connec
 
 				return append(slices.Clone(opts), cred), nil
 			}),
-		)
+		}
+		if log != nil {
+			resolverOpts = append(resolverOpts, WithResolverLogger(log.With(tag.Component("resolver"))))
+		}
+
+		return NewDynamicResolver(upstream, resolverOpts...)
 	}
 
 	serverName := ""

--- a/internal/proxy/resolver.go
+++ b/internal/proxy/resolver.go
@@ -15,6 +15,8 @@ import (
 	"github.com/temporalio/temporal-proxy/internal/config"
 	"github.com/temporalio/temporal-proxy/internal/template"
 	"github.com/temporalio/temporal-proxy/internal/transport/meta"
+	"github.com/temporalio/temporal-proxy/pkg/logger"
+	"github.com/temporalio/temporal-proxy/pkg/logger/tag"
 )
 
 type (
@@ -30,6 +32,7 @@ type (
 		serverName *template.Template[template.UpstreamContext]
 		remote     func(string) string
 		opts       func(d RouteData) ([]grpc.DialOption, error)
+		logger     logger.Logger
 	}
 
 	// RouteData is passed to the options factory once a request has been
@@ -90,6 +93,12 @@ func WithRemoteNamespacer(f func(string) string) ResolverOption {
 // resolved request. It receives the rendered host and server name via RouteData.
 func WithOptionsFactory(f func(RouteData) ([]grpc.DialOption, error)) ResolverOption {
 	return func(r *DynamicResolver) { r.opts = f }
+}
+
+// WithResolverLogger sets the logger used to emit a per-request debug entry
+// after a successful resolve. Unset: no entry is emitted.
+func WithResolverLogger(l logger.Logger) ResolverOption {
+	return func(r *DynamicResolver) { r.logger = l }
 }
 
 // IsStatic reports that a DynamicResolver always resolves per request.
@@ -154,6 +163,17 @@ func (r *DynamicResolver) Resolve(ctx context.Context) (string, string, []grpc.D
 			"proxy: upstream %q failed to build dial options: %v",
 			r.name,
 			err,
+		)
+	}
+
+	if r.logger != nil {
+		r.logger.Debug(
+			"resolved upstream target",
+			tag.String("upstream", r.name),
+			tag.String("localNamespace", localNS),
+			tag.String("remoteNamespace", data.RemoteNamespace),
+			tag.String("target", target),
+			tag.String("serverName", svrName),
 		)
 	}
 

--- a/internal/proxy/resolver_test.go
+++ b/internal/proxy/resolver_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/temporalio/temporal-proxy/internal/config"
 	"github.com/temporalio/temporal-proxy/internal/proxy"
 	"github.com/temporalio/temporal-proxy/internal/transport/meta"
+	"github.com/temporalio/temporal-proxy/pkg/logger"
+	"github.com/temporalio/temporal-proxy/pkg/logger/tag"
 )
 
 func TestDynamicResolverIsStatic(t *testing.T) {
@@ -133,6 +135,41 @@ func TestDynamicResolverRejectsInvalidAddresses(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+func TestDynamicResolverLogsDebugEntry(t *testing.T) {
+	t.Parallel()
+
+	up := upstreamWith("cloud", "{{ .RemoteNamespace }}.acme.example:7233", "{{ .RemoteNamespace }}.sni.example")
+	log := logger.NewTestLogger()
+	res, err := proxy.NewDynamicResolver(
+		up,
+		proxy.WithRemoteNamespacer(func(s string) string { return s + "-remote" }),
+		proxy.WithResolverLogger(log),
+	)
+	require.NoError(t, err)
+
+	_, _, _, err = res.Resolve(meta.WithNamespace(t.Context(), "orders"))
+	require.NoError(t, err)
+
+	require.True(t, log.ContainsEntry(
+		logger.LevelDebug,
+		"resolved upstream target",
+		tag.String("upstream", "cloud"),
+		tag.String("localNamespace", "orders"),
+		tag.String("remoteNamespace", "orders-remote"),
+		tag.String("target", "orders-remote.acme.example:7233"),
+		tag.String("serverName", "orders-remote.sni.example"),
+	))
+}
+
+func TestDynamicResolverNoLoggerNoPanic(t *testing.T) {
+	t.Parallel()
+
+	res, err := proxy.NewDynamicResolver(upstreamWith("u", "host:7233", ""))
+	require.NoError(t, err)
+	_, _, _, err = res.Resolve(meta.WithNamespace(t.Context(), "orders"))
+	require.NoError(t, err)
 }
 
 func upstreamWith(name, hostPort, serverName string) *config.Upstream {

--- a/internal/router/director_test.go
+++ b/internal/router/director_test.go
@@ -13,6 +13,8 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/temporalio/temporal-proxy/internal/metrics"
+	"github.com/temporalio/temporal-proxy/pkg/logger"
+	"github.com/temporalio/temporal-proxy/pkg/logger/tag"
 )
 
 func TestDirectorResolve(t *testing.T) {
@@ -94,6 +96,45 @@ tmprl_proxy_router_decisions_total{outcome="system",upstream="primary"} 0
 tmprl_proxy_router_decisions_total{outcome="unroutable",upstream="unknown"} 1
 `)
 	})
+}
+
+func TestDirectorLogsRoutingDecision(t *testing.T) {
+	t.Parallel()
+
+	reg := prometheus.NewRegistry()
+	log := logger.NewTestLogger()
+	d := &director{
+		conns:    map[string]*grpc.ClientConn{"primary": {}},
+		mux:      New("primary", ""),
+		reporter: testReporter(reg),
+		logger:   log,
+	}
+
+	_, err := d.Resolve(t.Context(), "/svc/M", "orders", nil)
+	require.NoError(t, err)
+
+	require.True(t, log.ContainsEntry(
+		logger.LevelDebug,
+		"routing request",
+		tag.String("method", "/svc/M"),
+		tag.String("namespace", "orders"),
+		tag.String("upstream", "primary"),
+		tag.Stringer("outcome", OutcomeDefault),
+	))
+}
+
+func TestDirectorLogsSkippedWhenLoggerUnset(t *testing.T) {
+	t.Parallel()
+
+	reg := prometheus.NewRegistry()
+	d := &director{
+		conns:    map[string]*grpc.ClientConn{"primary": {}},
+		mux:      New("primary", ""),
+		reporter: testReporter(reg),
+	}
+
+	_, err := d.Resolve(t.Context(), "/svc/M", "orders", nil)
+	require.NoError(t, err)
 }
 
 // testReporter builds a Reporter over reg with the production namespace and

--- a/internal/router/fx.go
+++ b/internal/router/fx.go
@@ -16,6 +16,8 @@ import (
 	"github.com/temporalio/temporal-proxy/internal/protoutil"
 	"github.com/temporalio/temporal-proxy/internal/transport/connect"
 	"github.com/temporalio/temporal-proxy/internal/transport/socket"
+	"github.com/temporalio/temporal-proxy/pkg/logger"
+	"github.com/temporalio/temporal-proxy/pkg/logger/tag"
 	"github.com/temporalio/temporal-proxy/pkg/match"
 )
 
@@ -46,11 +48,17 @@ var Module = fx.Options(fx.Provide(
 			conns[upstream.Name] = conn
 		}
 
+		log := p.Logger
+		if log == nil {
+			log = logger.Default()
+		}
+
 		return Handler(
 			&director{
 				conns:    conns,
 				mux:      p.Mux,
 				reporter: p.Reporter,
+				logger:   log.With(tag.Component("router")),
 			},
 			p.Extractor,
 			p.Reporter,
@@ -123,6 +131,9 @@ type (
 		Mux       *Mux
 		Pool      *connect.Pool
 		Reporter  *Reporter
+
+		// Optional; falls back to [logger.Default].
+		Logger logger.Logger `optional:"true"`
 	}
 
 	// director is the [Director] used by the module's handler. It maps the
@@ -131,6 +142,7 @@ type (
 		conns    map[string]*grpc.ClientConn
 		mux      *Mux
 		reporter *Reporter
+		logger   logger.Logger
 	}
 )
 
@@ -142,7 +154,7 @@ type (
 // upstream has no connection.
 func (d *director) Resolve(
 	ctx context.Context,
-	_, namespace string,
+	method, namespace string,
 	md map[string][]string,
 ) (Target, error) {
 	upstream, outcome := d.mux.Switch(namespace, md)
@@ -157,6 +169,16 @@ func (d *director) Resolve(
 	if !ok {
 		d.reporter.ForwardingError(upstream, reasonNoConnection)
 		return Target{}, status.Errorf(codes.Unavailable, "router: no connection for upstream %q", upstream)
+	}
+
+	if d.logger != nil {
+		d.logger.Debug(
+			"routing request",
+			tag.String("method", method),
+			tag.String("namespace", namespace),
+			tag.String("upstream", upstream),
+			tag.Stringer("outcome", outcome),
+		)
 	}
 
 	return Target{Upstream: upstream, Conn: cc}, nil


### PR DESCRIPTION
## Motivation

The proxy is opaque about routing decisions at runtime: today, only lifecycle events log. With namespace translation and per-request templated `hostPort` / TLS `serverName` resolution, an operator debugging misrouted or auth-failing traffic has no way to answer, without attaching a debugger or turning up `GRPC_GO_LOG_*`, questions like:

- Which upstream did the router pick for this method and namespace?
- What did the local namespace get translated into?
- What target host:port and TLS server name did the dynamic resolver render before dialing?

This turned up while debugging a per-account namespace-suffix issue in a downstream deployment — the pod had `LOG_LEVEL=debug` set and still surfaced zero request-path lines while every worker got `Unauthenticated` from the upstream.

## Change

Two `Debug` entries on the request path, both gated so callers that don't wire a logger emit nothing:

- `router.director.Resolve` — after a successful mux decision, logs `method`, `namespace`, chosen `upstream`, and `outcome`.
- `proxy.DynamicResolver.Resolve` — after a successful resolve, logs `upstream`, `localNamespace`, `remoteNamespace`, rendered `target`, and rendered `serverName`.

Wiring:

- `RouterParams` already had (no change to callers): an optional `Logger` that now propagates into `director` and gets a `component=router` tag.
- `ProxyParams.Logger` is now threaded through `upstreamResolver` into `DynamicResolver` via a new `WithResolverLogger(logger.Logger) ResolverOption`. Untagged callers still work.

## Sample output (at Debug)

```
DEBUG routing request  component=router method=/temporal.api.workflowservice.v1.WorkflowService/StartWorkflowExecution namespace=orders upstream=cloud outcome=match
DEBUG resolved upstream target  component=resolver upstream=cloud localNamespace=orders remoteNamespace=orders.acme target=orders.acme.example:7233 serverName=orders.acme.sni.example
```

## Tests

- `internal/proxy` — new `TestDynamicResolverLogsDebugEntry` asserts the debug entry with the exact tag set via `logger.TestLogger.ContainsEntry`; `TestDynamicResolverNoLoggerNoPanic` asserts the no-logger path is a no-op.
- `internal/router` — new `TestDirectorLogsRoutingDecision` and `TestDirectorLogsSkippedWhenLoggerUnset` assert the same for the router side.

`go vet ./...` and `go test ./...` both clean locally.

## Notes

- Only fires at `Debug`, so production defaults (`Info`) are unchanged.
- No metric changes — the existing `router.Reporter.Decision` metric is untouched.
- Log-line contents deliberately include no metadata values or headers, only routing/resolution outputs, to avoid accidentally exposing per-request user data at Debug.