### PR TITLE
[proxy]: Forward any allow-listed service

### DIFF
--- a/cmd/proxy/serve.go
+++ b/cmd/proxy/serve.go
@@ -9,6 +9,7 @@ import (
 	"go.uber.org/fx"
 	"go.uber.org/fx/fxevent"
 	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
 
 	"github.com/temporalio/temporal-proxy/internal/api"
 	"github.com/temporalio/temporal-proxy/internal/auth"
@@ -74,6 +75,8 @@ func serve() *cli.Command {
 					fx.Annotate(cmd.String("config"), config.ConfigFileTag),
 					fx.Annotate(cmd.String("metrics-addr"), metrics.AddrTag),
 					fx.Annotate(cmd.String("metrics-namespace"), metrics.NamespaceTag),
+					fx.Annotate(protoregistry.GlobalFiles, fx.As(new(protoutil.Files))),
+					fx.Annotate(protoregistry.GlobalTypes, fx.As(new(protoutil.Types))),
 					// Services whose request and response types have their namespace
 					// translation plans warmed at startup.
 					[]protoreflect.FullName{"temporal.api.workflowservice.v1.WorkflowService"},

--- a/e2e/harness_test.go
+++ b/e2e/harness_test.go
@@ -118,6 +118,7 @@ func newFullApp(t *testing.T, cfg *config.Config) *fx.App {
 		proxy.Module,
 		router.Module,
 		server.Module,
+		fx.Provide(config.NewAllowlist),
 		fx.NopLogger,
 	)
 }
@@ -140,6 +141,7 @@ func newProxyApp(t *testing.T, cfg *config.Config) *fx.App {
 		connect.Module,
 		protoutil.Module,
 		proxy.Module,
+		fx.Provide(config.NewAllowlist),
 		fx.NopLogger,
 	)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/goccy/go-yaml"
 
-	"github.com/temporalio/temporal-proxy/internal/services"
 	"github.com/temporalio/temporal-proxy/pkg/validation"
 )
 
@@ -45,9 +44,7 @@ func Load(r io.Reader) (*Config, error) {
 	// The allowlist defaults here rather than in a Services unmarshaler because
 	// an absent key never reaches one, and an absent allowedServices is how most
 	// configs are written.
-	if len(cfg.AllowedServices) == 0 {
-		cfg.AllowedServices = services.Default()
-	}
+	cfg.AllowedServices = cfg.AllowedServices.Allowed()
 
 	return &cfg, nil
 }

--- a/internal/config/fx.go
+++ b/internal/config/fx.go
@@ -4,11 +4,15 @@ import "go.uber.org/fx"
 
 var ConfigFileTag = fx.ResultTags(`name:"configFile"`)
 
-// Module is an fx module that provides *Config by loading the file path
-// supplied as the named value "configFile".
-var Module = fx.Option(fx.Provide(func(p ConfigParams) (*Config, error) {
-	return LoadFile(p.File)
-}))
+// Module is an fx module that provides *Config by loading the file path supplied
+// as the named value "configFile", along with the allowlist derived from it via
+// [NewAllowlist], which is the single owner of how the forwarding gate is built.
+var Module = fx.Option(fx.Provide(
+	func(p ConfigParams) (*Config, error) {
+		return LoadFile(p.File)
+	},
+	NewAllowlist,
+))
 
 // ConfigParams holds the fx-injected dependencies for loading the config file.
 type ConfigParams struct {

--- a/internal/config/fx_test.go
+++ b/internal/config/fx_test.go
@@ -33,6 +33,49 @@ func TestModule_ProvidesConfig(t *testing.T) {
 	}, got)
 }
 
+func TestModule_ProvidesAllowlist(t *testing.T) {
+	t.Parallel()
+
+	// The forwarding hops depend on this provider and nothing else supplies it, so
+	// without it the binary fails at construction with "missing type:
+	// services.Allowlist" while every other test still passes.
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("allowedServices: [\""+services.Reflection+"\"]\n"), 0o600))
+
+	var got services.Allowlist
+	app := fx.New(
+		fx.Supply(fx.Annotate(path, config.ConfigFileTag)),
+		config.Module,
+		fx.Populate(&got),
+		fx.NopLogger,
+	)
+
+	require.NoError(t, app.Err())
+	require.True(t, got.Allows(services.Reflection))
+	require.True(t, got.Allows(services.ReflectionV1Alpha), "expected the compatibility alias to be admitted")
+	require.False(t, got.Allows(services.WorkflowService), "expected a service the config omits to be denied")
+}
+
+func TestModule_AllowlistDefaultsWhenConfigNamesNone(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("hostPort: :7233\n"), 0o600))
+
+	var got services.Allowlist
+	app := fx.New(
+		fx.Supply(fx.Annotate(path, config.ConfigFileTag)),
+		config.Module,
+		fx.Populate(&got),
+		fx.NopLogger,
+	)
+
+	require.NoError(t, app.Err())
+	for _, svc := range services.Default() {
+		require.True(t, got.Allows(svc), "expected the default set to be admitted")
+	}
+}
+
 func TestModule_ErrorPropagates(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/services.go
+++ b/internal/config/services.go
@@ -14,6 +14,26 @@ import (
 // "temporal.api.workflowservice.v1.WorkflowService").
 type Services []string
 
+// NewAllowlist builds the [services.Allowlist] admitting the services c allows.
+// It is the fx provider [Module] registers, and is exported so an application
+// that assembles a partial graph (supplying a *Config rather than loading one)
+// can provide the allowlist the same way rather than rebuilding it.
+func NewAllowlist(c *Config) services.Allowlist {
+	return services.NewAllowlist(c.AllowedServices.Allowed())
+}
+
+// Allowed returns the services to forward: the configured names, or the default
+// set when none were configured. Callers build their allowlist from this rather
+// than from the raw field, so a Config assembled in code rather than through
+// Load forwards the defaults instead of denying everything.
+func (s Services) Allowed() []string {
+	if len(s) == 0 {
+		return services.Default()
+	}
+
+	return s
+}
+
 // Validate rejects duplicate entries and any name the proxy cannot forward. An
 // empty list is valid. Failures carry the "allowedServices" field and no
 // subject, so Config nests this under an empty subject rather than restating

--- a/internal/protoutil/rpc.go
+++ b/internal/protoutil/rpc.go
@@ -2,16 +2,25 @@ package protoutil
 
 import "strings"
 
+// SplitMethod splits a gRPC full method ("/pkg.Service/Method", with or without
+// the leading slash gRPC supplies) into its service and method halves. It
+// reports false when fullMethod carries no method to split off, in which case
+// both halves are empty.
+func SplitMethod(fullMethod string) (service, method string, ok bool) {
+	trimmed := strings.TrimPrefix(fullMethod, "/")
+	slash := strings.LastIndex(trimmed, "/")
+	if slash < 0 {
+		return "", "", false
+	}
+
+	return trimmed[:slash], trimmed[slash+1:], true
+}
+
 // ServiceName returns the service portion of a gRPC full method
 // ("/pkg.Service/Method"), with or without the leading slash gRPC supplies. It
 // returns "" when fullMethod carries no method to strip, which callers must
 // treat as "no service" rather than as a name to match on.
 func ServiceName(fullMethod string) string {
-	trimmed := strings.TrimPrefix(fullMethod, "/")
-	slash := strings.LastIndex(trimmed, "/")
-	if slash < 0 {
-		return ""
-	}
-
-	return trimmed[:slash]
+	service, _, _ := SplitMethod(fullMethod)
+	return service
 }

--- a/internal/protoutil/rpc_test.go
+++ b/internal/protoutil/rpc_test.go
@@ -69,3 +69,69 @@ func TestServiceName(t *testing.T) {
 		})
 	}
 }
+
+func TestSplitMethod(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		in      string
+		service string
+		method  string
+		ok      bool
+	}{
+		{
+			name:    "full method as gRPC supplies it",
+			in:      "/temporal.api.workflowservice.v1.WorkflowService/StartWorkflowExecution",
+			service: "temporal.api.workflowservice.v1.WorkflowService",
+			method:  "StartWorkflowExecution",
+			ok:      true,
+		},
+		{
+			name:    "full method without a leading slash",
+			in:      "temporal.api.workflowservice.v1.WorkflowService/StartWorkflowExecution",
+			service: "temporal.api.workflowservice.v1.WorkflowService",
+			method:  "StartWorkflowExecution",
+			ok:      true,
+		},
+		{
+			// The split succeeds and the caller decides an empty method is not
+			// resolvable, rather than this reporting a malformed name.
+			name:    "an empty method splits with an empty half",
+			in:      "/pkg.Service/",
+			service: "pkg.Service",
+			method:  "",
+			ok:      true,
+		},
+		{
+			name: "a bare service name has no method to split off",
+			in:   "pkg.Service",
+			ok:   false,
+		},
+		{
+			name: "the empty string does not split",
+			in:   "",
+			ok:   false,
+		},
+		{
+			// The split is on the last slash, so a method name is never mistaken
+			// for part of the service.
+			name:    "only the final segment is the method",
+			in:      "/a/b/c",
+			service: "a/b",
+			method:  "c",
+			ok:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			service, method, ok := protoutil.SplitMethod(tt.in)
+			require.Equal(t, tt.ok, ok)
+			require.Equal(t, tt.service, service)
+			require.Equal(t, tt.method, method)
+		})
+	}
+}

