### PR TITLE
[services]: Name the allowlist once

### DIFF
--- a/internal/config/fx.go
+++ b/internal/config/fx.go
@@ -6,7 +6,7 @@ var ConfigFileTag = fx.ResultTags(`name:"configFile"`)
 
 // Module is an fx module that provides *Config by loading the file path supplied
 // as the named value "configFile", along with the allowlist derived from it via
-// [NewAllowlist], which is the single owner of how the forwarding gate is built.
+// [NewAllowlist], which is the single owner of how the allowlist is built.
 var Module = fx.Option(fx.Provide(
 	func(p ConfigParams) (*Config, error) {
 		return LoadFile(p.File)

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -31,20 +31,13 @@ type (
 	// Resolved methods are cached, and a Forwarder is safe for concurrent use.
 	Forwarder struct {
 		cc      grpc.ClientConnInterface
-		gate    Gate
+		allowed services.Allowlist
 		methods sync.Map // fullName -> *methodInfo
 		types   protoutil.Types
 	}
 
 	// ForwarderOption configures a [Forwarder] at construction time.
 	ForwarderOption func(*Forwarder)
-
-	// Gate reports whether the proxy will forward the named service. Allows
-	// receives a service full name, never a full method; the assembled application
-	// passes the allowlist built from configuration.
-	Gate interface {
-		Allows(string) bool
-	}
 
 	// methodInfo is the resolved descriptor and message types for one full method.
 	methodInfo struct {
@@ -55,21 +48,21 @@ type (
 )
 
 // NewForwarder builds a Forwarder that forwards over cc every method belonging
-// to a service g admits. It fails when cc or g is nil. By default methods are
+// to a service a admits. It fails when cc or a is nil. By default methods are
 // typed against the global proto registry; use [WithProtoTypes] to override it.
-func NewForwarder(cc grpc.ClientConnInterface, g Gate, opts ...ForwarderOption) (*Forwarder, error) {
+func NewForwarder(cc grpc.ClientConnInterface, a services.Allowlist, opts ...ForwarderOption) (*Forwarder, error) {
 	if cc == nil {
 		return nil, fmt.Errorf("proxy: nil client connection passed to forwarder")
 	}
 
-	if g == nil {
-		return nil, fmt.Errorf("proxy: nil gate passed to forwarder")
+	if a == nil {
+		return nil, fmt.Errorf("proxy: nil allowlist passed to forwarder")
 	}
 
 	f := &Forwarder{
-		cc:    cc,
-		gate:  g,
-		types: protoregistry.GlobalTypes,
+		cc:      cc,
+		allowed: a,
+		types:   protoregistry.GlobalTypes,
 	}
 
 	for _, opt := range opts {
@@ -91,10 +84,10 @@ func WithProtoTypes(t protoutil.Types) ForwarderOption {
 
 // Handle forwards one stream to the upstream, and suits
 // [google.golang.org/grpc.UnknownServiceHandler]. A method whose service the
-// [Gate] does not admit is rejected with Unimplemented before any upstream work,
-// so the proxy answers as a server that does not implement it rather than
-// revealing that an upstream might. Only methods present in the compiled
-// descriptors can be forwarded; anything else is Unimplemented too.
+// [services.Allowlist] does not admit is rejected with Unimplemented before any
+// upstream work, so the proxy answers as a server that does not implement it
+// rather than revealing that an upstream might. Only methods present in the
+// compiled descriptors can be forwarded; anything else is Unimplemented too.
 func (f *Forwarder) Handle(_ any, ss grpc.ServerStream) error {
 	ctx := ss.Context()
 	method, err := rpc.FullMethod(ctx)
@@ -102,7 +95,7 @@ func (f *Forwarder) Handle(_ any, ss grpc.ServerStream) error {
 		return err
 	}
 
-	if service := rpc.Service(method); !f.gate.Allows(service) {
+	if service := rpc.Service(method); !f.allowed.Allows(service) {
 		return status.Errorf(codes.Unimplemented, "unknown service %s", service)
 	}
 

--- a/internal/proxy/forward_test.go
+++ b/internal/proxy/forward_test.go
@@ -82,25 +82,25 @@ func TestForwardContextWithoutIncomingMetadata(t *testing.T) {
 func TestNewForwarderValidation(t *testing.T) {
 	t.Parallel()
 
-	gate := services.NewAllowlist(services.Default())
+	allowed := services.NewAllowlist(services.Default())
 
 	tests := []struct {
-		name string
-		cc   grpc.ClientConnInterface
-		gate Gate
-		err  string
+		name    string
+		cc      grpc.ClientConnInterface
+		allowed services.Allowlist
+		err     string
 	}{
-		{name: "nil client connection", gate: gate, err: "nil client connection"},
-		{name: "nil gate", cc: &testutil.ClientConn{}, err: "nil gate"},
+		{name: "nil client connection", allowed: allowed, err: "nil client connection"},
+		{name: "nil allowlist", cc: &testutil.ClientConn{}, err: "nil allowlist"},
 		{name: "both nil reports the connection first", err: "nil client connection"},
-		{name: "a connection and a gate is enough", cc: &testutil.ClientConn{}, gate: gate},
+		{name: "a connection and an allowlist is enough", cc: &testutil.ClientConn{}, allowed: allowed},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			fw, err := NewForwarder(tt.cc, tt.gate)
+			fw, err := NewForwarder(tt.cc, tt.allowed)
 			if tt.err != "" {
 				require.ErrorContains(t, err, tt.err)
 				require.Nil(t, fw)

--- a/internal/proxy/fx_test.go
+++ b/internal/proxy/fx_test.go
@@ -269,7 +269,7 @@ func TestModuleRequiresTranslator(t *testing.T) {
 func TestModuleRequiresAllowlist(t *testing.T) {
 	t.Parallel()
 
-	// Deliberately without config.NewAllowlist: the gate is required so missing
+	// Deliberately without config.NewAllowlist: the allowlist is required so missing
 	// wiring fails here, rather than degrading to a proxy that forwards nothing.
 	app := fx.New(
 		fx.Supply(fx.Annotate(t.Context(), fx.As(new(context.Context)))),

--- a/internal/router/fx.go
+++ b/internal/router/fx.go
@@ -28,11 +28,10 @@ import (
 // handler dials one connection per configured upstream from the shared
 // [connect.Pool] (each unix socket path derived from that upstream's
 // host:port), then routes every request to an upstream by matching it with the
-// Mux. Requests are admitted through a [Gate] adapted from the allowlist
-// [config.Module] provides before any of that happens.
+// Mux. Requests are admitted through the [services.Allowlist] [config.Module]
+// provides before any of that happens.
 var Module = fx.Options(fx.Provide(
 	Codec,
-	func(a services.Allowlist) Gate { return a },
 	func(p RouterParams) (grpc.StreamHandler, error) {
 		conns := make(map[string]*grpc.ClientConn, len(p.Config.Upstreams))
 		for i := range p.Config.Upstreams {
@@ -64,7 +63,7 @@ var Module = fx.Options(fx.Provide(
 				logger:   log.With(tag.Component("router")),
 			},
 			p.Extractor,
-			p.Gate,
+			p.Allowlist,
 			p.Reporter,
 		), nil
 	},
@@ -130,9 +129,9 @@ type (
 	RouterParams struct {
 		fx.In
 
+		Allowlist services.Allowlist
 		Config    *config.Config
 		Extractor *protoutil.Extractor
-		Gate      Gate
 		Mux       *Mux
 		Pool      *connect.Pool
 		Reporter  *Reporter

--- a/internal/router/fx_test.go
+++ b/internal/router/fx_test.go
@@ -37,7 +37,7 @@ func TestModule(t *testing.T) {
 
 		app := fx.New(
 			fx.Supply(&config.Config{
-				// The module builds its Gate from this, so the stub service these
+				// The module builds its allowlist from this, so the stub service these
 				// tests forward has to be on it.
 				AllowedServices: config.Services{"test.v1.Echo"},
 				Upstreams:       []config.Upstream{{Name: "primary", Listen: config.ListenConfig{HostPort: "127.0.0.1:7233"}}},

--- a/internal/router/handler.go
+++ b/internal/router/handler.go
@@ -12,6 +12,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/temporalio/temporal-proxy/internal/rpc"
+	"github.com/temporalio/temporal-proxy/internal/services"
 	"github.com/temporalio/temporal-proxy/internal/transport/meta"
 )
 
@@ -40,18 +41,11 @@ type (
 	Reflector interface {
 		Namespace(string, []byte) string
 	}
-
-	// Gate reports whether the proxy will forward the named service. Allows
-	// receives a service full name, never a full method; the Module wires a
-	// services.Allowlist built from the configured allowlist.
-	Gate interface {
-		Allows(string) bool
-	}
 )
 
 // Handler returns a grpc.StreamHandler suitable for grpc.UnknownServiceHandler,
 // reporting a stream_setup forwarding error via rep when opening the upstream
-// stream fails. A method whose service g does not allow is rejected with
+// stream fails. A method whose service a does not allow is rejected with
 // Unimplemented before any upstream work, so the proxy answers as a server that
 // does not implement it rather than revealing that an upstream might.
 // It buffers the first request frame so r can peek the request
@@ -59,7 +53,7 @@ type (
 // the stream to that upstream using the same full method name: it replays the
 // buffered first frame, pumps raw frames in both directions, and propagates
 // header, trailer, and status verbatim.
-func Handler(d Director, r Reflector, g Gate, rep *Reporter) grpc.StreamHandler {
+func Handler(d Director, r Reflector, a services.Allowlist, rep *Reporter) grpc.StreamHandler {
 	return func(_ any, serverStream grpc.ServerStream) error {
 		ctx := serverStream.Context()
 		method, err := rpc.FullMethod(ctx)
@@ -67,7 +61,7 @@ func Handler(d Director, r Reflector, g Gate, rep *Reporter) grpc.StreamHandler 
 			return err
 		}
 
-		if svc := rpc.Service(method); !g.Allows(svc) {
+		if svc := rpc.Service(method); !a.Allows(svc) {
 			return status.Errorf(codes.Unimplemented, "unknown service %q", svc)
 		}
 

--- a/internal/router/handler_test.go
+++ b/internal/router/handler_test.go
@@ -63,11 +63,11 @@ type (
 
 	stubReflector struct{}
 
-	// stubGate admits everything. The handler tests dial a mix of stub services
+	// stubAllowlist admits everything. The handler tests dial a mix of stub services
 	// and the generated health client, so enumerating them here would silently
 	// deny a test the day someone adds another. Admission has its own test, and
-	// the real gate is covered in the services package.
-	stubGate struct{}
+	// the real allowlist is covered in the services package.
+	stubAllowlist struct{}
 )
 
 func TestHandlerForwardsUnary(t *testing.T) {
@@ -387,7 +387,7 @@ func TestHandlerCoHostsLocalHealthWithForwarding(t *testing.T) {
 
 	m, _ := newTestReporter(t)
 	svr, err := server.New(
-		server.WithUnknownServiceHandler(router.Handler(stubDirector{cc: upstreamConn}, stubReflector{}, stubGate{}, m)),
+		server.WithUnknownServiceHandler(router.Handler(stubDirector{cc: upstreamConn}, stubReflector{}, stubAllowlist{}, m)),
 		server.WithServerCodec(router.Codec()),
 	)
 	require.NoError(t, err)
@@ -441,7 +441,7 @@ func TestHandlerRecordsStreamSetupError(t *testing.T) {
 	relayLis := bufconn.Listen(1024 * 1024)
 	relay := grpc.NewServer(
 		grpc.ForceServerCodecV2(router.Codec()),
-		grpc.UnknownServiceHandler(router.Handler(stubDirector{upstream: "primary", cc: brokenConn}, stubReflector{}, stubGate{}, m)),
+		grpc.UnknownServiceHandler(router.Handler(stubDirector{upstream: "primary", cc: brokenConn}, stubReflector{}, stubAllowlist{}, m)),
 	)
 	serve(t, relay, relayLis)
 
@@ -474,7 +474,7 @@ func TestHandlerRelayedUpstreamErrorIsNotAForwardingError(t *testing.T) {
 
 	relay := grpc.NewServer(
 		grpc.ForceServerCodecV2(router.Codec()),
-		grpc.UnknownServiceHandler(router.Handler(stubDirector{upstream: "primary", cc: upstreamConn}, stubReflector{}, stubGate{}, m)),
+		grpc.UnknownServiceHandler(router.Handler(stubDirector{upstream: "primary", cc: upstreamConn}, stubReflector{}, stubAllowlist{}, m)),
 	)
 	serve(t, relay, relayLis)
 
@@ -503,7 +503,7 @@ func TestHandlerStampsNamespace(t *testing.T) {
 	relayLis := bufconn.Listen(1024 * 1024)
 	relay := grpc.NewServer(
 		grpc.ForceServerCodecV2(router.Codec()),
-		grpc.UnknownServiceHandler(router.Handler(stubDirector{upstream: "u", cc: upstream}, &recordingReflector{ns: "orders"}, stubGate{}, m)),
+		grpc.UnknownServiceHandler(router.Handler(stubDirector{upstream: "u", cc: upstream}, &recordingReflector{ns: "orders"}, stubAllowlist{}, m)),
 	)
 	serve(t, relay, relayLis)
 
@@ -528,7 +528,7 @@ func (s stubDirector) Resolve(context.Context, string, string, map[string][]stri
 
 func (stubReflector) Namespace(string, []byte) string { return "" }
 
-func (stubGate) Allows(string) bool { return true }
+func (stubAllowlist) Allows(string) bool { return true }
 
 func (r *recordingReflector) Namespace(method string, payload []byte) string {
 	r.mu.Lock()
@@ -652,7 +652,7 @@ func newRelayWith(
 	relayLis := bufconn.Listen(1024 * 1024)
 	relay := grpc.NewServer(
 		grpc.ForceServerCodecV2(router.Codec()),
-		grpc.UnknownServiceHandler(router.Handler(makeDirector(upstreamConn), reflector, stubGate{}, reporter)),
+		grpc.UnknownServiceHandler(router.Handler(makeDirector(upstreamConn), reflector, stubAllowlist{}, reporter)),
 	)
 	serve(t, relay, relayLis)
 

--- a/internal/services/allowlist.go
+++ b/internal/services/allowlist.go
@@ -1,17 +1,27 @@
 package services
 
-// Allowlist is the set of services the proxy will forward, keyed by proto full
-// name. It admits the names it was built from plus their compatibility aliases,
-// and does no registry lookup, since configuration validation has already
-// rejected names that cannot be forwarded.
-type Allowlist map[string]struct{}
+type (
+	// Allowlist reports whether the proxy will forward the named service. Allows
+	// matches a service full name only, so a caller holding a gRPC full method
+	// must strip the method first. An Allowlist built from no names allows
+	// nothing.
+	Allowlist interface {
+		Allows(string) bool
+	}
+
+	// allowSet is the concrete admission set, keyed by proto full name. It admits
+	// the names it was built from plus their compatibility aliases, and does no
+	// registry lookup, since configuration validation has already rejected names
+	// that cannot be forwarded.
+	allowSet map[string]struct{}
+)
 
 // NewAllowlist builds an Allowlist admitting names and their compatibility
 // aliases, so allowing a service also allows the spellings a client may fall
 // back to.
 func NewAllowlist(names []string) Allowlist {
 	exp := expand(names)
-	set := make(Allowlist, len(exp))
+	set := make(allowSet, len(exp))
 	for _, name := range exp {
 		set[name] = struct{}{}
 	}
@@ -19,10 +29,8 @@ func NewAllowlist(names []string) Allowlist {
 	return set
 }
 
-// Allows reports whether name was admitted. It matches a service full name
-// only, so a caller holding a gRPC full method must strip the method first. An
-// Allowlist built from no names allows nothing.
-func (a Allowlist) Allows(name string) bool {
-	_, ok := a[name]
+// Allows reports whether name was admitted.
+func (s allowSet) Allows(name string) bool {
+	_, ok := s[name]
 	return ok
 }

--- a/internal/services/allowlist_test.go
+++ b/internal/services/allowlist_test.go
@@ -104,14 +104,13 @@ func TestAllowlistAllows(t *testing.T) {
 	}
 }
 
-func TestNewAllowlistCollapsesDuplicates(t *testing.T) {
+func TestNewAllowlistToleratesDuplicates(t *testing.T) {
 	t.Parallel()
 
 	// Validation rejects a duplicated allowlist, but one is also constructible
-	// in code, so collapsing duplicates must not change what it admits.
-	allowlist := services.NewAllowlist([]string{services.WorkflowService, services.WorkflowService})
+	// in code, so a repeated name must not change what is admitted.
+	a := services.NewAllowlist([]string{services.WorkflowService, services.WorkflowService})
 
-	require.Len(t, allowlist, 1)
-	require.True(t, allowlist.Allows(services.WorkflowService))
-	require.False(t, allowlist.Allows(services.OperatorService))
+	require.True(t, a.Allows(services.WorkflowService))
+	require.False(t, a.Allows(services.OperatorService))
 }


### PR DESCRIPTION
`router` and `proxy` each declared an identical one-method Gate interface, both satisfied by the same `services.Allowlist` map. One concept had three names, and because each `Gate` was package-local, `config.Module` could only provide the concrete map, and every consumer needed an adapter to narrow it.

I've collapsed them. `services.Allowlist` becomes the interface, and the map that implements it is just an unexported `allowSet`. `config.NewAllowlist` already returned `services.Allowlist`, so it now hands out the interface directly and the router's adapter provider goes away.

This puts the interface in the package that provides it rather than the ones that consume it, against the usual Go idiom. Two packages need the same one-method contract, so whichever consumer owned it would force the other to import it, which is how the duplicate declarations turned up in the first place. `services` is the dependency both already have.