### PR TITLE
[router]: Make routing logic testable without fx

### DIFF
--- a/internal/router/compile.go
+++ b/internal/router/compile.go
@@ -1,0 +1,55 @@
+package router
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/temporalio/temporal-proxy/internal/config"
+	"github.com/temporalio/temporal-proxy/pkg/match"
+)
+
+// CompileMux compiles routing configuration into a Mux. An empty rule namespace
+// matches every namespace, and metadata keys are lowercased to match canonical
+// gRPC metadata.
+func CompileMux(r config.Routing) (*Mux, error) {
+	rules := make([]Rule, 0, len(r.Rules))
+	for i, rr := range r.Rules {
+		p := rr.Match.Namespace
+		if p == "" {
+			p = "*"
+		}
+
+		ns, err := match.Compile(p)
+		if err != nil {
+			return nil, fmt.Errorf("routing: rules[%d].match.namespace: %w", i, err)
+		}
+
+		meta := make(map[string]match.Matcher, len(rr.Match.Metadata))
+		seen := make(map[string]string, len(rr.Match.Metadata))
+		for k, v := range rr.Match.Metadata {
+			lk := strings.ToLower(k)
+			if prev, ok := seen[lk]; ok {
+				return nil, fmt.Errorf(
+					"routing: rules[%d].match.metadata: keys %q and %q both map to %q when lowercased",
+					i, prev, k, lk,
+				)
+			}
+
+			seen[lk] = k
+			m, err := match.Compile(v)
+			if err != nil {
+				return nil, fmt.Errorf("routing: rules[%d].match.metadata[%q]: %w", i, k, err)
+			}
+
+			meta[lk] = m
+		}
+
+		rules = append(rules, Rule{
+			upstream: rr.Upstream,
+			ns:       ns,
+			meta:     meta,
+		})
+	}
+
+	return New(r.DefaultUpstream, r.SystemUpstream, rules...), nil
+}