--- a/internal/proxy/doc.go
+++ b/internal/proxy/doc.go
@@ -1,5 +1,5 @@
-// Package proxy serves the Temporal WorkflowService on a local unix socket,
-// forwarding every request to an upstream Temporal frontend over gRPC. The
+// Package proxy serves every allowlisted service on a local unix socket,
+// forwarding each request to an upstream Temporal frontend over gRPC. The
 // socket path is derived from the upstream host:port, so local workers connect
 // without TLS while the upstream hop stays secured.
 package proxy

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -1,0 +1,358 @@
+package proxy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+
+	"github.com/temporalio/temporal-proxy/internal/protoutil"
+	"github.com/temporalio/temporal-proxy/internal/services"
+)
+
+// transportHeaders are the inbound hop's own headers, which describe that hop
+// rather than the request. gRPC sets its own on the outbound call and rejects a
+// pseudo-header supplied as metadata, so they are dropped rather than forwarded.
+var transportHeaders = []string{"user-agent", ":authority", "content-type"}
+
+type (
+	// Forwarder forwards any allowlisted method to a single upstream, typing each
+	// request and response from the proto registry rather than being generated per
+	// service. The typing is load-bearing: namespace translation and payload
+	// encryption are client interceptors on cc that operate on proto messages, so
+	// an opaque byte passthrough (as the router uses) would silently skip both.
+	// Resolved methods are cached, and a Forwarder is safe for concurrent use.
+	Forwarder struct {
+		cc      grpc.ClientConnInterface
+		gate    Gate
+		methods sync.Map // fullName -> *methodInfo
+		types   protoutil.Types
+	}
+
+	// ForwarderOption configures a [Forwarder] at construction time.
+	ForwarderOption func(*Forwarder)
+
+	// Gate reports whether the proxy will forward the named service. Allows
+	// receives a service full name, never a full method; the assembled application
+	// passes the allowlist built from configuration.
+	Gate interface {
+		Allows(string) bool
+	}
+
+	// methodInfo is the resolved descriptor and message types for one full method.
+	methodInfo struct {
+		desc protoreflect.MethodDescriptor
+		in   protoreflect.MessageType
+		out  protoreflect.MessageType
+	}
+)
+
+// NewForwarder builds a Forwarder that forwards over cc every method belonging
+// to a service g admits. It fails when cc or g is nil. By default methods are
+// typed against the global proto registry; use [WithProtoTypes] to override it.
+func NewForwarder(cc grpc.ClientConnInterface, g Gate, opts ...ForwarderOption) (*Forwarder, error) {
+	if cc == nil {
+		return nil, fmt.Errorf("proxy: nil client connection passed to forwarder")
+	}
+
+	if g == nil {
+		return nil, fmt.Errorf("proxy: nil gate passed to forwarder")
+	}
+
+	f := &Forwarder{
+		cc:    cc,
+		gate:  g,
+		types: protoregistry.GlobalTypes,
+	}
+
+	for _, opt := range opts {
+		opt(f)
+	}
+
+	return f, nil
+}
+
+// WithProtoTypes sets the registry used to resolve a method's request and
+// response message types. A nil registry leaves the default in place.
+func WithProtoTypes(t protoutil.Types) ForwarderOption {
+	return func(f *Forwarder) {
+		if t != nil {
+			f.types = t
+		}
+	}
+}
+
+// Handle forwards one stream to the upstream, and suits
+// [google.golang.org/grpc.UnknownServiceHandler]. A method whose service the
+// [Gate] does not admit is rejected with Unimplemented before any upstream work,
+// so the proxy answers as a server that does not implement it rather than
+// revealing that an upstream might. Only methods present in the compiled
+// descriptors can be forwarded; anything else is Unimplemented too.
+func (f *Forwarder) Handle(_ any, ss grpc.ServerStream) error {
+	ctx := ss.Context()
+	sts := grpc.ServerTransportStreamFromContext(ctx)
+	if sts == nil {
+		return status.Error(codes.Internal, "proxy: no server transport stream in context")
+	}
+
+	method := sts.Method()
+	if service := protoutil.ServiceName(method); !f.gate.Allows(service) {
+		return status.Errorf(codes.Unimplemented, "unknown service %s", service)
+	}
+
+	info := f.lookup(method)
+	if info == nil {
+		return status.Errorf(codes.Unimplemented, "unknown method %s", method)
+	}
+
+	ctx = forwardContext(ctx)
+	if info.desc.IsStreamingClient() || info.desc.IsStreamingServer() {
+		return f.stream(ctx, method, info, ss)
+	}
+
+	return f.unary(ctx, method, info, ss)
+}
+
+// unary forwards a single request and response, relaying the upstream's response
+// header and trailer to the caller.
+func (f *Forwarder) unary(ctx context.Context, method string, mi *methodInfo, ss grpc.ServerStream) error {
+	req := mi.in.New().Interface()
+	if err := ss.RecvMsg(req); err != nil {
+		// io.EOF here means the caller half-closed without sending a request, which
+		// is a client error rather than a clean end of stream.
+		return statusError("reading the request failed", err)
+	}
+
+	// Invoke discards the upstream's response metadata unless it is asked for it,
+	// so collect both and relay them the way the streaming path does.
+	var header, trailer metadata.MD
+	resp := mi.out.New().Interface()
+	callErr := f.cc.Invoke(ctx, method, req, resp, grpc.Header(&header), grpc.Trailer(&trailer))
+
+	// The trailer carries the upstream's typed error details, so it propagates on
+	// failure as well as success and must be set before this handler returns.
+	if len(trailer) > 0 {
+		ss.SetTrailer(trailer)
+	}
+
+	if callErr != nil {
+		return callErr
+	}
+
+	if len(header) > 0 {
+		if err := ss.SetHeader(header); err != nil {
+			return statusError("relaying the response header failed", err)
+		}
+	}
+
+	if err := ss.SendMsg(resp); err != nil {
+		return statusError("sending the response failed", err)
+	}
+
+	return nil
+}
+
+// stream forwards a streaming method, pumping typed messages in both directions
+// and propagating the upstream's header, trailer, and status.
+func (f *Forwarder) stream(ctx context.Context, method string, mi *methodInfo, ss grpc.ServerStream) error {
+	cs, err := f.cc.NewStream(
+		ctx,
+		&grpc.StreamDesc{
+			ServerStreams: mi.desc.IsStreamingServer(),
+			ClientStreams: mi.desc.IsStreamingClient(),
+		},
+		method,
+	)
+	if err != nil {
+		return err
+	}
+
+	reqErr := pumpRequests(ss, cs, mi.in)
+	respErr := pumpResponses(cs, ss, mi.out)
+
+	for range 2 {
+		select {
+		case err := <-reqErr:
+			if errors.Is(err, io.EOF) {
+				_ = cs.CloseSend()
+				continue
+			}
+
+			return statusError("forwarding the request stream failed", err)
+		case err := <-respErr:
+			ss.SetTrailer(cs.Trailer())
+			if !errors.Is(err, io.EOF) {
+				return statusError("forwarding response stream failed", err)
+			}
+
+			return nil
+		}
+	}
+
+	// Defensive: pumpResponses always returns above; unreachable in normal flow.
+	return status.Error(codes.Internal, "proxy: forwarding ended without completion")
+}
+
+// lookup returns the cached methodInfo for fullMethod, resolving and caching it
+// on first use. It returns nil when the method cannot be resolved, which is not
+// cached so an unresolvable name cannot grow the cache.
+func (f *Forwarder) lookup(fullMethod string) *methodInfo {
+	if v, ok := f.methods.Load(fullMethod); ok {
+		return v.(*methodInfo)
+	}
+
+	mi := f.resolveMethod(fullMethod)
+	if mi == nil {
+		return nil
+	}
+
+	actual, _ := f.methods.LoadOrStore(fullMethod, mi)
+	return actual.(*methodInfo)
+}
+
+// resolveMethod resolves fullMethod to its descriptor and message types, or nil
+// when the service is not linked into the binary, the service has no such
+// method, or either message type is missing from the registry.
+func (f *Forwarder) resolveMethod(fullMethod string) *methodInfo {
+	service, method, ok := protoutil.SplitMethod(fullMethod)
+	if !ok {
+		return nil
+	}
+
+	sd, err := services.Resolve(service)
+	if err != nil {
+		return nil
+	}
+
+	md := sd.Methods().ByName(protoreflect.Name(method))
+	if md == nil {
+		return nil
+	}
+
+	in, err := f.types.FindMessageByName(md.Input().FullName())
+	if err != nil {
+		return nil
+	}
+
+	out, err := f.types.FindMessageByName(md.Output().FullName())
+	if err != nil {
+		return nil
+	}
+
+	return &methodInfo{desc: md, in: in, out: out}
+}
+
+// forwardContext turns the inbound request's metadata into outgoing metadata for
+// the upstream call, minus the transport headers, without displacing a value
+// already set on the outgoing context. Templated upstream resolution reads the
+// router-stamped namespace from there, so this is load-bearing rather than
+// merely polite.
+func forwardContext(ctx context.Context) context.Context {
+	incoming, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return ctx
+	}
+
+	incoming = incoming.Copy()
+	for _, key := range transportHeaders {
+		incoming.Delete(key)
+	}
+
+	if len(incoming) == 0 {
+		return ctx
+	}
+
+	outgoing, ok := metadata.FromOutgoingContext(ctx)
+	if !ok {
+		outgoing = metadata.MD{}
+	} else {
+		outgoing = outgoing.Copy()
+	}
+
+	for k, v := range incoming {
+		if len(outgoing.Get(k)) == 0 {
+			outgoing.Set(k, v...)
+		}
+	}
+
+	return metadata.NewOutgoingContext(ctx, outgoing)
+}
+
+// pumpRequests forwards request messages from the caller to the upstream.
+func pumpRequests(src grpc.ServerStream, dst grpc.ClientStream, in protoreflect.MessageType) <-chan error {
+	ret := make(chan error, 1)
+	go func() {
+		for {
+			msg := in.New().Interface()
+			if err := src.RecvMsg(msg); err != nil {
+				ret <- err // io.EOF on clean half-close.
+				return
+			}
+			if err := dst.SendMsg(msg); err != nil {
+				ret <- err
+				return
+			}
+		}
+	}()
+
+	return ret
+}
+
+// pumpResponses forwards response messages from the upstream to the caller. It
+// forwards the response header once up front: Header() blocks until the upstream
+// sends headers or the stream completes, so header-only and immediately-failing
+// responses still propagate their metadata.
+func pumpResponses(src grpc.ClientStream, dst grpc.ServerStream, out protoreflect.MessageType) <-chan error {
+	ret := make(chan error, 1)
+	go func() {
+		md, err := src.Header()
+		if err != nil {
+			ret <- err
+			return
+		}
+
+		if err := dst.SendHeader(md); err != nil {
+			ret <- err
+			return
+		}
+
+		for {
+			msg := out.New().Interface()
+			if err := src.RecvMsg(msg); err != nil {
+				ret <- err // io.EOF on clean completion, else the upstream status.
+				return
+			}
+
+			if err := dst.SendMsg(msg); err != nil {
+				ret <- err
+				return
+			}
+		}
+	}()
+
+	return ret
+}
+
+// statusError maps a forwarding error to the gRPC status returned to the caller,
+// naming the step that failed as what. It forwards an error already carrying a
+// status verbatim, maps a raw context error to its status, and otherwise reports
+// Internal.
+func statusError(what string, err error) error {
+	if _, ok := status.FromError(err); ok {
+		return err
+	}
+
+	if st := status.FromContextError(err); st.Code() != codes.Unknown {
+		return st.Err()
+	}
+
+	return status.Errorf(codes.Internal, "proxy: %s: %v", what, err)
+}

