### PR TITLE
[proxy]: Export ResolverFor and add WithSocketPath

### DIFF
--- a/internal/proxy/fx.go
+++ b/internal/proxy/fx.go
@@ -3,7 +3,6 @@ package proxy
 import (
 	"context"
 	"fmt"
-	"slices"
 
 	"go.uber.org/fx"
 	"google.golang.org/grpc"
@@ -16,7 +15,6 @@ import (
 	"github.com/temporalio/temporal-proxy/internal/transport/connect"
 	"github.com/temporalio/temporal-proxy/pkg/crypto"
 	"github.com/temporalio/temporal-proxy/pkg/logger"
-	"github.com/temporalio/temporal-proxy/pkg/logger/tag"
 )
 
 // Module is the fx module that constructs the proxy [Server] from [ProxyParams]
@@ -77,7 +75,7 @@ var Module = fx.Options(fx.Invoke(func(p ProxyParams) error {
 			dialOpts = append(dialOpts, grpc.WithChainUnaryInterceptor(enc))
 		}
 
-		res, err := upstreamResolver(up, dialOpts, p.Logger)
+		res, err := ResolverFor(up, dialOpts, p.Logger)
 		if err != nil {
 			return err
 		}
@@ -171,55 +169,4 @@ type ProxyParams struct {
 	// Optional values
 	Logger logger.Logger   `optional:"true"`
 	Types  protoutil.Types `optional:"true"`
-}
-
-// upstreamResolver builds the [connect.Resolver] for an upstream. When neither
-// the hostPort nor the TLS server name is templated it returns a static
-// resolver, whose connection is constructed while the graph is built, opened on
-// start, and reused for every request; otherwise it returns a DynamicResolver
-// that renders the target and server name, and rebuilds credentials, per request.
-// opts holds the request-independent dial options (namespace translation and
-// outbound credentials). log, when non-nil, is threaded into the DynamicResolver
-// for per-request debug entries.
-func upstreamResolver(upstream *config.Upstream, opts []grpc.DialOption, log logger.Logger) (connect.Resolver, error) {
-	// One Dialer per upstream owns the TLS-mode decision and parses its
-	// certificate material once, so a templated upstream reuses it across every
-	// per-request dial (only the rendered server name varies).
-	dialer := upstream.Listen.TLS.Dialer()
-
-	if upstream.IsTemplated() {
-		translator := func(s string) string { return s }
-		if upstream.Namespaces.Rules.Configured() {
-			translator = upstream.Namespaces.Rules.Remote
-		}
-
-		resolverOpts := []ResolverOption{
-			WithRemoteNamespacer(translator),
-			WithOptionsFactory(func(data RouteData) ([]grpc.DialOption, error) {
-				cred, err := dialer.DialOption(data.ResolvedServerName)
-				if err != nil {
-					return nil, err
-				}
-
-				return append(slices.Clone(opts), cred), nil
-			}),
-		}
-		if log != nil {
-			resolverOpts = append(resolverOpts, WithResolverLogger(log.With(tag.Component("resolver"))))
-		}
-
-		return NewDynamicResolver(upstream, resolverOpts...)
-	}
-
-	serverName := ""
-	if upstream.Listen.TLS != nil {
-		serverName = upstream.Listen.TLS.ServerName
-	}
-
-	cred, err := dialer.DialOption(serverName)
-	if err != nil {
-		return nil, fmt.Errorf("failed to build credentials for upstream %q: %w", upstream.Name, err)
-	}
-
-	return connect.StaticResolver(upstream.Listen.HostPort, append(slices.Clone(opts), cred)...), nil
 }

--- a/internal/proxy/resolver.go
+++ b/internal/proxy/resolver.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/temporalio/temporal-proxy/internal/config"
 	"github.com/temporalio/temporal-proxy/internal/template"
+	"github.com/temporalio/temporal-proxy/internal/transport/connect"
 	"github.com/temporalio/temporal-proxy/internal/transport/meta"
 	"github.com/temporalio/temporal-proxy/pkg/logger"
 	"github.com/temporalio/temporal-proxy/pkg/logger/tag"
@@ -99,6 +100,57 @@ func WithOptionsFactory(f func(RouteData) ([]grpc.DialOption, error)) ResolverOp
 // after a successful resolve. Unset: no entry is emitted.
 func WithResolverLogger(l logger.Logger) ResolverOption {
 	return func(r *DynamicResolver) { r.logger = l }
+}
+
+// ResolverFor builds the [connect.Resolver] for an upstream. When neither
+// the hostPort nor the TLS server name is templated it returns a static
+// resolver, whose connection is constructed while the graph is built, opened on
+// start, and reused for every request; otherwise it returns a DynamicResolver
+// that renders the target and server name, and rebuilds credentials, per request.
+// opts holds the request-independent dial options (namespace translation and
+// outbound credentials). log, when non-nil, is threaded into the DynamicResolver
+// for per-request debug entries.
+func ResolverFor(upstream *config.Upstream, opts []grpc.DialOption, log logger.Logger) (connect.Resolver, error) {
+	// One Dialer per upstream owns the TLS-mode decision and parses its
+	// certificate material once, so a templated upstream reuses it across every
+	// per-request dial (only the rendered server name varies).
+	dialer := upstream.Listen.TLS.Dialer()
+
+	if upstream.IsTemplated() {
+		translator := func(s string) string { return s }
+		if upstream.Namespaces.Rules.Configured() {
+			translator = upstream.Namespaces.Rules.Remote
+		}
+
+		resolverOpts := []ResolverOption{
+			WithRemoteNamespacer(translator),
+			WithOptionsFactory(func(data RouteData) ([]grpc.DialOption, error) {
+				cred, err := dialer.DialOption(data.ResolvedServerName)
+				if err != nil {
+					return nil, err
+				}
+
+				return append(slices.Clone(opts), cred), nil
+			}),
+		}
+		if log != nil {
+			resolverOpts = append(resolverOpts, WithResolverLogger(log.With(tag.Component("resolver"))))
+		}
+
+		return NewDynamicResolver(upstream, resolverOpts...)
+	}
+
+	serverName := ""
+	if upstream.Listen.TLS != nil {
+		serverName = upstream.Listen.TLS.ServerName
+	}
+
+	cred, err := dialer.DialOption(serverName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build credentials for upstream %q: %w", upstream.Name, err)
+	}
+
+	return connect.StaticResolver(upstream.Listen.HostPort, append(slices.Clone(opts), cred)...), nil
 }
 
 // IsStatic reports that a DynamicResolver always resolves per request.

--- a/internal/proxy/resolver_for_test.go
+++ b/internal/proxy/resolver_for_test.go
@@ -1,0 +1,53 @@
+package proxy_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/temporalio/temporal-proxy/internal/config"
+	"github.com/temporalio/temporal-proxy/internal/proxy"
+)
+
+func TestResolverForStatic(t *testing.T) {
+	t.Parallel()
+
+	up := &config.Upstream{
+		Name:   "primary",
+		Listen: config.ListenConfig{HostPort: "127.0.0.1:7233"},
+	}
+
+	res, err := proxy.ResolverFor(up, nil, nil)
+	require.NoError(t, err)
+	require.True(t, res.IsStatic(), "a plain hostPort resolves once and is reused")
+
+	key, target, _, err := res.Resolve(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, "127.0.0.1:7233", key)
+	require.Equal(t, "127.0.0.1:7233", target)
+}
+
+func TestResolverForTemplated(t *testing.T) {
+	t.Parallel()
+
+	up := &config.Upstream{
+		Name:   "cloud",
+		Listen: config.ListenConfig{HostPort: "{{ .RemoteNamespace }}.tmprl.cloud:7233"},
+	}
+
+	res, err := proxy.ResolverFor(up, nil, nil)
+	require.NoError(t, err)
+	require.False(t, res.IsStatic(), "a templated hostPort resolves per request")
+}
+
+func TestResolverForRejectsUnknownTemplateField(t *testing.T) {
+	t.Parallel()
+
+	up := &config.Upstream{
+		Name:   "cloud",
+		Listen: config.ListenConfig{HostPort: "{{ .Nope }}.tmprl.cloud:7233"},
+	}
+
+	_, err := proxy.ResolverFor(up, nil, nil)
+	require.Error(t, err)
+}

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -25,7 +25,8 @@ type (
 
 	// Options configures a [Server] at construction time.
 	Options struct {
-		logger logger.Logger
+		logger     logger.Logger
+		socketPath string
 	}
 
 	// Option configures a [Server] via [New].
@@ -52,9 +53,16 @@ func New(hostPort string, fw *Forwarder, opts ...Option) (*Server, error) {
 		return nil, fmt.Errorf("failed to create proxy: %s, %w", hostPort, err)
 	}
 
-	path, err := socket.UnixPath(hostPort)
-	if err != nil {
-		return nil, fmt.Errorf("failed to resolve socket path: %w", err)
+	path := pops.socketPath
+	if path == "" {
+		p, err := socket.UnixPath(hostPort)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve socket path: %w", err)
+		}
+
+		path = p
+	} else if err := socket.ValidatePath(path); err != nil {
+		return nil, fmt.Errorf("invalid socket path: %w", err)
 	}
 
 	return &Server{svr: svr, path: path}, nil
@@ -63,6 +71,14 @@ func New(hostPort string, fw *Forwarder, opts ...Option) (*Server, error) {
 // WithLogger sets the logger used by the proxy.
 func WithLogger(log logger.Logger) Option {
 	return Option(func(o *Options) { o.logger = log })
+}
+
+// WithSocketPath sets the unix socket path the proxy binds, overriding the one
+// derived from hostPort. A caller that also dials this socket passes the same
+// value to both sides so the two cannot disagree. [New] rejects a path that
+// exceeds the platform's sun_path limit.
+func WithSocketPath(path string) Option {
+	return Option(func(o *Options) { o.socketPath = path })
 }
 
 // Listen removes any socket left behind by a prior run and binds the proxy's

--- a/internal/proxy/server_test.go
+++ b/internal/proxy/server_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -128,6 +129,38 @@ func TestStartRemovesStaleSocket(t *testing.T) {
 
 	require.NoError(t, svr.Stop(t.Context()))
 	require.NoError(t, <-errCh)
+}
+
+func TestNewWithSocketPathOverridesDerivedPath(t *testing.T) {
+	t.Parallel()
+
+	// A directory under os.TempDir() rather than t.TempDir() keeps the path
+	// short: t.TempDir() embeds the full test name, which here would push the
+	// socket path past the sun_path limit socket.UnixPath enforces.
+	dir, err := os.MkdirTemp("", "socket-override")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+
+	want := filepath.Join(dir, "override.sock")
+
+	svr, err := proxy.New("127.0.0.1:7233", forwarder(t, "127.0.0.1:7233"), proxy.WithSocketPath(want))
+	require.NoError(t, err)
+
+	lis, err := svr.Listen(t.Context())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = lis.Close() })
+
+	require.Equal(t, want, lis.Addr().String())
+}
+
+func TestNewRejectsOverlongSocketPath(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(os.TempDir(), strings.Repeat("d", 120)+".sock")
+
+	_, err := proxy.New("127.0.0.1:7233", forwarder(t, "127.0.0.1:7233"), proxy.WithSocketPath(path))
+	require.ErrorContains(t, err, "invalid socket path")
+	require.ErrorContains(t, err, "exceeds limit")
 }
 
 func TestListenReturnsErrorWhenStaleSocketCannotBeRemoved(t *testing.T) {

--- a/internal/transport/socket/socket.go
+++ b/internal/transport/socket/socket.go
@@ -35,9 +35,20 @@ func UnixPath(hostPort string) (string, error) {
 	}, hostPort)
 
 	path := filepath.Join(os.TempDir(), fmt.Sprintf("%s-%s.sock", slug[:min(32, len(slug))], hash))
-	if len(path) > maxUnixPath {
-		return "", fmt.Errorf("unix socket path %q (%d bytes) exceeds limit of %d", path, len(path), maxUnixPath)
+	if err := ValidatePath(path); err != nil {
+		return "", err
 	}
 
 	return path, nil
+}
+
+// ValidatePath returns an error when path would exceed the platform's sun_path
+// limit. Callers that supply their own socket path instead of deriving one with
+// [UnixPath] use it to fail fast rather than at bind time.
+func ValidatePath(path string) error {
+	if len(path) > maxUnixPath {
+		return fmt.Errorf("unix socket path %q (%d bytes) exceeds limit of %d", path, len(path), maxUnixPath)
+	}
+
+	return nil
 }

--- a/internal/transport/socket/socket_test.go
+++ b/internal/transport/socket/socket_test.go
@@ -46,6 +46,34 @@ func TestUnixPath(t *testing.T) {
 	})
 }
 
+func TestValidatePath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		path    string
+		wantErr bool
+	}{
+		{name: "short path", path: "/tmp/proxy.sock"},
+		{name: "at the limit", path: "/" + strings.Repeat("d", 102)},
+		{name: "one byte over the limit", path: "/" + strings.Repeat("d", 103), wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := socket.ValidatePath(tt.path)
+			if !tt.wantErr {
+				require.NoError(t, err)
+				return
+			}
+
+			require.ErrorContains(t, err, "exceeds limit")
+		})
+	}
+}
+
 func TestUnixPathRejectsOverlongPath(t *testing.T) {
 	// Not parallel: mutates TMPDIR, which os.TempDir reads.
 	t.Setenv("TMPDIR", "/"+strings.Repeat("d", 200))


### PR DESCRIPTION
`upstreamResolver` held the templated-versus-static branch and the credential decision in code reachable only by booting an fx app. Neither path had a direct test.

Move it to resolver.go as `ResolverFor` and cover both branches. `WithSocketPath` lets one caller derive the unix socket path once and hand the same string to the proxy that binds it and the gateway that dials it. Today each side derives it independently and nothing enforces that they agree.