### PR TITLE
[kms]: Do not schedule rotation without a vault

### DIFF
--- a/internal/kms/fx.go
+++ b/internal/kms/fx.go
@@ -72,7 +72,9 @@ var Module = fx.Options(
 		},
 	),
 	fx.Invoke(func(p KMSParams, v *crypto.Vault) {
-		if !p.Config.Encryption.Enabled {
+		// A vault is built from key presence, not from Enabled, so Enabled with no
+		// configured key yields no vault and nothing to rotate.
+		if !p.Config.Encryption.Enabled || v == nil {
 			return
 		}
 

--- a/internal/kms/fx_test.go
+++ b/internal/kms/fx_test.go
@@ -49,6 +49,32 @@ func TestModule_Enabled_ProvidesVaultAndRunsCleanly(t *testing.T) {
 	require.NotNil(t, v)
 }
 
+func TestModule_EnabledWithoutKeys_DoesNotScheduleRotation(t *testing.T) {
+	t.Parallel()
+
+	// Encryption enabled with no key policy yields a nil vault. Rotation must
+	// not be scheduled against it.
+	cfg := &config.Config{Encryption: config.Encryption{Enabled: true}}
+
+	var v *crypto.Vault
+	app := fx.New(append(
+		moduleOptions(t, cfg, logger.NewNoopLogger(), api.Connections{}),
+		fx.Populate(&v),
+		fx.NopLogger,
+	)...)
+
+	require.NoError(t, app.Err())
+	require.Nil(t, v)
+
+	startCtx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	require.NoError(t, app.Start(startCtx))
+
+	stopCtx, stop := context.WithTimeout(context.WithoutCancel(t.Context()), 5*time.Second)
+	defer stop()
+	require.NoError(t, app.Stop(stopCtx))
+}
+
 func TestModule_Enabled_InvalidURI_FailsConstruction(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
The vault is built from key presence while rotation was scheduled from Encryption.Enabled, so enabling encryption with no configured key produced a nil vault and a rotation goroutine that dereferences it.

The full app never hit this because whole-config validation rejects that combination, but validation lives in a module wired after this one, so the protection was ordering, not logic. Guard the hook and cover the case.