--- a/internal/proxy/forward_test.go
+++ b/internal/proxy/forward_test.go
@@ -1,0 +1,539 @@
+package proxy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	workflowservice "go.temporal.io/api/workflowservice/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+
+	"github.com/temporalio/temporal-proxy/internal/protoutil"
+	"github.com/temporalio/temporal-proxy/internal/services"
+	"github.com/temporalio/temporal-proxy/internal/transport/meta"
+	"github.com/temporalio/temporal-proxy/pkg/testutil"
+)
+
+type (
+	// partialTypes resolves every message except those named in missing, so a test
+	// can knock out just a request type or just a response type.
+	partialTypes struct {
+		missing map[protoreflect.FullName]struct{}
+	}
+)
+
+func TestForwardContextCarriesIncomingMetadataOutbound(t *testing.T) {
+	t.Parallel()
+
+	// Guard: incoming metadata must reach the outbound call. Templated upstream
+	// resolution reads the router-stamped namespace from the outgoing context and
+	// namespace translation rewrites the temporal-namespace header, so dropping
+	// incoming metadata here silently breaks both.
+	in := metadata.Pairs(
+		meta.NamespaceHeader, "orders",
+		temporalNamespaceHeader, "orders",
+		"authorization", "Bearer k3y",
+		"user-agent", "grpc-go/1.0",
+		"content-type", "application/grpc",
+		":authority", "127.0.0.1:7233",
+	)
+
+	out, ok := metadata.FromOutgoingContext(forwardContext(metadata.NewIncomingContext(t.Context(), in)))
+	require.True(t, ok, "expected forwardContext to install outgoing metadata")
+	require.Equal(t, []string{"orders"}, out.Get(meta.NamespaceHeader))
+	require.Equal(t, []string{"orders"}, out.Get(temporalNamespaceHeader))
+	require.Equal(t, []string{"Bearer k3y"}, out.Get("authorization"))
+
+	// Transport headers describe the inbound hop: gRPC sets its own on the
+	// outbound call and rejects a pseudo-header supplied as metadata.
+	for _, key := range transportHeaders {
+		require.Empty(t, out.Get(key), "expected %q to be stripped", key)
+	}
+}
+
+func TestForwardContextKeepsExistingOutgoingValue(t *testing.T) {
+	t.Parallel()
+
+	// An outgoing value already set for a key wins, so a caller-supplied header
+	// cannot displace one the proxy stamped itself.
+	ctx := metadata.NewIncomingContext(t.Context(), metadata.Pairs("authorization", "Bearer caller"))
+	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs("authorization", "Bearer upstream"))
+
+	out, ok := metadata.FromOutgoingContext(forwardContext(ctx))
+	require.True(t, ok)
+	require.Equal(t, []string{"Bearer upstream"}, out.Get("authorization"))
+}
+
+func TestForwardContextWithoutIncomingMetadata(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	require.Equal(t, ctx, forwardContext(ctx))
+}
+
+func TestNewForwarderValidation(t *testing.T) {
+	t.Parallel()
+
+	gate := services.NewAllowlist(services.Default())
+
+	tests := []struct {
+		name string
+		cc   grpc.ClientConnInterface
+		gate Gate
+		err  string
+	}{
+		{name: "nil client connection", gate: gate, err: "nil client connection"},
+		{name: "nil gate", cc: &testutil.ClientConn{}, err: "nil gate"},
+		{name: "both nil reports the connection first", err: "nil client connection"},
+		{name: "a connection and a gate is enough", cc: &testutil.ClientConn{}, gate: gate},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			fw, err := NewForwarder(tt.cc, tt.gate)
+			if tt.err != "" {
+				require.ErrorContains(t, err, tt.err)
+				require.Nil(t, fw)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, protoregistry.GlobalTypes, fw.types, "expected the global registry by default")
+		})
+	}
+}
+
+func TestWithProtoTypes(t *testing.T) {
+	t.Parallel()
+
+	custom := partialTypes{}
+
+	fw, err := NewForwarder(&testutil.ClientConn{}, services.NewAllowlist(services.Default()), WithProtoTypes(custom))
+	require.NoError(t, err)
+	require.Equal(t, custom, fw.types)
+
+	// A nil registry leaves the default in place rather than disabling resolution.
+	fw, err = NewForwarder(&testutil.ClientConn{}, services.NewAllowlist(services.Default()), WithProtoTypes(nil))
+	require.NoError(t, err)
+	require.Equal(t, protoregistry.GlobalTypes, fw.types)
+}
+
+func TestStatusError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		code codes.Code
+		msg  string
+	}{
+		{name: "nil stays nil", code: codes.OK},
+		{
+			name: "an error already carrying a status is forwarded verbatim",
+			err:  status.Error(codes.NotFound, "namespace not found"),
+			code: codes.NotFound,
+			msg:  "namespace not found",
+		},
+		{
+			name: "a raw cancellation maps to its status",
+			err:  context.Canceled,
+			code: codes.Canceled,
+		},
+		{
+			name: "a raw deadline maps to its status",
+			err:  context.DeadlineExceeded,
+			code: codes.DeadlineExceeded,
+		},
+		{
+			// io.EOF reaches here when a caller half-closes mid-request and carries no
+			// status of its own, so it must not surface as an opaque Unknown.
+			name: "io.EOF is reported as Internal naming the step",
+			err:  io.EOF,
+			code: codes.Internal,
+			msg:  "proxy: sending the response failed: EOF",
+		},
+		{
+			name: "anything else is reported as Internal naming the step",
+			err:  errors.New("boom"),
+			code: codes.Internal,
+			msg:  "proxy: sending the response failed: boom",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := statusError("sending the response failed", tt.err)
+			require.Equal(t, tt.code, status.Code(got))
+
+			if tt.msg == "" {
+				return
+			}
+
+			require.ErrorContains(t, got, tt.msg)
+		})
+	}
+}
+
+func TestResolveMethod(t *testing.T) {
+	t.Parallel()
+
+	const getSystemInfo = "/" + services.WorkflowService + "/GetSystemInfo"
+
+	tests := []struct {
+		name  string
+		types protoutil.Types
+		in    string
+		want  protoreflect.FullName
+	}{
+		{
+			name: "a resolvable method yields its descriptor",
+			in:   getSystemInfo,
+			want: services.WorkflowService + ".GetSystemInfo",
+		},
+		{name: "a name with no method to split off", in: "GetSystemInfo"},
+		{name: "a service that is not linked in", in: "/not.A.Service/Method"},
+		{name: "a method the service does not have", in: "/" + services.WorkflowService + "/NoSuchMethod"},
+		{
+			name:  "a request type missing from the registry",
+			types: missingTypes(msgName(&workflowservice.GetSystemInfoRequest{})),
+			in:    getSystemInfo,
+		},
+		{
+			name:  "a response type missing from the registry",
+			types: missingTypes(msgName(&workflowservice.GetSystemInfoResponse{})),
+			in:    getSystemInfo,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			fw, err := NewForwarder(&testutil.ClientConn{}, services.NewAllowlist(services.Default()), WithProtoTypes(tt.types))
+			require.NoError(t, err)
+
+			got := fw.resolveMethod(tt.in)
+			if tt.want == "" {
+				require.Nil(t, got)
+
+				return
+			}
+
+			require.NotNil(t, got)
+			require.Equal(t, tt.want, got.desc.FullName())
+		})
+	}
+}
+
+func TestLookupCachesResolvedMethods(t *testing.T) {
+	t.Parallel()
+
+	fw, err := NewForwarder(&testutil.ClientConn{}, services.NewAllowlist(services.Default()))
+	require.NoError(t, err)
+
+	const method = "/" + services.WorkflowService + "/GetSystemInfo"
+
+	first := fw.lookup(method)
+	require.NotNil(t, first)
+	require.Same(t, first, fw.lookup(method), "expected the second lookup to hit the cache")
+
+	// An unresolvable method is not cached, so a bad name cannot grow the map.
+	require.Nil(t, fw.lookup("/"+services.WorkflowService+"/NoSuchMethod"))
+	_, cached := fw.methods.Load("/" + services.WorkflowService + "/NoSuchMethod")
+	require.False(t, cached)
+}
+
+func TestHandleErrors(t *testing.T) {
+	t.Parallel()
+
+	const (
+		unaryMethod  = "/" + services.WorkflowService + "/GetSystemInfo"
+		streamMethod = "/" + services.Reflection + "/ServerReflectionInfo"
+	)
+
+	tests := []struct {
+		name     string
+		method   string
+		noStream bool
+		allowed  []string
+		conn     *testutil.ClientConn
+		ss       testutil.ServerStream
+		code     codes.Code
+		msg      string
+	}{
+		{
+			name:     "a context without a server transport stream",
+			noStream: true,
+			code:     codes.Internal,
+			msg:      "no server transport stream",
+		},
+		{
+			name:    "a service that is not on the allowlist",
+			method:  "/" + services.OperatorService + "/DeleteNamespace",
+			allowed: []string{services.WorkflowService},
+			code:    codes.Unimplemented,
+			msg:     "unknown service " + services.OperatorService,
+		},
+		{
+			name:    "a method the compiled descriptors do not have",
+			method:  "/" + services.WorkflowService + "/NoSuchMethod",
+			allowed: services.Default(),
+			code:    codes.Unimplemented,
+			msg:     "unknown method",
+		},
+		{
+			name:    "an upstream that rejects the unary call",
+			method:  unaryMethod,
+			allowed: services.Default(),
+			conn:    &testutil.ClientConn{InvokeErr: status.Error(codes.PermissionDenied, "denied")},
+			code:    codes.PermissionDenied,
+			msg:     "denied",
+		},
+		{
+			name:    "a caller that cannot receive the relayed header",
+			method:  unaryMethod,
+			allowed: services.Default(),
+			conn:    &testutil.ClientConn{Header: metadata.Pairs("x-upstream", "1")},
+			ss:      testutil.ServerStream{HeaderErr: errors.New("header refused")},
+			code:    codes.Internal,
+			msg:     "header refused",
+		},
+		{
+			name:    "a caller that cannot receive the response",
+			method:  unaryMethod,
+			allowed: services.Default(),
+			ss:      testutil.ServerStream{SendErr: errors.New("broken pipe")},
+			code:    codes.Internal,
+			msg:     "broken pipe",
+		},
+		{
+			name:    "an upstream stream that cannot be opened",
+			method:  streamMethod,
+			allowed: []string{services.Reflection},
+			conn:    &testutil.ClientConn{StreamErr: status.Error(codes.Unavailable, "upstream down")},
+			code:    codes.Unavailable,
+			msg:     "upstream down",
+		},
+		{
+			name:    "an upstream stream that fails before its header",
+			method:  streamMethod,
+			allowed: []string{services.Reflection},
+			conn:    &testutil.ClientConn{Stream: &testutil.ClientStream{HeaderErr: status.Error(codes.Aborted, "header failed")}},
+			ss:      testutil.ServerStream{RecvErr: io.EOF},
+			code:    codes.Aborted,
+			msg:     "header failed",
+		},
+		{
+			// The request pump reports first because the response pump is parked in
+			// RecvMsg, so this pins the mapping of a caller-side stream failure.
+			name:    "a caller whose request stream breaks",
+			method:  streamMethod,
+			allowed: []string{services.Reflection},
+			conn:    &testutil.ClientConn{Stream: &testutil.ClientStream{BlockRecv: make(chan struct{})}},
+			ss:      testutil.ServerStream{RecvErr: errors.New("caller vanished")},
+			code:    codes.Internal,
+			msg:     "caller vanished",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			conn := tt.conn
+			if conn == nil {
+				conn = &testutil.ClientConn{}
+			}
+
+			if cs, ok := conn.Stream.(*testutil.ClientStream); ok && cs.BlockRecv != nil {
+				t.Cleanup(func() { close(cs.BlockRecv) })
+			}
+
+			fw, err := NewForwarder(conn, services.NewAllowlist(tt.allowed))
+			require.NoError(t, err)
+
+			ss := tt.ss
+			ss.Ctx = t.Context()
+			if !tt.noStream {
+				ss.Ctx = grpc.NewContextWithServerTransportStream(ss.Ctx, testutil.ServerTransportStream{FullMethodName: tt.method})
+			}
+
+			err = fw.Handle(nil, ss)
+			require.Equal(t, tt.code, status.Code(err))
+			require.ErrorContains(t, err, tt.msg)
+		})
+	}
+}
+
+func TestStreamTreatsWrappedEOFAsHalfClose(t *testing.T) {
+	t.Parallel()
+
+	// The pumps forward whatever the streams hand back, so a wrapped io.EOF has to
+	// read as a clean end of stream. Comparing with == instead of errors.Is turns
+	// one into a forwarding failure, which the caller sees as Internal on an
+	// otherwise successful call.
+	wrapped := fmt.Errorf("transport closed: %w", io.EOF)
+
+	fw, err := NewForwarder(
+		&testutil.ClientConn{Stream: &testutil.ClientStream{RecvErr: wrapped}},
+		services.NewAllowlist([]string{services.Reflection}),
+	)
+	require.NoError(t, err)
+
+	ss := testutil.ServerStream{RecvErr: wrapped}
+	ss.Ctx = grpc.NewContextWithServerTransportStream(
+		t.Context(),
+		testutil.ServerTransportStream{FullMethodName: "/" + services.Reflection + "/ServerReflectionInfo"},
+	)
+
+	require.NoError(t, fw.Handle(nil, ss))
+}
+
+func TestPumpRequestsReportsFailures(t *testing.T) {
+	t.Parallel()
+
+	in := messageType(t, &workflowservice.GetSystemInfoRequest{})
+
+	tests := []struct {
+		name string
+		src  grpc.ServerStream
+		dst  grpc.ClientStream
+		want string
+	}{
+		{
+			name: "a clean half-close reports io.EOF",
+			src:  testutil.ServerStream{RecvErr: io.EOF},
+			want: io.EOF.Error(),
+		},
+		{
+			name: "a failed receive is reported",
+			src:  testutil.ServerStream{RecvErr: errors.New("recv failed")},
+			want: "recv failed",
+		},
+		{
+			name: "a failed send upstream is reported",
+			dst:  &testutil.ClientStream{SendErr: errors.New("send failed")},
+			want: "send failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// The side a case does not configure succeeds, rather than being a nil
+			// interface the pump would dereference.
+			src, dst := tt.src, tt.dst
+			if src == nil {
+				src = testutil.ServerStream{}
+			}
+
+			if dst == nil {
+				dst = &testutil.ClientStream{}
+			}
+
+			require.ErrorContains(t, <-pumpRequests(src, dst, in), tt.want)
+		})
+	}
+}
+
+func TestPumpResponsesReportsFailures(t *testing.T) {
+	t.Parallel()
+
+	out := messageType(t, &workflowservice.GetSystemInfoResponse{})
+
+	tests := []struct {
+		name string
+		src  grpc.ClientStream
+		dst  grpc.ServerStream
+		want string
+	}{
+		{
+			name: "a failed upstream header is reported",
+			src:  &testutil.ClientStream{HeaderErr: errors.New("header failed")},
+			want: "header failed",
+		},
+		{
+			name: "a header the caller refuses is reported",
+			dst:  testutil.ServerStream{HeaderErr: errors.New("send header failed")},
+			want: "send header failed",
+		},
+		{
+			name: "a clean completion reports io.EOF",
+			src:  &testutil.ClientStream{RecvErr: io.EOF},
+			want: io.EOF.Error(),
+		},
+		{
+			name: "a failed upstream receive is reported",
+			src:  &testutil.ClientStream{RecvErr: errors.New("recv failed")},
+			want: "recv failed",
+		},
+		{
+			name: "a response the caller refuses is reported",
+			dst:  testutil.ServerStream{SendErr: errors.New("send failed")},
+			want: "send failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// The side a case does not configure succeeds, rather than being a nil
+			// interface the pump would dereference.
+			src, dst := tt.src, tt.dst
+			if src == nil {
+				src = &testutil.ClientStream{}
+			}
+
+			if dst == nil {
+				dst = testutil.ServerStream{}
+			}
+
+			require.ErrorContains(t, <-pumpResponses(src, dst, out), tt.want)
+		})
+	}
+}
+
+func (p partialTypes) FindMessageByName(name protoreflect.FullName) (protoreflect.MessageType, error) {
+	if _, ok := p.missing[name]; ok {
+		return nil, protoregistry.NotFound
+	}
+
+	return protoregistry.GlobalTypes.FindMessageByName(name)
+}
+
+// missingTypes returns a registry that resolves everything except name.
+func missingTypes(name protoreflect.FullName) partialTypes {
+	return partialTypes{missing: map[protoreflect.FullName]struct{}{name: {}}}
+}
+
+// msgName returns m's fully qualified proto message name, derived from the
+// generated type so no literal can drift from the descriptors.
+func msgName(m proto.Message) protoreflect.FullName {
+	return m.ProtoReflect().Descriptor().FullName()
+}
+
+// messageType resolves the registered type for m, as the pumps do per frame.
+func messageType(t *testing.T, m proto.Message) protoreflect.MessageType {
+	t.Helper()
+
+	mt, err := protoregistry.GlobalTypes.FindMessageByName(msgName(m))
+	require.NoError(t, err)
+
+	return mt
+}

