### PR TITLE
[auth]: Export AdmitAll

### DIFF
--- a/internal/auth/authenticator.go
+++ b/internal/auth/authenticator.go
@@ -30,7 +30,7 @@ type (
 		SecureHeaders() []string
 	}
 
-	defaultAuthenticator struct{}
+	admitAll struct{}
 
 	// strippedStream overrides Context so a downstream handler sees metadata with a
 	// consumed credential header removed.
@@ -39,6 +39,12 @@ type (
 		ctx context.Context
 	}
 )
+
+// AdmitAll returns the Authenticator used when no inbound authentication is
+// configured. It admits every request and consumes no header.
+func AdmitAll() Authenticator {
+	return &admitAll{}
+}
 
 // StreamServerInterceptor adapts an Authenticator to a gRPC stream server
 // interceptor, logging each rejection's detailed reason (never the token) via
@@ -83,14 +89,14 @@ func StreamServerInterceptor(a Authenticator, log logger.Logger) grpc.StreamServ
 	}
 }
 
-func (a *defaultAuthenticator) Authenticate(_ context.Context, _ metadata.MD) error {
+func (a *admitAll) Authenticate(_ context.Context, _ metadata.MD) error {
 	return nil
 }
 
-// SecureHeaders reports that the admit-all default consumes no header, so
+// SecureHeaders reports that admitAll consumes no header, so
 // StreamServerInterceptor strips nothing and the transparent relay is
 // preserved.
-func (a *defaultAuthenticator) SecureHeaders() []string { return nil }
+func (a *admitAll) SecureHeaders() []string { return nil }
 
 // Context returns the context carrying the stripped incoming metadata.
 func (s *strippedStream) Context() context.Context { return s.ctx }

--- a/internal/auth/authenticator_test.go
+++ b/internal/auth/authenticator_test.go
@@ -15,17 +15,23 @@ import (
 	"github.com/temporalio/temporal-proxy/pkg/logger"
 )
 
-type fakeStream struct {
-	grpc.ServerStream
-	ctx context.Context
+type (
+	fakeStream struct {
+		grpc.ServerStream
+		ctx context.Context
+	}
+
+	fakeAuthenticator struct{ err error }
+)
+
+func TestAdmitAll(t *testing.T) {
+	t.Parallel()
+
+	a := auth.AdmitAll()
+
+	require.NoError(t, a.Authenticate(t.Context(), metadata.MD{}))
+	require.Nil(t, a.SecureHeaders(), "admitting every request must strip no header")
 }
-
-func (f *fakeStream) Context() context.Context { return f.ctx }
-
-type fakeAuthenticator struct{ err error }
-
-func (f fakeAuthenticator) Authenticate(context.Context, metadata.MD) error { return f.err }
-func (fakeAuthenticator) SecureHeaders() []string                           { return nil }
 
 func TestStreamServerInterceptor(t *testing.T) {
 	t.Parallel()
@@ -123,3 +129,8 @@ func TestStreamServerInterceptorLogsReason(t *testing.T) {
 	require.NotContains(t, logged, "s3cret")
 	require.NotContains(t, logged, "wrong")
 }
+
+func (f *fakeStream) Context() context.Context { return f.ctx }
+
+func (f fakeAuthenticator) Authenticate(context.Context, metadata.MD) error { return f.err }
+func (fakeAuthenticator) SecureHeaders() []string                           { return nil }

--- a/internal/auth/fx.go
+++ b/internal/auth/fx.go
@@ -26,7 +26,7 @@ import (
 var Module = fx.Options(fx.Provide(func(cfg *config.Config, conns api.Connections) (Authenticator, error) {
 	ac := cfg.Auth
 	if ac == nil {
-		return &defaultAuthenticator{}, nil
+		return AdmitAll(), nil
 	}
 
 	selected := 0

--- a/internal/server/fx_test.go
+++ b/internal/server/fx_test.go
@@ -26,11 +26,6 @@ import (
 	"github.com/temporalio/temporal-proxy/pkg/validation"
 )
 
-// stubAuthenticator is a local admit-all stand-in for tests in this package,
-// which (being package server_test) cannot see the unexported
-// defaultAuthenticator that auth.Module supplies in production.
-type stubAuthenticator struct{}
-
 func TestModule(t *testing.T) {
 	t.Parallel()
 
@@ -183,7 +178,7 @@ func TestModuleWiresInjectedCodecAndHandler(t *testing.T) {
 		fx.Provide(
 			func() encoding.CodecV2 { return rec },
 			func() grpc.StreamHandler { return handler },
-			func() auth.Authenticator { return stubAuthenticator{} },
+			func() auth.Authenticator { return auth.AdmitAll() },
 		),
 		server.Module,
 		fx.NopLogger,
@@ -248,7 +243,7 @@ func TestModuleWiresMetricsInterceptor(t *testing.T) {
 		fx.Provide(
 			func() encoding.CodecV2 { return encoding.GetCodecV2("proto") },
 			func() grpc.StreamHandler { return handler },
-			func() auth.Authenticator { return stubAuthenticator{} },
+			func() auth.Authenticator { return auth.AdmitAll() },
 		),
 		server.Module,
 		fx.NopLogger,
@@ -290,9 +285,10 @@ func TestModuleWiresMetricsInterceptor(t *testing.T) {
 func TestServerEndToEndAuth(t *testing.T) {
 	t.Parallel()
 
-	// This wires the real auth.Module (not the nil-Authenticator stub used by the
-	// tests above) alongside server.Module over a real TCP listener, proving the
-	// two modules compose the way cmd/proxy/serve.go wires them.
+	// This wires the real auth.Module with a configured token (the tests above
+	// inject auth.AdmitAll() directly) alongside server.Module over a real TCP
+	// listener, proving the two modules compose the way cmd/proxy/serve.go wires
+	// them.
 	//
 	// The target is an unregistered method routed to the injected
 	// grpc.StreamHandler, the same shape router.Handler is installed as in
@@ -387,9 +383,6 @@ func TestServerEndToEndAuth(t *testing.T) {
 	require.NoError(t, app.Stop(stopCtx))
 }
 
-func (stubAuthenticator) Authenticate(context.Context, metadata.MD) error { return nil }
-func (stubAuthenticator) SecureHeaders() []string                         { return nil }
-
 func newTestApp(t *testing.T, opts ...fx.Option) *fx.App {
 	t.Helper()
 
@@ -406,7 +399,7 @@ func newTestApp(t *testing.T, opts ...fx.Option) *fx.App {
 					return status.Error(codes.Unimplemented, "stub handler")
 				}
 			},
-			func() auth.Authenticator { return stubAuthenticator{} },
+			func() auth.Authenticator { return auth.AdmitAll() },
 		),
 		server.Module,
 		fx.NopLogger,


### PR DESCRIPTION
The admit-all authenticator was unexported, so internal/server's external test package could not reach the one that ships and stubbed its own instead. Those tests were therefore exercising a different admit-all than production runs.

Export it and use it from both the provider and the server tests. The concrete type drops its `default` name for `admitAll`, so the type, the constructor, and the docs all describe it the same way.