--- a/internal/router/compile_test.go
+++ b/internal/router/compile_test.go
@@ -1,0 +1,162 @@
+package router_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/temporalio/temporal-proxy/internal/config"
+	"github.com/temporalio/temporal-proxy/internal/router"
+)
+
+func TestCompileMux(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		routing config.Routing
+		ns      string
+		md      map[string][]string
+		want    string
+		outcome router.Outcome
+	}{
+		{
+			name: "namespace glob matches",
+			routing: config.Routing{
+				DefaultUpstream: "fallback",
+				Rules: []config.RoutingRule{
+					{Upstream: "prod", Match: config.RoutingMatch{Namespace: "prod-*"}},
+				},
+			},
+			ns:      "prod-1",
+			want:    "prod",
+			outcome: router.OutcomeMatch,
+		},
+		{
+			name: "no rule falls through to default",
+			routing: config.Routing{
+				DefaultUpstream: "fallback",
+				Rules: []config.RoutingRule{
+					{Upstream: "prod", Match: config.RoutingMatch{Namespace: "prod-*"}},
+				},
+			},
+			ns:      "staging-1",
+			want:    "fallback",
+			outcome: router.OutcomeDefault,
+		},
+		{
+			name: "empty namespace goes to the system upstream",
+			routing: config.Routing{
+				DefaultUpstream: "fallback",
+				SystemUpstream:  "sys",
+			},
+			ns:      "",
+			want:    "sys",
+			outcome: router.OutcomeSystem,
+		},
+		{
+			name: "empty rule namespace matches everything",
+			routing: config.Routing{
+				Rules: []config.RoutingRule{
+					{Upstream: "gold", Match: config.RoutingMatch{Metadata: map[string]string{"x-tier": "gold"}}},
+				},
+			},
+			ns:      "anything",
+			md:      map[string][]string{"x-tier": {"gold"}},
+			want:    "gold",
+			outcome: router.OutcomeMatch,
+		},
+		{
+			name: "metadata key is lowercased to match canonical gRPC metadata",
+			routing: config.Routing{
+				Rules: []config.RoutingRule{
+					{Upstream: "gold", Match: config.RoutingMatch{
+						Namespace: "*",
+						Metadata:  map[string]string{"X-Tier": "gold"},
+					}},
+				},
+			},
+			ns:      "anything",
+			md:      map[string][]string{"x-tier": {"gold"}},
+			want:    "gold",
+			outcome: router.OutcomeMatch,
+		},
+		{
+			name: "no rule and no default is unroutable",
+			routing: config.Routing{
+				Rules: []config.RoutingRule{
+					{Upstream: "prod", Match: config.RoutingMatch{Namespace: "prod-*"}},
+				},
+			},
+			ns:      "staging-1",
+			want:    "",
+			outcome: router.OutcomeUnroutable,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mux, err := router.CompileMux(tt.routing)
+			require.NoError(t, err)
+
+			got, outcome := mux.Switch(tt.ns, tt.md)
+			require.Equal(t, tt.want, got)
+			require.Equal(t, tt.outcome, outcome)
+		})
+	}
+}
+
+func TestCompileMuxErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		routing config.Routing
+		wantErr string
+	}{
+		{
+			name: "interior wildcard in a namespace",
+			routing: config.Routing{
+				Rules: []config.RoutingRule{
+					{Upstream: "prod", Match: config.RoutingMatch{Namespace: "a*b"}},
+				},
+			},
+			wantErr: `rules[0].match.namespace`,
+		},
+		{
+			name: "interior wildcard in a metadata value",
+			routing: config.Routing{
+				Rules: []config.RoutingRule{
+					{Upstream: "prod", Match: config.RoutingMatch{
+						Namespace: "*",
+						Metadata:  map[string]string{"x-tier": "a*b"},
+					}},
+				},
+			},
+			wantErr: `rules[0].match.metadata["x-tier"]`,
+		},
+		{
+			name: "metadata keys colliding once lowercased",
+			routing: config.Routing{
+				Rules: []config.RoutingRule{
+					{Upstream: "prod", Match: config.RoutingMatch{
+						Namespace: "*",
+						Metadata:  map[string]string{"X-Tier": "gold", "x-tier": "silver"},
+					}},
+				},
+			},
+			wantErr: `both map to "x-tier" when lowercased`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := router.CompileMux(tt.routing)
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}

--- a/internal/router/director.go
+++ b/internal/router/director.go
@@ -1,0 +1,88 @@
+package router
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/temporalio/temporal-proxy/pkg/logger"
+	"github.com/temporalio/temporal-proxy/pkg/logger/tag"
+)
+
+type (
+	// Director selects the upstream for a request. Resolve receives the full
+	// method, the namespace peeked from the first request message (empty when the
+	// client sent no message), and the incoming metadata, and returns the Target to
+	// forward over. A non-nil error aborts the stream and is returned to the caller
+	// verbatim, so implementations should return a gRPC status error.
+	Director interface {
+		Resolve(ctx context.Context, method, namespace string, md map[string][]string) (Target, error)
+	}
+
+	// director maps the upstream name the Mux chooses to that upstream's
+	// connection.
+	director struct {
+		conns    map[string]grpc.ClientConnInterface
+		mux      *Mux
+		reporter *Reporter
+		logger   logger.Logger
+	}
+)
+
+// NewDirector returns the Director that routes a request with mux and looks the
+// chosen upstream up in conns. A nil log falls back to the default logger.
+func NewDirector(
+	mux *Mux,
+	conns map[string]grpc.ClientConnInterface,
+	rep *Reporter,
+	log logger.Logger,
+) Director {
+	if log == nil {
+		log = logger.Default()
+	}
+
+	return &director{
+		conns:    conns,
+		mux:      mux,
+		reporter: rep,
+		logger:   log.With(tag.Component("router")),
+	}
+}
+
+// Resolve routes a request by matching it against the Mux and returning the
+// Target for the resulting upstream. It fails with FailedPrecondition when
+// no upstream matches (and no default is configured) and with Unavailable when
+// the matched upstream has no connection. It records a decision metric on
+// every call, plus a no_connection forwarding-error metric when the chosen
+// upstream has no connection.
+func (d *director) Resolve(
+	ctx context.Context,
+	method, namespace string,
+	md map[string][]string,
+) (Target, error) {
+	upstream, outcome := d.mux.Switch(namespace, md)
+	if outcome == OutcomeUnroutable {
+		d.reporter.Decision(upstreamUnknown, OutcomeUnroutable)
+		return Target{}, status.Error(codes.FailedPrecondition, "no upstream matched the request and no default is configured")
+	}
+
+	d.reporter.Decision(upstream, outcome)
+
+	cc, ok := d.conns[upstream]
+	if !ok {
+		d.reporter.ForwardingError(upstream, reasonNoConnection)
+		return Target{}, status.Errorf(codes.Unavailable, "router: no connection for upstream %q", upstream)
+	}
+
+	d.logger.Debug(
+		"routing request",
+		tag.String("method", method),
+		tag.String("namespace", namespace),
+		tag.String("upstream", upstream),
+		tag.Stringer("outcome", outcome),
+	)
+
+	return Target{Upstream: upstream, Conn: cc}, nil
+}