--- a/internal/proxy/forwarding_test.go
+++ b/internal/proxy/forwarding_test.go
@@ -1,0 +1,137 @@
+package proxy_test
+
+// These tests drive real requests through a real [proxy.Server] over its unix
+// socket, so they use only the exported surface and live in the external test
+// package. forward_test.go stays in package proxy for the unit tests that need
+// the forwarder's unexported internals.
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	workflowservice "go.temporal.io/api/workflowservice/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/reflection"
+	"google.golang.org/grpc/reflection/grpc_reflection_v1"
+	"google.golang.org/grpc/status"
+
+	"github.com/temporalio/temporal-proxy/internal/services"
+)
+
+// metadataStampingService is a fake WorkflowService upstream that sets a response
+// header and trailer, so a caller can tell whether the proxy relayed them.
+type metadataStampingService struct {
+	workflowservice.UnimplementedWorkflowServiceServer
+}
+
+func TestUnaryRelaysUpstreamHeaderAndTrailer(t *testing.T) {
+	t.Parallel()
+
+	// Invoke drops the upstream's response metadata unless asked for it, and the
+	// loss is invisible to a caller that does not read it, so this drives a real
+	// request through a real proxy and asserts both arrive.
+	addr := serveUpstream(t, func(s *grpc.Server) {
+		workflowservice.RegisterWorkflowServiceServer(s, &metadataStampingService{})
+	})
+	conn := startProxy(t, addr)
+
+	var header, trailer metadata.MD
+	_, err := workflowservice.NewWorkflowServiceClient(conn).GetSystemInfo(
+		t.Context(),
+		&workflowservice.GetSystemInfoRequest{},
+		grpc.Header(&header),
+		grpc.Trailer(&trailer),
+		grpc.WaitForReady(true),
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"hdr"}, header.Get("x-upstream-header"))
+	require.Equal(t, []string{"tlr"}, trailer.Get("x-upstream-trailer"))
+}
+
+func TestStreamForwardsBidiReflection(t *testing.T) {
+	t.Parallel()
+
+	// ServerReflectionInfo is the only streaming method across every forwardable
+	// service, so it is the only way to exercise the streaming path at all. The
+	// upstream is the sole reflection provider (the proxy's local server registers
+	// only the health service), so a response naming WorkflowService proves the
+	// stream reached it and came back.
+	addr := serveUpstream(t, func(s *grpc.Server) {
+		workflowservice.RegisterWorkflowServiceServer(s, &metadataStampingService{})
+		reflection.Register(s)
+	})
+	conn := startProxy(t, addr, services.Reflection)
+
+	stream, err := grpc_reflection_v1.NewServerReflectionClient(conn).ServerReflectionInfo(
+		t.Context(),
+		grpc.WaitForReady(true),
+	)
+	require.NoError(t, err)
+	require.NoError(t, stream.Send(&grpc_reflection_v1.ServerReflectionRequest{
+		MessageRequest: &grpc_reflection_v1.ServerReflectionRequest_ListServices{},
+	}))
+
+	resp, err := stream.Recv()
+	require.NoError(t, err)
+
+	var got []string
+	for _, svc := range resp.GetListServicesResponse().GetService() {
+		got = append(got, svc.GetName())
+	}
+
+	require.Contains(t, got, services.WorkflowService, "expected the upstream's services, not the proxy's")
+
+	// Half-close and drain, so the request pump reports a clean end of stream and
+	// the response pump completes rather than the test tearing the stream down.
+	require.NoError(t, stream.CloseSend())
+
+	_, err = stream.Recv()
+	require.ErrorIs(t, err, io.EOF)
+}
+
+func TestUnaryWithoutRequestMessageFails(t *testing.T) {
+	t.Parallel()
+
+	// A caller that half-closes without sending a request makes RecvMsg report
+	// io.EOF, which carries no gRPC status. Left unmapped it reaches the caller as
+	// an opaque Unknown, so this pins the mapping.
+	addr := serveUpstream(t, func(s *grpc.Server) {
+		workflowservice.RegisterWorkflowServiceServer(s, &metadataStampingService{})
+	})
+	conn := startProxy(t, addr)
+
+	// Driving a unary method as a raw stream is the only way to reach the proxy
+	// without sending a message; the generated client always sends one.
+	stream, err := conn.NewStream(
+		t.Context(),
+		&grpc.StreamDesc{ServerStreams: true, ClientStreams: true},
+		"/"+services.WorkflowService+"/GetSystemInfo",
+		grpc.WaitForReady(true),
+	)
+	require.NoError(t, err)
+	require.NoError(t, stream.CloseSend())
+
+	err = stream.RecvMsg(&workflowservice.GetSystemInfoResponse{})
+	require.Equal(t, codes.Internal, status.Code(err))
+	require.ErrorContains(t, err, "reading the request failed",
+		"expected the status to name the step that failed, not the request stream generally")
+}
+
+func (*metadataStampingService) GetSystemInfo(
+	ctx context.Context, _ *workflowservice.GetSystemInfoRequest,
+) (*workflowservice.GetSystemInfoResponse, error) {
+	if err := grpc.SetHeader(ctx, metadata.Pairs("x-upstream-header", "hdr")); err != nil {
+		return nil, err
+	}
+
+	if err := grpc.SetTrailer(ctx, metadata.Pairs("x-upstream-trailer", "tlr")); err != nil {
+		return nil, err
+	}
+
+	return &workflowservice.GetSystemInfoResponse{}, nil
+}

--- a/internal/proxy/fx.go
+++ b/internal/proxy/fx.go
@@ -12,6 +12,7 @@ import (
 	"github.com/temporalio/temporal-proxy/internal/config"
 	"github.com/temporalio/temporal-proxy/internal/metrics"
 	"github.com/temporalio/temporal-proxy/internal/protoutil"
+	"github.com/temporalio/temporal-proxy/internal/services"
 	"github.com/temporalio/temporal-proxy/internal/transport/connect"
 	"github.com/temporalio/temporal-proxy/pkg/crypto"
 	"github.com/temporalio/temporal-proxy/pkg/logger"
@@ -93,7 +94,12 @@ var Module = fx.Options(fx.Invoke(func(p ProxyParams) error {
 			opts = append(opts, WithLogger(p.Logger))
 		}
 
-		svr, err := New(up.Listen.HostPort, conn, opts...)
+		fw, err := NewForwarder(conn, p.Allowlist, WithProtoTypes(p.Types))
+		if err != nil {
+			return err
+		}
+
+		svr, err := New(up.Listen.HostPort, fw, opts...)
 		if err != nil {
 			return fmt.Errorf("failed to create proxy for upstream %q: %w", up.Name, err)
 		}
@@ -143,10 +149,11 @@ var Module = fx.Options(fx.Invoke(func(p ProxyParams) error {
 }))
 
 // ProxyParams collects the fx-provided dependencies needed to construct and run
-// the proxy [Server]. Context, Config, Translator, and Pool are required;
-// Logger is optional and falls back to the default used by [New] when not
-// supplied. [protoutil.Module] provides the Translator and [connect.Module]
-// provides the Pool in the assembled application.
+// the proxy [Server]. Context, Config, Translator, Pool, and Allowlist are
+// required. Logger falls back to the default used by [New] and Types to the
+// global proto registry, so neither has to be supplied. [protoutil.Module]
+// provides the Translator, [connect.Module] the Pool, and [config.Module] the
+// Allowlist in the assembled application.
 type ProxyParams struct {
 	fx.In
 	Lifecycle  fx.Lifecycle
@@ -159,9 +166,11 @@ type ProxyParams struct {
 	Pool       *connect.Pool
 	Vault      *crypto.Vault
 	Factory    *metrics.Factory
+	Allowlist  services.Allowlist
 
 	// Optional values
-	Logger logger.Logger `optional:"true"`
+	Logger logger.Logger   `optional:"true"`
+	Types  protoutil.Types `optional:"true"`
 }
 
 // upstreamResolver builds the [connect.Resolver] for an upstream. When neither

--- a/internal/proxy/fx_test.go
+++ b/internal/proxy/fx_test.go
@@ -257,24 +257,52 @@ func TestModuleRequiresTranslator(t *testing.T) {
 		fx.Provide(func() *metrics.Factory { return metrics.New("tmprl_proxy", promauto.With(prometheus.NewRegistry())) }),
 		connect.Module,
 		proxy.Module,
+		fx.Provide(config.NewAllowlist),
 		fx.NopLogger,
 	)
 
-	require.Error(t, app.Err())
+	// Naming the missing type keeps this from passing for any other absent
+	// dependency, which is how it would silently stop testing the Translator.
+	require.ErrorContains(t, app.Err(), "protoutil.Translator")
 }
 
-// serveUpstream starts a plaintext gRPC server on a loopback port and returns
-// its address, for use as an upstream hostPort. A static upstream's connection
-// is opened on start, so an upstream pointing at nothing fails the lifecycle.
-// The ephemeral port also keeps the proxy's derived socket path unique across
-// parallel tests.
-func serveUpstream(t *testing.T) string {
+func TestModuleRequiresAllowlist(t *testing.T) {
+	t.Parallel()
+
+	// Deliberately without config.NewAllowlist: the gate is required so missing
+	// wiring fails here, rather than degrading to a proxy that forwards nothing.
+	app := fx.New(
+		fx.Supply(fx.Annotate(t.Context(), fx.As(new(context.Context)))),
+		fx.Supply(&config.Config{
+			Upstreams: []config.Upstream{{Name: "primary", Listen: config.ListenConfig{HostPort: "127.0.0.1:47244"}}},
+		}),
+		fx.Provide(func() *crypto.Vault { return nil }),
+		fx.Provide(func() *metrics.Factory { return metrics.New("tmprl_proxy", promauto.With(prometheus.NewRegistry())) }),
+		connect.Module,
+		protoutil.Module,
+		proxy.Module,
+		fx.NopLogger,
+	)
+
+	require.ErrorContains(t, app.Err(), "services.Allowlist")
+}
+
+// serveUpstream starts a plaintext gRPC server on a loopback port, registers any
+// services supplied, and returns its address for use as an upstream hostPort. A
+// static upstream's connection is opened on start, so an upstream pointing at
+// nothing fails the lifecycle. The ephemeral port also keeps the proxy's derived
+// socket path unique across parallel tests.
+func serveUpstream(t *testing.T, register ...func(*grpc.Server)) string {
 	t.Helper()
 
 	lis, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
 	svr := grpc.NewServer()
+	for _, reg := range register {
+		reg(svr)
+	}
+
 	go func() { _ = svr.Serve(lis) }()
 	t.Cleanup(svr.Stop)
 
@@ -309,6 +337,7 @@ func newProxyApp(t *testing.T, cfg *config.Config, opts ...fx.Option) *fx.App {
 		connect.Module,
 		protoutil.Module,
 		proxy.Module,
+		fx.Provide(config.NewAllowlist),
 		fx.NopLogger,
 	}
 

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -7,10 +7,6 @@ import (
 	"net"
 	"os"
 
-	"go.temporal.io/api/proxy"
-	"go.temporal.io/api/workflowservice/v1"
-	"google.golang.org/grpc"
-
 	"github.com/temporalio/temporal-proxy/internal/server"
 	"github.com/temporalio/temporal-proxy/internal/transport/creds"
 	"github.com/temporalio/temporal-proxy/internal/transport/socket"
@@ -36,28 +32,21 @@ type (
 	Option func(*Options)
 )
 
-// New constructs a Server that forwards WorkflowService traffic to the
-// upstream reachable through cc. The local listener is a unix socket whose
-// path is derived from hostPort. cc is typically a resolvingConn; the
-// connection(s) it uses are owned by the shared pool, not by this Server.
-func New(hostPort string, cc grpc.ClientConnInterface, opts ...Option) (*Server, error) {
+// New constructs a Server that hands every inbound method to fw, which forwards
+// it to the upstream fw was built against. The local listener is a unix socket
+// whose path is derived from hostPort. The connection(s) fw forwards over are
+// owned by the shared pool, not by this Server.
+func New(hostPort string, fw *Forwarder, opts ...Option) (*Server, error) {
 	pops := &Options{logger: logger.Default()}
 	for _, opt := range opts {
 		opt(pops)
-	}
-
-	wfs, err := proxy.NewWorkflowServiceProxyServer(workflowProxyOptions(cc))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create workflowservice proxy: %w", err)
 	}
 
 	svr, err := server.New(
 		// NB: Hosting on local unix port, no need for TLS here.
 		server.WithCredentials(creds.NewListener(creds.Insecure())),
 		server.WithLogger(pops.logger),
-		server.WithService(func(sr grpc.ServiceRegistrar) {
-			workflowservice.RegisterWorkflowServiceServer(sr, wfs)
-		}),
+		server.WithUnknownServiceHandler(fw.Handle),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create proxy: %s, %w", hostPort, err)
@@ -110,13 +99,4 @@ func (s *Server) Stop(ctx context.Context) error {
 	}
 
 	return nil
-}
-
-// workflowProxyOptions builds the options for the WorkflowService proxy
-// server backed by cc. DisableHeaderForwarding is intentionally left false:
-// the upstream proxy must forward incoming metadata (including the
-// router-stamped namespace) onto the outbound call, since templated upstream
-// resolution and namespace translation both depend on it.
-func workflowProxyOptions(cc grpc.ClientConnInterface) proxy.WorkflowServiceProxyOptions {
-	return proxy.WorkflowServiceProxyOptions{Client: workflowservice.NewWorkflowServiceClient(cc)}
 }

--- a/internal/proxy/server_test.go
+++ b/internal/proxy/server_test.go
@@ -2,6 +2,7 @@ package proxy_test
 
 import (
 	"context"
+	"net"
 	"os"
 	"path/filepath"
 	"testing"
@@ -13,6 +14,7 @@ import (
 	"google.golang.org/grpc/health/grpc_health_v1"
 
 	"github.com/temporalio/temporal-proxy/internal/proxy"
+	"github.com/temporalio/temporal-proxy/internal/services"
 	"github.com/temporalio/temporal-proxy/internal/transport/socket"
 	"github.com/temporalio/temporal-proxy/pkg/logger"
 )
@@ -23,7 +25,7 @@ func TestNew(t *testing.T) {
 	t.Run("returns a server with default options", func(t *testing.T) {
 		t.Parallel()
 
-		svr, err := proxy.New("127.0.0.1:7233", upstreamConn(t, "127.0.0.1:7233"))
+		svr, err := proxy.New("127.0.0.1:7233", forwarder(t, "127.0.0.1:7233"))
 		require.NoError(t, err)
 		require.NotNil(t, svr)
 	})
@@ -38,7 +40,7 @@ func TestServerStartAndStop(t *testing.T) {
 	const upstream = "127.0.0.1:17233"
 
 	log := logger.NewTestLogger()
-	svr, err := proxy.New(upstream, upstreamConn(t, upstream), proxy.WithLogger(log))
+	svr, err := proxy.New(upstream, forwarder(t, upstream), proxy.WithLogger(log))
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(t.Context())
@@ -77,17 +79,32 @@ func TestServerStartAndStop(t *testing.T) {
 func TestStartRemovesStaleSocket(t *testing.T) {
 	t.Parallel()
 
-	const upstream = "127.0.0.1:27233"
+	// An ephemeral port gives this test its own socket path. A fixed one is shared
+	// with every past run on the machine, so a socket left behind by a run that was
+	// killed before it could shut down would occupy the path and make planting the
+	// stale socket below fail with "operation not supported on socket".
+	upstream := deadUpstream(t)
 
 	path, err := socket.UnixPath(upstream)
 	require.NoError(t, err)
 
-	// Leave a file behind where the listener wants to bind. Without removal the
-	// bind would fail with "address already in use" and the Check never succeeds.
-	require.NoError(t, os.WriteFile(path, []byte("stale"), 0o600))
-	t.Cleanup(func() { _ = os.Remove(path) })
+	// Clear the path first: a run killed before its cleanup leaves its own socket
+	// or directory behind, and planting over either fails.
+	require.NoError(t, os.RemoveAll(path))
 
-	svr, err := proxy.New(upstream, upstreamConn(t, upstream))
+	// Leave a real socket behind, which is what a killed process leaves. Without
+	// removal the bind would fail with "address already in use" and the Check never
+	// succeeds.
+	stale, err := net.Listen("unix", path)
+	require.NoError(t, err)
+	unix, ok := stale.(*net.UnixListener)
+	require.True(t, ok)
+	unix.SetUnlinkOnClose(false)
+	require.NoError(t, unix.Close())
+	t.Cleanup(func() { _ = os.Remove(path) })
+	require.FileExists(t, path, "expected a stale socket to be planted")
+
+	svr, err := proxy.New(upstream, forwarder(t, upstream))
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(t.Context())
@@ -116,10 +133,15 @@ func TestStartRemovesStaleSocket(t *testing.T) {
 func TestListenReturnsErrorWhenStaleSocketCannotBeRemoved(t *testing.T) {
 	t.Parallel()
 
-	const upstream = "127.0.0.1:37233"
+	// As above, an ephemeral port keeps the path this test's own, so a leftover
+	// socket cannot make the Mkdir below fail with "file exists".
+	upstream := deadUpstream(t)
 
 	path, err := socket.UnixPath(upstream)
 	require.NoError(t, err)
+
+	// Clear the path first, as above.
+	require.NoError(t, os.RemoveAll(path))
 
 	// A non-empty directory at the socket path makes os.Remove fail, so Listen
 	// returns before it ever binds.
@@ -127,7 +149,7 @@ func TestListenReturnsErrorWhenStaleSocketCannotBeRemoved(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(path, "child"), nil, 0o600))
 	t.Cleanup(func() { _ = os.RemoveAll(path) })
 
-	svr, err := proxy.New(upstream, upstreamConn(t, upstream))
+	svr, err := proxy.New(upstream, forwarder(t, upstream))
 	require.NoError(t, err)
 
 	_, err = svr.Listen(t.Context())
@@ -135,16 +157,46 @@ func TestListenReturnsErrorWhenStaleSocketCannotBeRemoved(t *testing.T) {
 	require.ErrorContains(t, err, "failed to remove stale socket")
 }
 
-// upstreamConn returns a grpc.ClientConnInterface for New's cc argument. gRPC
-// dials lazily, so this never opens a socket to upstream; the tests in this
-// file never make an outbound RPC through it (they only exercise the local
-// unix listener), so a plain client conn stands in for the pool-backed
-// resolvingConn used in production.
-func upstreamConn(t *testing.T, upstream string) grpc.ClientConnInterface {
+// forwarder returns the Forwarder for New's fw argument, allowing the services
+// named or the default set when none are. gRPC dials lazily, so the underlying
+// client conn opens no socket to upstream until a request needs it, which lets
+// the tests that only exercise the local unix listener pass an upstream that was
+// never started. A plain client conn stands in for the pool-backed resolvingConn
+// used in production.
+func forwarder(t *testing.T, upstream string, allowed ...string) *proxy.Forwarder {
 	t.Helper()
+
+	if len(allowed) == 0 {
+		allowed = services.Default()
+	}
 
 	conn, err := grpc.NewClient(upstream, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	fw, err := proxy.NewForwarder(conn, services.NewAllowlist(allowed))
+	require.NoError(t, err)
+
+	return fw
+}
+
+// startProxy runs a proxy forwarding the named services to upstream and returns a
+// client connection to its local unix socket. Stop takes a fresh context because
+// the test's own is already cancelled by the time cleanups run.
+func startProxy(t *testing.T, upstream string, allowed ...string) *grpc.ClientConn {
+	t.Helper()
+
+	svr, err := proxy.New(upstream, forwarder(t, upstream, allowed...))
+	require.NoError(t, err)
+
+	ctx := t.Context()
+	lis, err := svr.Listen(ctx)
+	require.NoError(t, err)
+
+	go func() { _ = svr.Start(ctx, lis) }()
+	t.Cleanup(func() { _ = svr.Stop(context.Background()) })
+
+	conn := dialUnix(t, upstream)
 	t.Cleanup(func() { _ = conn.Close() })
 
 	return conn

--- a/internal/proxy/translation_test.go
+++ b/internal/proxy/translation_test.go
@@ -19,6 +19,7 @@ import (
 	"google.golang.org/protobuf/reflect/protoregistry"
 
 	"github.com/temporalio/temporal-proxy/internal/protoutil"
+	"github.com/temporalio/temporal-proxy/internal/services"
 	"github.com/temporalio/temporal-proxy/internal/transport/socket"
 )
 
@@ -36,15 +37,6 @@ type (
 		recv proto.Message
 	}
 )
-
-func TestWorkflowProxyOptionsForwardsHeaders(t *testing.T) {
-	t.Parallel()
-
-	// Guard: New must not disable header forwarding, or the upstream proxy would
-	// drop the router-stamped namespace header and templated resolution would
-	// break.
-	require.False(t, workflowProxyOptions(nil).DisableHeaderForwarding)
-}
 
 func TestUnaryClientInterceptorTranslatesBothDirections(t *testing.T) {
 	t.Parallel()
@@ -157,7 +149,10 @@ func TestOutboundNamespaceTranslation(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = cc.Close() })
 
-	svr, err := New(lis.Addr().String(), cc)
+	fw, err := NewForwarder(cc, services.NewAllowlist(services.Default()))
+	require.NoError(t, err)
+
+	svr, err := New(lis.Addr().String(), fw)
 	require.NoError(t, err)
 
 	ctx := t.Context()

--- a/internal/router/fx.go
+++ b/internal/router/fx.go
@@ -28,13 +28,11 @@ import (
 // handler dials one connection per configured upstream from the shared
 // [connect.Pool] (each unix socket path derived from that upstream's
 // host:port), then routes every request to an upstream by matching it with the
-// Mux. Requests are admitted through a [Gate] built from the configured
-// allowlist before any of that happens.
+// Mux. Requests are admitted through a [Gate] adapted from the allowlist
+// [config.Module] provides before any of that happens.
 var Module = fx.Options(fx.Provide(
 	Codec,
-	func(c *config.Config) Gate {
-		return services.NewAllowlist(c.AllowedServices)
-	},
+	func(a services.Allowlist) Gate { return a },
 	func(p RouterParams) (grpc.StreamHandler, error) {
 		conns := make(map[string]*grpc.ClientConn, len(p.Config.Upstreams))
 		for i := range p.Config.Upstreams {

--- a/internal/router/fx_test.go
+++ b/internal/router/fx_test.go
@@ -46,6 +46,7 @@ func TestModule(t *testing.T) {
 			connect.Module,
 			protoutil.Module,
 			router.Module,
+			fx.Provide(config.NewAllowlist),
 			fx.Populate(&codec, &handler),
 			fx.NopLogger,
 		)
@@ -115,6 +116,7 @@ func TestModule(t *testing.T) {
 			connect.Module,
 			protoutil.Module,
 			router.Module,
+			fx.Provide(config.NewAllowlist),
 			fx.Populate(&codec, &handler),
 			fx.NopLogger,
 		)

--- a/internal/router/handler.go
+++ b/internal/router/handler.go
@@ -2,6 +2,7 @@ package router
 
 import (
 	"context"
+	"errors"
 	"io"
 	"maps"
 
@@ -83,7 +84,7 @@ func Handler(d Director, r Reflector, g Gate, rep *Reporter) grpc.StreamHandler 
 		// sending a message (namespace is empty).
 		first := &frame{}
 		firstErr := serverStream.RecvMsg(first)
-		eof := firstErr == io.EOF
+		eof := errors.Is(firstErr, io.EOF)
 		if firstErr != nil && !eof {
 			return StatusError(firstErr)
 		}
@@ -131,7 +132,7 @@ func Handler(d Director, r Reflector, g Gate, rep *Reporter) grpc.StreamHandler 
 		for range 2 {
 			select {
 			case err := <-reqErr:
-				if err == io.EOF {
+				if errors.Is(err, io.EOF) {
 					_ = stream.CloseSend()
 					continue
 				}
@@ -140,7 +141,7 @@ func Handler(d Director, r Reflector, g Gate, rep *Reporter) grpc.StreamHandler 
 				return StatusError(err)
 			case err := <-respErr:
 				serverStream.SetTrailer(stream.Trailer())
-				if err != io.EOF {
+				if !errors.Is(err, io.EOF) {
 					return err
 				}
 

--- a/pkg/testutil/rpc.go
+++ b/pkg/testutil/rpc.go
@@ -1,0 +1,140 @@
+package testutil
+
+import (
+	"context"
+	"io"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+type (
+	// ClientConn is a [google.golang.org/grpc.ClientConnInterface] that succeeds or
+	// fails as configured, so a test can drive an outbound call's failure modes
+	// without standing up an upstream. The zero value succeeds and yields no
+	// response metadata.
+	ClientConn struct {
+		InvokeErr error
+		StreamErr error
+		Stream    grpc.ClientStream
+		Header    metadata.MD
+		Trailer   metadata.MD
+	}
+
+	// ClientStream is a [google.golang.org/grpc.ClientStream] whose steps fail as
+	// configured. When BlockRecv is non-nil, RecvMsg waits on it and then reports
+	// io.EOF, which lets a test park the stream and control which of two concurrent
+	// readers reports first.
+	ClientStream struct {
+		RecvErr   error
+		SendErr   error
+		HeaderErr error
+		BlockRecv chan struct{}
+	}
+
+	// ServerStream is a [google.golang.org/grpc.ServerStream] whose steps fail as
+	// configured. A nil RecvErr means a request message arrived.
+	ServerStream struct {
+		Ctx       context.Context
+		RecvErr   error
+		SendErr   error
+		HeaderErr error
+	}
+
+	// ServerTransportStream carries the full method name a handler reads from its
+	// request context, for installing via
+	// [google.golang.org/grpc.NewContextWithServerTransportStream].
+	ServerTransportStream struct {
+		FullMethodName string
+	}
+)
+
+// Invoke reports InvokeErr, having first filled the caller's header and trailer
+// the way a real upstream would, so code that relays response metadata has
+// something to pass along. Call options other than
+// [google.golang.org/grpc.Header] and [google.golang.org/grpc.Trailer] are
+// ignored.
+func (c *ClientConn) Invoke(_ context.Context, _ string, _, _ any, opts ...grpc.CallOption) error {
+	for _, opt := range opts {
+		switch o := opt.(type) {
+		case grpc.HeaderCallOption:
+			*o.HeaderAddr = c.Header
+		case grpc.TrailerCallOption:
+			*o.TrailerAddr = c.Trailer
+		}
+	}
+
+	return c.InvokeErr
+}
+
+// NewStream reports StreamErr when set, and otherwise returns the configured
+// Stream, which may be nil for a caller that never reads it.
+func (c *ClientConn) NewStream(
+	context.Context,
+	*grpc.StreamDesc,
+	string,
+	...grpc.CallOption,
+) (grpc.ClientStream, error) {
+	if c.StreamErr != nil {
+		return nil, c.StreamErr
+	}
+
+	return c.Stream, nil
+}
+
+// Header reports HeaderErr and never returns metadata.
+func (s *ClientStream) Header() (metadata.MD, error) { return nil, s.HeaderErr }
+
+// Trailer returns no metadata.
+func (*ClientStream) Trailer() metadata.MD { return nil }
+
+// CloseSend always succeeds.
+func (*ClientStream) CloseSend() error { return nil }
+
+// Context returns a background context.
+func (*ClientStream) Context() context.Context { return context.Background() }
+
+// SendMsg reports SendErr.
+func (s *ClientStream) SendMsg(any) error { return s.SendErr }
+
+// RecvMsg waits on BlockRecv and reports io.EOF when one is configured, and
+// otherwise reports RecvErr immediately.
+func (s *ClientStream) RecvMsg(any) error {
+	if s.BlockRecv != nil {
+		<-s.BlockRecv
+
+		return io.EOF
+	}
+
+	return s.RecvErr
+}
+
+// Context returns Ctx.
+func (s ServerStream) Context() context.Context { return s.Ctx }
+
+// SetHeader reports HeaderErr.
+func (s ServerStream) SetHeader(metadata.MD) error { return s.HeaderErr }
+
+// SendHeader reports HeaderErr.
+func (s ServerStream) SendHeader(metadata.MD) error { return s.HeaderErr }
+
+// SetTrailer discards the trailer.
+func (ServerStream) SetTrailer(metadata.MD) {}
+
+// SendMsg reports SendErr.
+func (s ServerStream) SendMsg(any) error { return s.SendErr }
+
+// RecvMsg reports RecvErr.
+func (s ServerStream) RecvMsg(any) error { return s.RecvErr }
+
+// Method returns FullMethodName.
+func (s ServerTransportStream) Method() string { return s.FullMethodName }
+
+// SetHeader always succeeds.
+func (ServerTransportStream) SetHeader(metadata.MD) error { return nil }
+
+// SendHeader always succeeds.
+func (ServerTransportStream) SendHeader(metadata.MD) error { return nil }
+
+// SetTrailer always succeeds.
+func (ServerTransportStream) SetTrailer(metadata.MD) error { return nil }

--- a/pkg/testutil/rpc_test.go
+++ b/pkg/testutil/rpc_test.go
@@ -1,0 +1,180 @@
+package testutil_test
+
+import (
+	"errors"
+	"io"
+	"testing"
+	"testing/synctest"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+
+	"github.com/temporalio/temporal-proxy/pkg/testutil"
+)
+
+func TestClientConnInvoke(t *testing.T) {
+	t.Parallel()
+
+	t.Run("fills the header and trailer the caller asked for", func(t *testing.T) {
+		t.Parallel()
+
+		cc := &testutil.ClientConn{
+			Header:  metadata.Pairs("x-header", "h"),
+			Trailer: metadata.Pairs("x-trailer", "t"),
+		}
+
+		var header, trailer metadata.MD
+		err := cc.Invoke(t.Context(), "/pkg.Svc/M", nil, nil, grpc.Header(&header), grpc.Trailer(&trailer))
+		require.NoError(t, err)
+		require.Equal(t, []string{"h"}, header.Get("x-header"))
+		require.Equal(t, []string{"t"}, trailer.Get("x-trailer"))
+	})
+
+	t.Run("ignores call options it does not fill", func(t *testing.T) {
+		t.Parallel()
+
+		cc := &testutil.ClientConn{}
+		require.NoError(t, cc.Invoke(t.Context(), "/pkg.Svc/M", nil, nil, grpc.WaitForReady(true)))
+	})
+
+	t.Run("reports the configured error", func(t *testing.T) {
+		t.Parallel()
+
+		want := errors.New("upstream refused")
+		cc := &testutil.ClientConn{InvokeErr: want}
+		require.ErrorIs(t, cc.Invoke(t.Context(), "/pkg.Svc/M", nil, nil), want)
+	})
+}
+
+func TestClientConnNewStream(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns the configured stream", func(t *testing.T) {
+		t.Parallel()
+
+		want := &testutil.ClientStream{}
+		cc := &testutil.ClientConn{Stream: want}
+
+		got, err := cc.NewStream(t.Context(), &grpc.StreamDesc{}, "/pkg.Svc/M")
+		require.NoError(t, err)
+		require.Same(t, want, got)
+	})
+
+	t.Run("reports the configured error instead of a stream", func(t *testing.T) {
+		t.Parallel()
+
+		want := errors.New("cannot open")
+		cc := &testutil.ClientConn{StreamErr: want, Stream: &testutil.ClientStream{}}
+
+		got, err := cc.NewStream(t.Context(), &grpc.StreamDesc{}, "/pkg.Svc/M")
+		require.ErrorIs(t, err, want)
+		require.Nil(t, got)
+	})
+}
+
+func TestClientStream(t *testing.T) {
+	t.Parallel()
+
+	t.Run("reports the configured errors", func(t *testing.T) {
+		t.Parallel()
+
+		headerErr := errors.New("header")
+		sendErr := errors.New("send")
+		recvErr := errors.New("recv")
+		cs := &testutil.ClientStream{HeaderErr: headerErr, SendErr: sendErr, RecvErr: recvErr}
+
+		md, err := cs.Header()
+		require.Nil(t, md)
+		require.ErrorIs(t, err, headerErr)
+		require.ErrorIs(t, cs.SendMsg(nil), sendErr)
+		require.ErrorIs(t, cs.RecvMsg(nil), recvErr)
+	})
+
+	t.Run("the zero value succeeds and carries no metadata", func(t *testing.T) {
+		t.Parallel()
+
+		cs := &testutil.ClientStream{}
+
+		md, err := cs.Header()
+		require.NoError(t, err)
+		require.Nil(t, md)
+		require.Nil(t, cs.Trailer())
+		require.NoError(t, cs.CloseSend())
+		require.NoError(t, cs.SendMsg(nil))
+		require.NoError(t, cs.RecvMsg(nil))
+		require.NotNil(t, cs.Context())
+	})
+}
+
+func TestClientStreamBlockRecv(t *testing.T) {
+	t.Parallel()
+
+	// The blocking behaviour is the point of BlockRecv: a caller uses it to park
+	// one reader so a concurrent one reports first. Assert it really parks, rather
+	// than trusting a sleep to have been long enough.
+	synctest.Test(t, func(t *testing.T) {
+		release := make(chan struct{})
+		cs := &testutil.ClientStream{BlockRecv: release, RecvErr: errors.New("never returned")}
+
+		got := make(chan error, 1)
+		go func() { got <- cs.RecvMsg(nil) }()
+
+		// Wait for every goroutine in the bubble to block; RecvMsg is still parked.
+		synctest.Wait()
+		require.Empty(t, got, "expected RecvMsg to block until BlockRecv is closed")
+
+		// Releasing reports a clean end of stream, not the configured RecvErr.
+		close(release)
+		synctest.Wait()
+		require.ErrorIs(t, <-got, io.EOF)
+	})
+}
+
+func TestServerStream(t *testing.T) {
+	t.Parallel()
+
+	t.Run("reports the configured errors", func(t *testing.T) {
+		t.Parallel()
+
+		headerErr := errors.New("header")
+		sendErr := errors.New("send")
+		recvErr := errors.New("recv")
+		ss := testutil.ServerStream{HeaderErr: headerErr, SendErr: sendErr, RecvErr: recvErr}
+
+		require.ErrorIs(t, ss.SetHeader(nil), headerErr)
+		require.ErrorIs(t, ss.SendHeader(nil), headerErr)
+		require.ErrorIs(t, ss.SendMsg(nil), sendErr)
+		require.ErrorIs(t, ss.RecvMsg(nil), recvErr)
+	})
+
+	t.Run("carries the configured context and discards trailers", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		ss := testutil.ServerStream{Ctx: ctx}
+
+		require.Equal(t, ctx, ss.Context())
+		require.NoError(t, ss.SetHeader(nil))
+		require.NoError(t, ss.SendHeader(nil))
+		require.NoError(t, ss.SendMsg(nil))
+		require.NoError(t, ss.RecvMsg(nil))
+
+		ss.SetTrailer(metadata.Pairs("x-trailer", "t"))
+	})
+}
+
+func TestServerTransportStream(t *testing.T) {
+	t.Parallel()
+
+	sts := testutil.ServerTransportStream{FullMethodName: "/pkg.Svc/M"}
+
+	require.Equal(t, "/pkg.Svc/M", sts.Method())
+	require.NoError(t, sts.SetHeader(nil))
+	require.NoError(t, sts.SendHeader(nil))
+	require.NoError(t, sts.SetTrailer(nil))
+
+	// It satisfies the interface gRPC installs into a request context.
+	ctx := grpc.NewContextWithServerTransportStream(t.Context(), sts)
+	require.Equal(t, "/pkg.Svc/M", grpc.ServerTransportStreamFromContext(ctx).Method())
+}


### PR DESCRIPTION
The proxy hop served only WorkflowService, through the generated proxy server from go.temporal.io/api. The router already admits every service allowedServices names, so an allow-listed OperatorService or reflection request reached the proxy's socket and came back Unimplemented, and widening that meant registering another generated proxy per service.

Replace the registered WorkflowService implementation with a Forwarder installed as the server's unknown-service handler. It admits any method whose service the allowlist permits and types each request and response from the proto registry. The typing is intentional since namespace translation and payload encryption are client interceptors on the upstream connection and operate on proto.Message, so the router's opaque frame passthrough would silently skip both at this hop. The rub is that only methods present in the compiled descriptors can be forwarded, which is the same limitation the generated proxy carried.