--- a/internal/router/director_test.go
+++ b/internal/router/director_test.go
@@ -1,155 +1,161 @@
-package router
+package router_test
 
 import (
 	"strings"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/temporalio/temporal-proxy/internal/metrics"
+	"github.com/temporalio/temporal-proxy/internal/config"
+	"github.com/temporalio/temporal-proxy/internal/router"
 	"github.com/temporalio/temporal-proxy/pkg/logger"
 	"github.com/temporalio/temporal-proxy/pkg/logger/tag"
 )
 
+type fakeConn struct{ grpc.ClientConnInterface }
+
 func TestDirectorResolve(t *testing.T) {
 	t.Parallel()
 
-	t.Run("default decision with a connection", func(t *testing.T) {
-		t.Parallel()
-
-		reg := prometheus.NewRegistry()
-		d := &director{
-			conns:    map[string]*grpc.ClientConn{"primary": {}},
-			mux:      New("primary", "", Rule{upstream: "primary", ns: matchPrefix("prod-")}),
-			reporter: testReporter(reg),
-		}
-
-		target, err := d.Resolve(t.Context(), "/svc/M", "other", nil)
-		require.NoError(t, err)
-		require.Equal(t, "primary", target.Upstream)
-		require.NotNil(t, target.Conn)
-
-		requireDecisions(t, reg, `
-# HELP tmprl_proxy_router_decisions_total Total routing decisions, labeled by chosen upstream and outcome.
-# TYPE tmprl_proxy_router_decisions_total counter
-tmprl_proxy_router_decisions_total{outcome="default",upstream="primary"} 1
-tmprl_proxy_router_decisions_total{outcome="match",upstream="primary"} 0
-tmprl_proxy_router_decisions_total{outcome="system",upstream="primary"} 0
-tmprl_proxy_router_decisions_total{outcome="unroutable",upstream="unknown"} 0
-`)
+	conn := &fakeConn{}
+	mux, err := router.CompileMux(config.Routing{
+		DefaultUpstream: "primary",
+		Rules: []config.RoutingRule{
+			{Upstream: "prod", Match: config.RoutingMatch{Namespace: "prod-*"}},
+		},
 	})
+	require.NoError(t, err)
 
-	t.Run("no connection for chosen upstream", func(t *testing.T) {
-		t.Parallel()
+	rep, reg := newTestReporter(t, "primary", "prod")
+	d := router.NewDirector(
+		mux,
+		map[string]grpc.ClientConnInterface{"primary": conn, "prod": conn},
+		rep,
+		nil,
+	)
 
-		reg := prometheus.NewRegistry()
-		d := &director{
-			conns:    map[string]*grpc.ClientConn{},
-			mux:      New("primary", ""),
-			reporter: testReporter(reg),
-		}
+	target, err := d.Resolve(t.Context(), "/svc/Method", "prod-1", nil)
+	require.NoError(t, err)
+	require.Equal(t, "prod", target.Upstream)
+	require.Same(t, conn, target.Conn)
 
-		_, err := d.Resolve(t.Context(), "/svc/M", "other", nil)
-		require.Equal(t, codes.Unavailable, status.Code(err))
+	requireDecisions(t, reg, `
+tmprl_proxy_router_decisions_total{outcome="default",upstream="primary"} 0
+tmprl_proxy_router_decisions_total{outcome="default",upstream="prod"} 0
+tmprl_proxy_router_decisions_total{outcome="match",upstream="primary"} 0
+tmprl_proxy_router_decisions_total{outcome="match",upstream="prod"} 1
+tmprl_proxy_router_decisions_total{outcome="system",upstream="primary"} 0
+tmprl_proxy_router_decisions_total{outcome="system",upstream="prod"} 0
+tmprl_proxy_router_decisions_total{outcome="unroutable",upstream="unknown"} 0
+`)
+}
 
-		requireDecisions(t, reg, `
-# HELP tmprl_proxy_router_decisions_total Total routing decisions, labeled by chosen upstream and outcome.
-# TYPE tmprl_proxy_router_decisions_total counter
+func TestDirectorResolveUnroutable(t *testing.T) {
+	t.Parallel()
+
+	mux, err := router.CompileMux(config.Routing{})
+	require.NoError(t, err)
+
+	rep, reg := newTestReporter(t)
+	d := router.NewDirector(mux, nil, rep, nil)
+
+	_, err = d.Resolve(t.Context(), "/svc/Method", "anything", nil)
+	require.Equal(t, codes.FailedPrecondition, status.Code(err))
+
+	// An unroutable request is attributed to the "unknown" upstream, since no
+	// upstream was chosen.
+	requireDecisions(t, reg, `
+tmprl_proxy_router_decisions_total{outcome="unroutable",upstream="unknown"} 1
+`)
+}
+
+func TestDirectorResolveNoConnection(t *testing.T) {
+	t.Parallel()
+
+	mux, err := router.CompileMux(config.Routing{DefaultUpstream: "primary"})
+	require.NoError(t, err)
+
+	rep, reg := newTestReporter(t, "primary")
+	d := router.NewDirector(mux, nil, rep, nil)
+
+	_, err = d.Resolve(t.Context(), "/svc/Method", "anything", nil)
+	require.Equal(t, codes.Unavailable, status.Code(err))
+	require.ErrorContains(t, err, `no connection for upstream "primary"`)
+
+	// The decision is recorded before the connection lookup, so a missing
+	// connection counts as both a decision and a forwarding error.
+	requireDecisions(t, reg, `
 tmprl_proxy_router_decisions_total{outcome="default",upstream="primary"} 1
 tmprl_proxy_router_decisions_total{outcome="match",upstream="primary"} 0
 tmprl_proxy_router_decisions_total{outcome="system",upstream="primary"} 0
 tmprl_proxy_router_decisions_total{outcome="unroutable",upstream="unknown"} 0
 `)
-		requireErrors(t, reg, `
-# HELP tmprl_proxy_router_forwarding_errors_total Total router-originated forwarding failures, labeled by upstream and reason.
-# TYPE tmprl_proxy_router_forwarding_errors_total counter
+	requireForwardingErrors(t, reg, `
 tmprl_proxy_router_forwarding_errors_total{reason="no_connection",upstream="primary"} 1
 tmprl_proxy_router_forwarding_errors_total{reason="stream_setup",upstream="primary"} 0
 `)
-	})
-
-	t.Run("unroutable request", func(t *testing.T) {
-		t.Parallel()
-
-		reg := prometheus.NewRegistry()
-		d := &director{
-			conns:    map[string]*grpc.ClientConn{},
-			mux:      New("", ""),
-			reporter: testReporter(reg),
-		}
-
-		_, err := d.Resolve(t.Context(), "/svc/M", "other", nil)
-		require.Equal(t, codes.FailedPrecondition, status.Code(err))
-
-		requireDecisions(t, reg, `
-# HELP tmprl_proxy_router_decisions_total Total routing decisions, labeled by chosen upstream and outcome.
-# TYPE tmprl_proxy_router_decisions_total counter
-tmprl_proxy_router_decisions_total{outcome="default",upstream="primary"} 0
-tmprl_proxy_router_decisions_total{outcome="match",upstream="primary"} 0
-tmprl_proxy_router_decisions_total{outcome="system",upstream="primary"} 0
-tmprl_proxy_router_decisions_total{outcome="unroutable",upstream="unknown"} 1
-`)
-	})
 }
 
 func TestDirectorLogsRoutingDecision(t *testing.T) {
 	t.Parallel()
 
-	reg := prometheus.NewRegistry()
-	log := logger.NewTestLogger()
-	d := &director{
-		conns:    map[string]*grpc.ClientConn{"primary": {}},
-		mux:      New("primary", ""),
-		reporter: testReporter(reg),
-		logger:   log,
-	}
-
-	_, err := d.Resolve(t.Context(), "/svc/M", "orders", nil)
+	mux, err := router.CompileMux(config.Routing{DefaultUpstream: "primary"})
 	require.NoError(t, err)
 
+	rep, _ := newTestReporter(t, "primary")
+	log := logger.NewTestLogger()
+	d := router.NewDirector(
+		mux,
+		map[string]grpc.ClientConnInterface{"primary": &fakeConn{}},
+		rep,
+		log,
+	)
+
+	_, err = d.Resolve(t.Context(), "/svc/Method", "orders", nil)
+	require.NoError(t, err)
+
+	// The constructor scopes the logger to the router component, so that tag
+	// leads every entry.
 	require.True(t, log.ContainsEntry(
 		logger.LevelDebug,
 		"routing request",
-		tag.String("method", "/svc/M"),
+		tag.Component("router"),
+		tag.String("method", "/svc/Method"),
 		tag.String("namespace", "orders"),
 		tag.String("upstream", "primary"),
-		tag.Stringer("outcome", OutcomeDefault),
+		tag.Stringer("outcome", router.OutcomeDefault),
 	))
 }
 
-func TestDirectorLogsSkippedWhenLoggerUnset(t *testing.T) {
-	t.Parallel()
-
-	reg := prometheus.NewRegistry()
-	d := &director{
-		conns:    map[string]*grpc.ClientConn{"primary": {}},
-		mux:      New("primary", ""),
-		reporter: testReporter(reg),
-	}
-
-	_, err := d.Resolve(t.Context(), "/svc/M", "orders", nil)
-	require.NoError(t, err)
-}
-
-// testReporter builds a Reporter over reg with the production namespace and
-// subsystem, so emitted series match the tmprl_proxy_router_* names asserted
-// below.
-func testReporter(reg *prometheus.Registry) *Reporter {
-	return NewReporter(metrics.New("tmprl_proxy", promauto.With(reg)).ForSubsystem("router"), []string{"primary"})
-}
-
+// requireDecisions asserts the full set of decision series, so a stray
+// increment on an unexpected label fails too. want omits the HELP and TYPE
+// lines, which are prepended here.
 func requireDecisions(t *testing.T, g prometheus.Gatherer, want string) {
 	t.Helper()
-	require.NoError(t, testutil.GatherAndCompare(g, strings.NewReader(want), "tmprl_proxy_router_decisions_total"))
+
+	const header = `
+# HELP tmprl_proxy_router_decisions_total Total routing decisions, labeled by chosen upstream and outcome.
+# TYPE tmprl_proxy_router_decisions_total counter`
+
+	require.NoError(t, testutil.GatherAndCompare(
+		g, strings.NewReader(header+want), "tmprl_proxy_router_decisions_total",
+	))
 }
 
-func requireErrors(t *testing.T, g prometheus.Gatherer, want string) {
+// requireForwardingErrors asserts the full set of forwarding-error series.
+func requireForwardingErrors(t *testing.T, g prometheus.Gatherer, want string) {
 	t.Helper()
-	require.NoError(t, testutil.GatherAndCompare(g, strings.NewReader(want), "tmprl_proxy_router_forwarding_errors_total"))
+
+	const header = `
+# HELP tmprl_proxy_router_forwarding_errors_total Total router-originated forwarding failures, labeled by upstream and reason.
+# TYPE tmprl_proxy_router_forwarding_errors_total counter`
+
+	require.NoError(t, testutil.GatherAndCompare(
+		g, strings.NewReader(header+want), "tmprl_proxy_router_forwarding_errors_total",
+	))
 }

--- a/internal/router/fx.go
+++ b/internal/router/fx.go
@@ -1,15 +1,11 @@
 package router
 
 import (
-	"context"
 	"fmt"
-	"strings"
 
 	"go.uber.org/fx"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/status"
 
 	"github.com/temporalio/temporal-proxy/internal/config"
 	"github.com/temporalio/temporal-proxy/internal/metrics"
@@ -18,8 +14,6 @@ import (
 	"github.com/temporalio/temporal-proxy/internal/transport/connect"
 	"github.com/temporalio/temporal-proxy/internal/transport/socket"
 	"github.com/temporalio/temporal-proxy/pkg/logger"
-	"github.com/temporalio/temporal-proxy/pkg/logger/tag"
-	"github.com/temporalio/temporal-proxy/pkg/match"
 )
 
 // Module is the fx module that provides the routing-and-forwarding pieces: a
@@ -33,7 +27,7 @@ import (
 var Module = fx.Options(fx.Provide(
 	Codec,
 	func(p RouterParams) (grpc.StreamHandler, error) {
-		conns := make(map[string]*grpc.ClientConn, len(p.Config.Upstreams))
+		conns := make(map[string]grpc.ClientConnInterface, len(p.Config.Upstreams))
 		for i := range p.Config.Upstreams {
 			upstream := &p.Config.Upstreams[i]
 			sockPath, err := socket.UnixPath(upstream.Listen.HostPort)
@@ -50,18 +44,8 @@ var Module = fx.Options(fx.Provide(
 			conns[upstream.Name] = conn
 		}
 
-		log := p.Logger
-		if log == nil {
-			log = logger.Default()
-		}
-
 		return Handler(
-			&director{
-				conns:    conns,
-				mux:      p.Mux,
-				reporter: p.Reporter,
-				logger:   log.With(tag.Component("router")),
-			},
+			NewDirector(p.Mux, conns, p.Reporter, p.Logger),
 			p.Extractor,
 			p.Allowlist,
 			p.Reporter,
@@ -75,52 +59,7 @@ var Module = fx.Options(fx.Provide(
 
 		return NewReporter(f.ForSubsystem("router"), names)
 	},
-	func(c *config.Config) (*Mux, error) {
-		rules := make([]Rule, 0, len(c.Routing.Rules))
-		for i, r := range c.Routing.Rules {
-			p := r.Match.Namespace
-			if p == "" {
-				p = "*"
-			}
-
-			ns, err := match.Compile(p)
-			if err != nil {
-				return nil, fmt.Errorf("routing: rules[%d].match.namespace: %w", i, err)
-			}
-
-			meta := make(map[string]Matcher, len(r.Match.Metadata))
-			seen := make(map[string]string, len(r.Match.Metadata))
-			for k, v := range r.Match.Metadata {
-				lk := strings.ToLower(k)
-				if prev, ok := seen[lk]; ok {
-					return nil, fmt.Errorf(
-						"routing: rules[%d].match.metadata: keys %q and %q both map to %q when lowercased",
-						i, prev, k, lk,
-					)
-				}
-
-				seen[lk] = k
-				m, err := match.Compile(v)
-				if err != nil {
-					return nil, fmt.Errorf("routing: rules[%d].match.metadata[%q]: %w", i, k, err)
-				}
-
-				meta[lk] = m
-			}
-
-			rules = append(rules, Rule{
-				upstream: r.Upstream,
-				ns:       ns,
-				meta:     meta,
-			})
-		}
-
-		return New(
-			c.Routing.DefaultUpstream,
-			c.Routing.SystemUpstream,
-			rules...,
-		), nil
-	},
+	func(c *config.Config) (*Mux, error) { return CompileMux(c.Routing) },
 ))
 
 type (
@@ -139,51 +78,4 @@ type (
 		// Optional; falls back to [logger.Default].
 		Logger logger.Logger `optional:"true"`
 	}
-
-	// director is the [Director] used by the module's handler. It maps the
-	// upstream name chosen by the Mux to that upstream's pooled connection.
-	director struct {
-		conns    map[string]*grpc.ClientConn
-		mux      *Mux
-		reporter *Reporter
-		logger   logger.Logger
-	}
 )
-
-// Resolve routes a request by matching it against the Mux and returning the
-// Target for the resulting upstream. It fails with FailedPrecondition when
-// no upstream matches (and no default is configured) and with Unavailable when
-// the matched upstream has no connection. It records a decision metric on
-// every call, plus a no_connection forwarding-error metric when the chosen
-// upstream has no connection.
-func (d *director) Resolve(
-	ctx context.Context,
-	method, namespace string,
-	md map[string][]string,
-) (Target, error) {
-	upstream, outcome := d.mux.Switch(namespace, md)
-	if outcome == OutcomeUnroutable {
-		d.reporter.Decision(upstreamUnknown, OutcomeUnroutable)
-		return Target{}, status.Error(codes.FailedPrecondition, "no upstream matched the request and no default is configured")
-	}
-
-	d.reporter.Decision(upstream, outcome)
-
-	cc, ok := d.conns[upstream]
-	if !ok {
-		d.reporter.ForwardingError(upstream, reasonNoConnection)
-		return Target{}, status.Errorf(codes.Unavailable, "router: no connection for upstream %q", upstream)
-	}
-
-	if d.logger != nil {
-		d.logger.Debug(
-			"routing request",
-			tag.String("method", method),
-			tag.String("namespace", namespace),
-			tag.String("upstream", upstream),
-			tag.Stringer("outcome", outcome),
-		)
-	}
-
-	return Target{Upstream: upstream, Conn: cc}, nil
-}

--- a/internal/router/fx_test.go
+++ b/internal/router/fx_test.go
@@ -189,46 +189,4 @@ func TestModuleMux(t *testing.T) {
 		require.Equal(t, "system", got, "no namespace falls to system")
 	})
 
-	t.Run("rejects an invalid rule", func(t *testing.T) {
-		t.Parallel()
-
-		tests := []struct {
-			match config.RoutingMatch
-			exp   string
-		}{
-			{
-				match: config.RoutingMatch{Namespace: "a*b"},
-				exp:   "rules[0].match.namespace",
-			},
-			{
-				match: config.RoutingMatch{Metadata: map[string]string{"k": "a*b"}},
-				exp:   `rules[0].match.metadata["k"]`,
-			},
-			{
-				// Keys differing only by case collide once lowercased; which one
-				// would win depends on random map iteration, so this must fail.
-				match: config.RoutingMatch{Metadata: map[string]string{"X-Tier": "gold", "x-tier": "silver"}},
-				exp:   `both map to "x-tier" when lowercased`,
-			},
-		}
-
-		var mux *router.Mux
-		for _, tt := range tests {
-			app := fx.New(
-				fx.Supply(&config.Config{
-					Routing: config.Routing{
-						Rules: []config.RoutingRule{
-							{Upstream: "x", Match: tt.match},
-						},
-					},
-				}),
-				router.Module,
-				fx.Populate(&mux),
-				fx.NopLogger,
-			)
-
-			require.Error(t, app.Err())
-			require.ErrorContains(t, app.Err(), tt.exp)
-		}
-	})
 }

--- a/internal/router/handler.go
+++ b/internal/router/handler.go
@@ -1,7 +1,6 @@
 package router
 
 import (
-	"context"
 	"errors"
 	"io"
 	"maps"
@@ -23,16 +22,7 @@ type (
 	// its fields.
 	Target struct {
 		Upstream string
-		Conn     *grpc.ClientConn
-	}
-
-	// Director selects the upstream for a request. Resolve receives the full
-	// method, the namespace peeked from the first request message (empty when the
-	// client sent no message), and the incoming metadata, and returns the Target to
-	// forward over. A non-nil error aborts the stream and is returned to the caller
-	// verbatim, so implementations should return a gRPC status error.
-	Director interface {
-		Resolve(ctx context.Context, method, namespace string, md map[string][]string) (Target, error)
+		Conn     grpc.ClientConnInterface
 	}
 
 	// Reflector extracts the Temporal namespace from a request. Namespace

--- a/internal/router/mux.go
+++ b/internal/router/mux.go
@@ -1,6 +1,10 @@
 package router
 
-import "slices"
+import (
+	"slices"
+
+	"github.com/temporalio/temporal-proxy/pkg/match"
+)
 
 const (
 	// OutcomeMatch means a rule matched the request.
@@ -24,13 +28,6 @@ type (
 		rules []Rule
 	}
 
-	// Matcher reports whether a string satisfies some pattern. Rules use it to
-	// match namespaces and metadata values, keeping Mux decoupled from any
-	// particular matching implementation.
-	Matcher interface {
-		Match(string) bool
-	}
-
 	// Outcome describes why Switch chose (or failed to choose) an upstream.
 	Outcome byte
 
@@ -39,11 +36,11 @@ type (
 	// and, for every constrained metadata key, at least one of the request's
 	// values for that key is accepted. Metadata keys are compared as stored, so
 	// the rule builder is responsible for canonicalizing them (gRPC lowercases
-	// metadata keys). Construct rules within this package.
+	// metadata keys). Construct rules with CompileMux.
 	Rule struct {
 		upstream string
-		ns       Matcher
-		meta     map[string]Matcher
+		ns       match.Matcher
+		meta     map[string]match.Matcher
 	}
 )
 
@@ -84,12 +81,12 @@ func (m *Mux) Switch(ns string, md map[string][]string) (string, Outcome) {
 // and metadata: the namespace must match and, for every metadata key the rule
 // constrains, at least one of the request's values for that key must match.
 func (r *Rule) matches(ns string, md map[string][]string) bool {
-	if r.ns == nil || !r.ns.Match(ns) {
+	if !r.ns.Match(ns) {
 		return false
 	}
 
 	for key, matcher := range r.meta {
-		if matcher == nil || !slices.ContainsFunc(md[key], matcher.Match) {
+		if !slices.ContainsFunc(md[key], matcher.Match) {
 			return false
 		}
 	}

--- a/internal/router/mux_test.go
+++ b/internal/router/mux_test.go
@@ -1,13 +1,12 @@
 package router
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-)
 
-type matcherFunc func(string) bool
+	"github.com/temporalio/temporal-proxy/pkg/match"
+)
 
 func TestMuxSwitch(t *testing.T) {
 	t.Parallel()
@@ -15,9 +14,9 @@ func TestMuxSwitch(t *testing.T) {
 	mux := New(
 		"default",
 		"system",
-		Rule{upstream: "prod", ns: matchPrefix("prod-")},
-		Rule{upstream: "gold", ns: matchAll(), meta: map[string]Matcher{"x-tier": matchExact("gold")}},
-		Rule{upstream: "combo", ns: matchPrefix("eu-"), meta: map[string]Matcher{"x-region": matchPrefix("eu")}},
+		Rule{upstream: "prod", ns: match.MustCompile("prod-*")},
+		Rule{upstream: "gold", ns: match.MustCompile("*"), meta: map[string]match.Matcher{"x-tier": match.MustCompile("gold")}},
+		Rule{upstream: "combo", ns: match.MustCompile("eu-*"), meta: map[string]match.Matcher{"x-region": match.MustCompile("eu*")}},
 	)
 
 	tests := []struct {
@@ -54,8 +53,8 @@ func TestMuxSwitchFirstMatchWins(t *testing.T) {
 	mux := New(
 		"default",
 		"",
-		Rule{upstream: "first", ns: matchPrefix("prod-")},
-		Rule{upstream: "second", ns: matchPrefix("prod-")},
+		Rule{upstream: "first", ns: match.MustCompile("prod-*")},
+		Rule{upstream: "second", ns: match.MustCompile("prod-*")},
 	)
 
 	got, outcome := mux.Switch("prod-1", nil)
@@ -69,7 +68,7 @@ func TestMuxSwitchNoDefault(t *testing.T) {
 	mux := New(
 		"",
 		"",
-		Rule{upstream: "prod", ns: matchPrefix("prod-")},
+		Rule{upstream: "prod", ns: match.MustCompile("prod-*")},
 	)
 
 	got, outcome := mux.Switch("other", nil)
@@ -87,7 +86,7 @@ func TestMuxSwitchEmptyRuleUpstreamIsUnroutable(t *testing.T) {
 	mux := New(
 		"default",
 		"",
-		Rule{upstream: "", ns: matchAll()},
+		Rule{upstream: "", ns: match.MustCompile("*")},
 	)
 
 	got, outcome := mux.Switch("other", nil)
@@ -95,16 +94,22 @@ func TestMuxSwitchEmptyRuleUpstreamIsUnroutable(t *testing.T) {
 	require.Equal(t, OutcomeUnroutable, outcome)
 }
 
-func (f matcherFunc) Match(s string) bool { return f(s) }
+func TestMuxSwitchZeroMatcherMatchesOnlyEmpty(t *testing.T) {
+	t.Parallel()
 
-func matchExact(want string) Matcher {
-	return matcherFunc(func(s string) bool { return s == want })
-}
+	// A Rule whose namespace matcher was never compiled must not act as a
+	// catch-all. The zero match.Matcher matches only the empty string.
+	mux := New(
+		"default",
+		"",
+		Rule{upstream: "unset"},
+	)
 
-func matchPrefix(p string) Matcher {
-	return matcherFunc(func(s string) bool { return strings.HasPrefix(s, p) })
-}
+	got, outcome := mux.Switch("anything", nil)
+	require.Equal(t, "default", got)
+	require.Equal(t, OutcomeDefault, outcome)
 
-func matchAll() Matcher {
-	return matcherFunc(func(string) bool { return true })
+	got, outcome = mux.Switch("", nil)
+	require.Equal(t, "unset", got)
+	require.Equal(t, OutcomeMatch, outcome)
 }


### PR DESCRIPTION
`Rule` compilation and the director both lived inside anonymous fx providers in fx.go. Exercising glob syntax or metadata key handling meant booting fx apps and asserting on app.Err() substrings, and testing the director meant hand-building struct literals that skipped the pool and socket wiring, which is the part worth exercising.

Lift both into their own files behind exported functions, `CompileMux` taking `config.Routing` and `NewDirector` taking its dependencies. The providers forward to them, so behaviour is unchanged.