### PR TITLE
[server]: Bound the shutdown drain

### DIFF
--- a/cmd/proxy/serve.go
+++ b/cmd/proxy/serve.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"os"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/urfave/cli/v3"
@@ -22,6 +23,11 @@ import (
 	"github.com/temporalio/temporal-proxy/pkg/logger"
 	"github.com/temporalio/temporal-proxy/pkg/logger/tag"
 )
+
+// shutdownTimeout bounds the whole stop sequence: the serving tiers, which drain
+// concurrently within their own budgets, and every lifecycle hook queued behind
+// them.
+const shutdownTimeout = 30 * time.Second
 
 // fxLogger swallows fx's event stream except for Started/Stopped failures,
 // which it forwards to the app logger. Configuration errors are caught
@@ -93,6 +99,14 @@ func serve() *cli.Command {
 				metrics.Module,
 				protoutil.Module,
 				fx.WithLogger(func(l logger.Logger) fxevent.Logger { return &fxLogger{log: l} }),
+
+				// Stated rather than inherited, because the relationship is what
+				// matters and it is otherwise invisible: each serving tier drains
+				// within its own budget, this bounds all of them plus the hooks behind
+				// them, and whatever supervises the process has to allow more than
+				// this before it resorts to SIGKILL. fx abandons the hooks still
+				// queued when this expires.
+				fx.StopTimeout(shutdownTimeout),
 			)
 
 			if err := fxApp.Err(); err != nil {

--- a/internal/dataplane/lifecycle.go
+++ b/internal/dataplane/lifecycle.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"sync"
 
 	"github.com/temporalio/temporal-proxy/internal/transport/connect"
 	"github.com/temporalio/temporal-proxy/pkg/logger/tag"
@@ -57,8 +58,10 @@ func (d *Dataplane) Start(ctx context.Context) error {
 }
 
 // Stop drains the gateway first, so no request is admitted for a tier that is
-// going away, then every upstream proxy. The connection Pool is not closed
-// here; it belongs to whoever supplied it.
+// going away, then every upstream proxy. Each tier's drain is bounded, so the
+// upstreams go concurrently: they are independent, and serially their budgets
+// would sum, which is how a shutdown overruns the lifecycle deadline and strands
+// the hooks queued behind this one.
 func (d *Dataplane) Stop(ctx context.Context) error {
 	d.mu.Lock()
 	d.stopping = true
@@ -71,11 +74,21 @@ func (d *Dataplane) Stop(ctx context.Context) error {
 		errs = append(errs, err)
 	}
 
-	for _, up := range d.upstreams {
-		if err := up.svr.Stop(ctx); err != nil {
-			errs = append(errs, fmt.Errorf("upstream %q: %w", up.name, err))
-		}
+	// Indexed rather than appended, so the slot is written without coordinating
+	// and the report stays in upstream order.
+	upstreamErrs := make([]error, len(d.upstreams))
+
+	var wg sync.WaitGroup
+	for i, up := range d.upstreams {
+		wg.Go(func() {
+			if err := up.svr.Stop(ctx); err != nil {
+				upstreamErrs[i] = fmt.Errorf("upstream %q: %w", up.name, err)
+			}
+		})
 	}
+
+	wg.Wait()
+	errs = append(errs, upstreamErrs...)
 
 	// A graceful stop closes the listeners its server was serving on, but one
 	// bound by a Start that failed before its goroutine reached Serve is not

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -109,7 +109,8 @@ func (s *Server) Start(ctx context.Context, lis net.Listener) error {
 	return s.svr.Start(ctx, lis)
 }
 
-// Stop gracefully shuts the proxy down, waiting for in-flight RPCs to complete.
+// Stop shuts the proxy down, draining in-flight RPCs within the server's
+// shutdown budget and dropping whatever is left.
 func (s *Server) Stop(ctx context.Context) error {
 	if err := s.svr.Stop(ctx); err != nil {
 		return fmt.Errorf("failed to stop GRPC server: %w", err)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -16,6 +16,18 @@ import (
 	"github.com/temporalio/temporal-proxy/pkg/logger/tag"
 )
 
+const (
+	// defaultShutdownTimeout bounds the drain in [Server.Stop]. The gateway
+	// proxies long-poll methods that block 60s+, so a budget that waits them out
+	// would stall every restart; dropping them instead is safe because callers
+	// re-poll.
+	defaultShutdownTimeout = 5 * time.Second
+
+	// minShutdownTimeout keeps a zero or negative [WithShutdownTimeout] from
+	// turning Stop into an immediate kill: an already-answered call still flushes.
+	minShutdownTimeout = 50 * time.Millisecond
+)
+
 type (
 	// Server is a gRPC server with a built-in health service and a
 	// configurable periodic health check.
@@ -23,9 +35,10 @@ type (
 		grpcSvr   *grpc.Server
 		healthSvr *health.Server
 
-		creds          Credentials
-		healthCheck    HealthCheck
-		healthServices []string
+		creds           Credentials
+		healthCheck     HealthCheck
+		healthServices  []string
+		shutdownTimeout time.Duration
 
 		// mu guards logger and cancelFunc, which Start writes from its own
 		// goroutine while Stop reads them from the caller's goroutine.
@@ -52,6 +65,7 @@ type (
 		healthCheck        HealthCheck
 		healthServices     []string
 		logger             logger.Logger
+		shutdownTimeout    time.Duration
 		unaryInterceptors  []grpc.UnaryServerInterceptor
 		streamInterceptors []grpc.StreamServerInterceptor
 		services           []func(grpc.ServiceRegistrar)
@@ -63,13 +77,14 @@ type (
 )
 
 // New constructs a [Server]. When no options are supplied, it uses insecure
-// credentials, a default health check that always reports SERVING, and a CLI
-// logger.
+// credentials, a default health check that always reports SERVING, a CLI
+// logger, and a five second drain budget.
 func New(sopts ...Option) (*Server, error) {
 	opts := &options{
-		creds:       creds.NewListener(creds.Insecure()),
-		healthCheck: defaultHealthCheck(),
-		logger:      logger.Default(),
+		creds:           creds.NewListener(creds.Insecure()),
+		healthCheck:     defaultHealthCheck(),
+		logger:          logger.Default(),
+		shutdownTimeout: defaultShutdownTimeout,
 	}
 	for _, opt := range sopts {
 		opt.apply(opts)
@@ -97,12 +112,13 @@ func New(sopts ...Option) (*Server, error) {
 	}
 
 	return &Server{
-		grpcSvr:        svr,
-		healthSvr:      hc,
-		creds:          opts.creds,
-		healthCheck:    opts.healthCheck,
-		healthServices: opts.healthServices,
-		logger:         opts.logger,
+		grpcSvr:         svr,
+		healthSvr:       hc,
+		creds:           opts.creds,
+		healthCheck:     opts.healthCheck,
+		healthServices:  opts.healthServices,
+		logger:          opts.logger,
+		shutdownTimeout: opts.shutdownTimeout,
 	}, nil
 }
 
@@ -162,6 +178,14 @@ func WithLogger(log logger.Logger) Option {
 	return optFunc(func(o *options) { o.logger = log })
 }
 
+// WithShutdownTimeout bounds how long [Server.Stop] waits for in-flight calls
+// before dropping them. It defaults to five seconds and is clamped to a 50ms
+// floor. Stop also honours its Context, so the effective budget is whichever
+// expires first; a Context already cancelled forces immediately.
+func WithShutdownTimeout(d time.Duration) Option {
+	return optFunc(func(o *options) { o.shutdownTimeout = max(minShutdownTimeout, d) })
+}
+
 // Start serves on lis and blocks until the server stops. It also kicks off
 // the periodic health check, which runs until ctx is cancelled or [Server.Stop]
 // is called.
@@ -193,20 +217,71 @@ func (s *Server) Start(ctx context.Context, lis net.Listener) error {
 	return nil
 }
 
-// Stop gracefully shuts the server down, halting the health check loop and
-// waiting for in-flight RPCs to complete.
+// Stop shuts the server down, halting the health check loop and draining
+// in-flight RPCs. The drain is bounded by whichever expires first: the
+// [WithShutdownTimeout] budget or ctx. Past that, remaining calls are dropped.
+// A forced shutdown is still a shutdown, so it is reported through a warning
+// rather than an error; the only errors here would be a caller's to handle, and
+// there are none.
 func (s *Server) Stop(ctx context.Context) error {
 	s.mu.Lock()
-	logger := s.logger
+	log := s.logger
 	cancel := s.cancelFunc
 	s.mu.Unlock()
 
-	logger.Info("Shutting down")
+	log.Info("Shutting down")
+
+	// Flipped here rather than left to the health loop so a probe sees NOT_SERVING
+	// before the drain closes the listener, and so a status refresh already in
+	// flight cannot push SERVING back out behind it: SetServingStatus is ignored
+	// once the health server is shut down.
+	s.healthSvr.Shutdown()
 	if cancel != nil {
 		cancel()
 	}
 
-	s.grpcSvr.GracefulStop()
+	done := make(chan struct{})
+	go func() {
+		s.grpcSvr.GracefulStop()
+		close(done)
+	}()
+
+	// fx runs the remaining OnStop hooks off the same Context, so overrunning it
+	// strands them.
+	stopCtx, cancelStop := context.WithTimeout(ctx, s.shutdownTimeout)
+	defer cancelStop()
+
+	select {
+	case <-done:
+		log.Info("Server stopped cleanly")
+	case <-stopCtx.Done():
+		// stopCtx ends on whichever came first, our budget or ctx, so name which.
+		// An operator who raises WithShutdownTimeout past the caller's budget
+		// otherwise reads a number that never elapsed and tunes the knob that is
+		// not binding.
+		cause := "shutdown timeout"
+		if err := ctx.Err(); err != nil {
+			cause = "stop context: " + err.Error()
+		}
+
+		log.Warn(
+			"Drain ended with calls in flight. Dropping them",
+			tag.String("cause", cause),
+			tag.String("timeout", s.shutdownTimeout.String()),
+		)
+
+		// Closes the transports, so a caller waiting on a call this drain gave up on
+		// learns now rather than at its own timeout.
+		//
+		// Backgrounded because it cannot be relied on to return: GracefulStop waits
+		// for handlers while holding the server's lock, which Stop needs, so a
+		// handler that never returns wedges both, and Serve with them. That is why
+		// Serve is not waited on here and why the deadline is enforced by this
+		// select rather than by Stop. The goroutines end with the process, which by
+		// this point is what we are.
+		go s.grpcSvr.Stop()
+	}
+
 	return nil
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -22,9 +22,14 @@ import (
 
 	"github.com/temporalio/temporal-proxy/internal/server"
 	"github.com/temporalio/temporal-proxy/pkg/logger"
+	"github.com/temporalio/temporal-proxy/pkg/logger/tag"
 )
 
-const insecureMessage = "Running with insecure credentials. Configure TLS for production use."
+const (
+	insecureMessage = "Running with insecure credentials. Configure TLS for production use."
+	forcedMessage   = "Drain ended with calls in flight. Dropping them"
+	cleanMessage    = "Server stopped cleanly"
+)
 
 type (
 	failingCredentials struct {
@@ -469,6 +474,191 @@ func TestServerStartAndStop(t *testing.T) {
 	}
 }
 
+func TestStopForcesShutdownWhenHandlerHangs(t *testing.T) {
+	t.Parallel()
+
+	log := logger.NewTestLogger()
+	svr, callErr := wedgedServer(t,
+		server.WithLogger(log),
+		server.WithShutdownTimeout(100*time.Millisecond),
+	)
+
+	start := time.Now()
+	require.NoError(t, svr.Stop(t.Context()), "a forced shutdown is still a shutdown")
+	require.Less(t, time.Since(start), 5*time.Second, "Stop waited on the wedged handler")
+
+	require.True(t, log.Contains(forcedMessage), "expected the forced drain to be logged")
+	require.False(t, log.Contains(cleanMessage))
+	// Serve scopes the logger to the bound address, so that tag leads every entry.
+	require.True(
+		t,
+		log.ContainsEntry(
+			logger.LevelWarn,
+			forcedMessage,
+			tag.String("addr", "bufconn"),
+			tag.String("cause", "shutdown timeout"),
+			tag.String("timeout", "100ms"),
+		),
+		"the budget expiring should be reported as the cause",
+	)
+
+	// The point of forcing: the call this drain gave up on is dropped, so its
+	// caller finds out now instead of waiting on its own timeout.
+	select {
+	case err := <-callErr:
+		require.Error(t, err, "the abandoned call should have been dropped")
+	case <-time.After(5 * time.Second):
+		t.Fatal("the abandoned call was left hanging")
+	}
+}
+
+// Real time rather than synctest: the drain is bounded by a timer, but what it
+// waits on is gRPC's own connection bookkeeping across a bufconn pipe, which
+// synctest cannot see as idle.
+func TestWithShutdownTimeoutClampsToFloor(t *testing.T) {
+	t.Parallel()
+
+	log := logger.NewTestLogger()
+	svr, _ := wedgedServer(t,
+		server.WithLogger(log),
+		server.WithShutdownTimeout(0),
+	)
+
+	start := time.Now()
+	require.NoError(t, svr.Stop(t.Context()))
+
+	// Clamped, so an already-answered call still gets a moment to flush instead of
+	// the drain becoming an immediate kill.
+	require.GreaterOrEqual(t, time.Since(start), 50*time.Millisecond)
+	require.True(t, log.Contains(forcedMessage))
+}
+
+func TestStopHonoursContextDeadline(t *testing.T) {
+	t.Parallel()
+
+	log := logger.NewTestLogger()
+	svr, _ := wedgedServer(t,
+		server.WithLogger(log),
+		// Far longer than the Context allows, so only the deadline can end this.
+		server.WithShutdownTimeout(10*time.Second),
+	)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	require.NoError(t, svr.Stop(ctx))
+	require.Less(t, time.Since(start), 5*time.Second, "Stop ignored the Context deadline")
+
+	// The budget never elapsed, so blaming it would send an operator to raise a
+	// setting that was not binding.
+	require.True(
+		t,
+		log.ContainsEntry(
+			logger.LevelWarn,
+			forcedMessage,
+			tag.String("addr", "bufconn"),
+			tag.String("cause", "stop context: context deadline exceeded"),
+			tag.String("timeout", "10s"),
+		),
+		"the Context deadline should be reported as the cause, not the budget",
+	)
+}
+
+func TestStopWithCancelledContextForcesImmediately(t *testing.T) {
+	t.Parallel()
+
+	log := logger.NewTestLogger()
+	svr, _ := wedgedServer(t,
+		server.WithLogger(log),
+		server.WithShutdownTimeout(10*time.Second),
+	)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	require.NoError(t, svr.Stop(ctx))
+	require.True(t, log.Contains(forcedMessage), "a cancelled Context should force the drain")
+	require.True(
+		t,
+		log.ContainsEntry(
+			logger.LevelWarn,
+			forcedMessage,
+			tag.String("addr", "bufconn"),
+			tag.String("cause", "stop context: context canceled"),
+			tag.String("timeout", "10s"),
+		),
+		"a cancelled Context should be distinguishable from an expired budget",
+	)
+}
+
+func TestStopDrainsCleanlyWhenNothingIsInFlight(t *testing.T) {
+	t.Parallel()
+
+	log := logger.NewTestLogger()
+	svr, err := server.New(server.WithLogger(log))
+	require.NoError(t, err)
+
+	lis := bufconn.Listen(1024 * 1024)
+	defer func() { _ = lis.Close() }()
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- svr.Start(t.Context(), lis) }()
+
+	require.Eventually(t, func() bool {
+		return log.Contains("Starting the server")
+	}, time.Second, 10*time.Millisecond)
+
+	require.NoError(t, svr.Stop(t.Context()))
+	<-errCh
+
+	// Guards against the forced path becoming unconditional: with nothing to wait
+	// on, the drain must finish on its own.
+	require.True(t, log.Contains(cleanMessage))
+	require.False(t, log.Contains(forcedMessage))
+}
+
+func TestStopMarksNotServingBeforeDraining(t *testing.T) {
+	t.Parallel()
+
+	// A watcher keeps GracefulStop from ever finishing, so this exercises the
+	// forced path by design; the point is that the status flip still lands first.
+	svr, err := server.New(server.WithShutdownTimeout(100 * time.Millisecond))
+	require.NoError(t, err)
+
+	lis := bufconn.Listen(1024 * 1024)
+	defer func() { _ = lis.Close() }()
+
+	go func() { _ = svr.Start(t.Context(), lis) }()
+
+	conn := newBufConnClient(t, lis)
+	defer func() { _ = conn.Close() }()
+
+	stream, err := grpc_health_v1.NewHealthClient(conn).Watch(t.Context(), &grpc_health_v1.HealthCheckRequest{})
+	require.NoError(t, err)
+
+	first, err := stream.Recv()
+	require.NoError(t, err)
+	require.Equal(t, grpc_health_v1.HealthCheckResponse_SERVING, first.GetStatus())
+
+	go func() { _ = svr.Stop(t.Context()) }()
+
+	next, err := stream.Recv()
+	require.NoError(t, err)
+	require.Equal(t, grpc_health_v1.HealthCheckResponse_NOT_SERVING, next.GetStatus())
+}
+
+func TestStopBeforeStart(t *testing.T) {
+	t.Parallel()
+
+	// The rollback path: a Start that failed before reaching Serve still gets
+	// stopped, so Stop has to tolerate never having been started.
+	svr, err := server.New()
+	require.NoError(t, err)
+
+	require.NoError(t, svr.Stop(t.Context()))
+}
+
 func (f failingCredentials) ServerOption() (grpc.ServerOption, error) {
 	return nil, f.err
 }
@@ -492,6 +682,64 @@ func (c *recordingCodec) Unmarshal(data mem.BufferSlice, v any) error {
 }
 
 func (c *recordingCodec) Name() string { return c.delegate.Name() }
+
+// wedgedServer starts a server whose unknown-service handler parks forever,
+// standing in for one blocked on a backend that never answers, and returns once
+// that handler has actually been entered: only then is there something for the
+// drain to wait on. The handler is released during cleanup so it does not
+// outlive the test.
+//
+// The returned channel carries the parked call's outcome. Start's return is not
+// offered because a forced drain never produces one: GracefulStop waits for
+// handlers holding the server's lock, so a handler that never returns wedges it,
+// the forced Stop that needs the same lock, and Serve waiting on either to
+// finish. Stop returning promptly is the guarantee, not teardown.
+func wedgedServer(t *testing.T, sopts ...server.Option) (*server.Server, <-chan error) {
+	t.Helper()
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+
+	var once sync.Once
+	handler := func(_ any, _ grpc.ServerStream) error {
+		once.Do(func() { close(entered) })
+		<-release
+
+		return nil
+	}
+
+	svr, err := server.New(append(sopts, server.WithUnknownServiceHandler(handler))...)
+	require.NoError(t, err)
+
+	lis := bufconn.Listen(1024 * 1024)
+	t.Cleanup(func() { _ = lis.Close() })
+
+	go func() { _ = svr.Start(t.Context(), lis) }()
+
+	conn := newBufConnClient(t, lis)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	// Invoked from its own goroutine because it never returns until the drain
+	// drops it.
+	callErr := make(chan error, 1)
+	go func() {
+		callErr <- conn.Invoke(
+			t.Context(),
+			"/not.registered.Service/Method",
+			&grpc_health_v1.HealthCheckRequest{},
+			&grpc_health_v1.HealthCheckResponse{},
+		)
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("handler was never entered")
+	}
+
+	return svr, callErr
+}
 
 func newBufConnClient(t *testing.T, lis *bufconn.Listener) *grpc.ClientConn {
 	t.Helper()

--- a/pkg/ext/auth.go
+++ b/pkg/ext/auth.go
@@ -2,14 +2,21 @@ package ext
 
 import (
 	"context"
+	"strings"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
 	"github.com/temporalio/temporal-proxy/pkg/api/auth/v1"
 )
+
+// healthPrefix matches every method of the gRPC health service, which
+// [unaryGuard] lets through. Taken from the service descriptor rather than
+// spelled out, so it cannot drift from what was registered.
+var healthPrefix = "/" + grpc_health_v1.Health_ServiceDesc.ServiceName + "/"
 
 type (
 	// authService adapts an [Auth] to the generated service. The embedded
@@ -61,6 +68,11 @@ func (a *authService) Auth(ctx context.Context, req *auth.AuthRequest) (*auth.Au
 // Unauthenticated, and the message separates an absent credential from a rejected
 // one: both ends here are operator-run, so telling "wrong header" from "wrong
 // value" is worth more than withholding it.
+//
+// The health service is exempt. Guarding it would break every probe, which has no
+// credential to present and in Kubernetes' native gRPC prober cannot send
+// metadata at all, and would withhold nothing in exchange: Watch reports the same
+// status over a stream, which this interceptor does not see.
 func unaryGuard(hdr string, check CredentialCheck) grpc.UnaryServerInterceptor {
 	return func(
 		ctx context.Context,
@@ -68,6 +80,10 @@ func unaryGuard(hdr string, check CredentialCheck) grpc.UnaryServerInterceptor {
 		info *grpc.UnaryServerInfo,
 		handler grpc.UnaryHandler,
 	) (any, error) {
+		if strings.HasPrefix(info.FullMethod, healthPrefix) {
+			return handler(ctx, req)
+		}
+
 		md, ok := metadata.FromIncomingContext(ctx)
 		if !ok {
 			return nil, status.Error(codes.Unauthenticated, "missing metadata")

--- a/pkg/ext/doc.go
+++ b/pkg/ext/doc.go
@@ -13,14 +13,22 @@
 // [Auth] is the proxy asking about a worker that connected to the gateway;
 // [WithServerAuth] is about the caller of this server, which is the proxy.
 // Answering the first does not imply enforcing the second, and a server that
-// skips the second admits anyone who finds its port.
+// skips the second admits anyone who finds its port to everything but health.
+//
+// The gRPC health service is always registered, and always exempt from
+// [WithServerAuth], since a probe has no credential to present. It reports SERVING
+// from startup until shutdown begins, which makes it a liveness signal and not a
+// readiness one: it says this process is up and answering, never that the [Auth]
+// or [KMS] behind it can reach whatever it depends on. Wiring it to a readiness
+// probe would report a server with an unreachable key store as ready.
 //
 // The proxy fails closed, so any error from either service denies the request.
 // Return a [google.golang.org/grpc/status] error: the code tells the proxy
 // whether the caller can fix this or should retry, and a plain error arrives as
 // Unknown.
 //
-// [Serve] listens in plaintext unless [WithServerOption] supplies credentials.
-// Both are supported, but the ends must agree, since the proxy dials plaintext
-// when the extension server's TLS block is absent.
+// [Serve] listens in plaintext unless [WithServerOption] supplies credentials, and
+// warns once when the first call confirms it. Both are supported, but the ends must
+// agree, since the proxy dials plaintext when the extension server's TLS block is
+// absent.
 package ext

--- a/pkg/ext/plaintext.go
+++ b/pkg/ext/plaintext.go
@@ -1,0 +1,84 @@
+package ext
+
+import (
+	"context"
+	"sync"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/peer"
+
+	"github.com/temporalio/temporal-proxy/pkg/logger"
+)
+
+// plaintextMessage is logged the first time a call arrives unencrypted, and only
+// the first time: an extension server admits callers and unwraps key material, so
+// this is worth saying, but not once per request.
+const plaintextMessage = "Serving in plaintext. Supply credentials via WithServerOption for production use."
+
+// plaintextWarning returns interceptors that log [plaintextMessage] once if calls
+// are arriving over an unencrypted connection.
+//
+// It reads the connection rather than the configuration because a
+// [grpc.ServerOption] is opaque: what [WithServerOption] was handed cannot be read
+// back, so whether this server ended up serving TLS is only knowable from a call
+// that actually arrived. The cost is that a server nobody ever calls stays quiet,
+// which the health service makes unlikely.
+func plaintextWarning(log logger.Logger) (grpc.UnaryServerInterceptor, grpc.StreamServerInterceptor) {
+	var once sync.Once
+
+	warn := func(ctx context.Context) {
+		if isPlaintext(ctx) {
+			once.Do(func() { log.Warn(plaintextMessage) })
+		}
+	}
+
+	unary := func(
+		ctx context.Context,
+		req any,
+		_ *grpc.UnaryServerInfo,
+		handler grpc.UnaryHandler,
+	) (any, error) {
+		warn(ctx)
+
+		return handler(ctx, req)
+	}
+
+	stream := func(
+		srv any,
+		ss grpc.ServerStream,
+		_ *grpc.StreamServerInfo,
+		handler grpc.StreamHandler,
+	) error {
+		warn(ss.Context())
+
+		return handler(srv, ss)
+	}
+
+	return unary, stream
+}
+
+// isPlaintext reports whether the call in ctx arrived unencrypted. A server given
+// no credentials attaches no auth information at all, and insecure credentials
+// report NoSecurity. A credential that reports no level is left alone rather than
+// assumed plaintext, matching how gRPC treats one: a false warning about somebody
+// else's custom credentials would be worse than staying quiet.
+func isPlaintext(ctx context.Context) bool {
+	p, ok := peer.FromContext(ctx)
+	if !ok {
+		return false
+	}
+
+	if p.AuthInfo == nil {
+		return true
+	}
+
+	common, ok := p.AuthInfo.(interface {
+		GetCommonAuthInfo() credentials.CommonAuthInfo
+	})
+	if !ok {
+		return false
+	}
+
+	return common.GetCommonAuthInfo().SecurityLevel == credentials.NoSecurity
+}

--- a/pkg/ext/server.go
+++ b/pkg/ext/server.go
@@ -11,6 +11,8 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health"
+	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/keepalive"
 
 	"github.com/temporalio/temporal-proxy/pkg/api/auth/v1"
@@ -96,11 +98,29 @@ func Serve(ctx context.Context, opts ...Option) error {
 		}, sOpts.serverOptions...)
 	}
 
+	// Prepended after the guard so it ends up outermost, which means it also sees
+	// the calls the guard turns away: one of those arrived over the same wire this
+	// is about, and a server rejecting everything is exactly when an operator is
+	// looking at the log.
+	warnUnary, warnStream := plaintextWarning(sOpts.logger)
+	sOpts.serverOptions = append([]grpc.ServerOption{
+		grpc.ChainUnaryInterceptor(warnUnary),
+		grpc.ChainStreamInterceptor(warnStream),
+	}, sOpts.serverOptions...)
+
 	svr := grpc.NewServer(sOpts.serverOptions...)
 	auth.RegisterAuthServiceServer(svr, &authService{auth: sOpts.auth})
 	kms.RegisterEncryptionServiceServer(svr, &kmsService{kms: sOpts.kms, log: sOpts.logger})
 
-	return runServer(ctx, svr, sOpts)
+	// Registered unconditionally: without it there is no way to ask this server
+	// whether it is up, and a probe is the one caller that cannot be configured to
+	// use something else. It reports SERVING from the moment it is registered until
+	// shutdown, which makes it a liveness signal and not a readiness one; see the
+	// package documentation.
+	hc := health.NewServer()
+	grpc_health_v1.RegisterHealthServer(svr, hc)
+
+	return runServer(ctx, svr, hc, sOpts)
 }
 
 // WithAddr sets the address to listen on, defaulting to :8900 on every
@@ -148,9 +168,13 @@ func WithLogger(l logger.Logger) Option {
 // WithServerAuth guards this server's unary methods with check, which receives
 // the single value of the header metadata. It authenticates the proxy to this
 // server, unlike the [Auth] service, which is how the proxy asks about somebody
-// else. Unary covers the whole surface today, since both generated services are
-// unary; adding a streaming method to either proto means pairing this with a
+// else. Unary covers both generated services, since every method on them is unary;
+// adding a streaming method to either proto means pairing this with a
 // [grpc.StreamServerInterceptor].
+//
+// The health service is exempt, and deliberately: a probe has no credential to
+// give, and guarding it would withhold nothing anyway, because Watch reports the
+// same status over a stream that no unary interceptor sees.
 //
 // A call is rejected with Unauthenticated unless the header is present exactly
 // once and check accepts its value. Repeats are refused rather than searched, so
@@ -186,6 +210,11 @@ func WithServerOption(opts ...grpc.ServerOption) Option {
 // floor, so a zero or negative value still lets an already-answered call flush.
 // Set it below the grace period of whatever supervises the process; overrunning
 // that trades the graceful shutdown for a SIGKILL.
+//
+// A client watching the health service holds the drain open until this expires,
+// because a Watch ends with its stream rather than with the status going
+// NOT_SERVING. Expect the bound to be reached, not merely available, wherever
+// something watches.
 func WithShutdownTimeout(t time.Duration) Option {
 	return func(o *options) { o.shutdownTimeout = max(50*time.Millisecond, t) }
 }
@@ -193,7 +222,7 @@ func WithShutdownTimeout(t time.Duration) Option {
 // runServer serves and shuts down on the first of ctx being cancelled or a signal
 // arriving. The listener is obtained before the signal handler is installed, so a
 // bind failure comes back as Serve's error rather than as a shutdown.
-func runServer(ctx context.Context, svr *grpc.Server, opts *options) error {
+func runServer(ctx context.Context, svr *grpc.Server, hc *health.Server, opts *options) error {
 	lis := opts.listener
 	if lis == nil {
 		var err error
@@ -223,6 +252,11 @@ func runServer(ctx context.Context, svr *grpc.Server, opts *options) error {
 		return err
 	case <-ctx.Done():
 		log.Info("Shutdown signal received")
+
+		// Ahead of the drain, so anything routing to this server is told to stop
+		// before the door closes rather than by a refused connection. Note this does
+		// not end an open Watch: a watcher holds the drain open until the timeout.
+		hc.Shutdown()
 
 		// GracefulStop has no bound of its own, so it runs where it can be abandoned.
 		// A handler blocked on a backend that never answers would otherwise hold the

--- a/pkg/ext/server_test.go
+++ b/pkg/ext/server_test.go
@@ -15,6 +15,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/test/bufconn"
@@ -36,6 +37,11 @@ const (
 	// request in TestReceiveLimit is refused by the server's own limit rather than
 	// wedged in the pipe.
 	bufSize = 4 * 1024 * 1024
+
+	// plaintextMessage is the warning ext logs for an unencrypted connection.
+	// Spelled out here rather than exported: publishing a log line as API would
+	// promise not to reword it.
+	plaintextMessage = "Serving in plaintext. Supply credentials via WithServerOption for production use."
 )
 
 // blockingKMS enters Wrap, records that it did, and stays there until released.
@@ -382,6 +388,108 @@ func (b *blockingKMS) Unwrap(context.Context, []byte) ([]byte, error) {
 	return nil, status.Error(codes.Unimplemented, "not used")
 }
 
+func TestServeRegistersHealthService(t *testing.T) {
+	t.Parallel()
+
+	client := grpc_health_v1.NewHealthClient(dial(t, serve(t), nil))
+
+	resp, err := client.Check(t.Context(), &grpc_health_v1.HealthCheckRequest{})
+	require.NoError(t, err)
+	require.Equal(t, grpc_health_v1.HealthCheckResponse_SERVING, resp.GetStatus())
+}
+
+func TestHealthIsExemptFromServerAuth(t *testing.T) {
+	t.Parallel()
+
+	conn := dial(t, serve(t, ext.WithServerAuth(extHeader, acceptExtToken)), nil)
+
+	// No credential, because a probe has none to give.
+	resp, err := grpc_health_v1.NewHealthClient(conn).Check(
+		t.Context(),
+		&grpc_health_v1.HealthCheckRequest{},
+	)
+	require.NoError(t, err, "guarding health would break every probe")
+	require.Equal(t, grpc_health_v1.HealthCheckResponse_SERVING, resp.GetStatus())
+
+	// The same call without a credential to a guarded service, to show the
+	// exemption is confined to health rather than the guard being absent.
+	_, err = auth.NewAuthServiceClient(conn).Auth(t.Context(), &auth.AuthRequest{})
+	require.Error(t, err)
+	require.Equal(t, codes.Unauthenticated, status.Code(err))
+}
+
+func TestHealthReportsNotServingOnShutdown(t *testing.T) {
+	t.Parallel()
+
+	lis := bufconn.Listen(bufSize)
+	ctx, cancel := context.WithCancel(t.Context())
+
+	errs := make(chan error, 1)
+	go func() {
+		errs <- ext.Serve(ctx,
+			ext.WithListener(lis),
+			ext.WithLogger(logger.NewNoopLogger()),
+			// A watcher holds the drain open, so this shutdown is forced by design.
+			ext.WithShutdownTimeout(100*time.Millisecond),
+		)
+	}()
+
+	stream, err := grpc_health_v1.NewHealthClient(dial(t, lis, nil)).Watch(
+		t.Context(),
+		&grpc_health_v1.HealthCheckRequest{},
+	)
+	require.NoError(t, err)
+
+	first, err := stream.Recv()
+	require.NoError(t, err)
+	require.Equal(t, grpc_health_v1.HealthCheckResponse_SERVING, first.GetStatus())
+
+	cancel()
+
+	// Watchers are told before the door closes, so whatever routes here can stop
+	// sending rather than discovering it through a refused connection.
+	next, err := stream.Recv()
+	require.NoError(t, err)
+	require.Equal(t, grpc_health_v1.HealthCheckResponse_NOT_SERVING, next.GetStatus())
+
+	require.NoError(t, waitFor(t, errs))
+}
+
+func TestServeWarnsWhenServingPlaintext(t *testing.T) {
+	t.Parallel()
+
+	log := logger.NewTestLogger()
+	client := grpc_health_v1.NewHealthClient(dial(t, serve(t, ext.WithLogger(log)), nil))
+
+	// The warning reads the connection, not the configuration, so it needs a call
+	// to have arrived before there is anything to report.
+	_, err := client.Check(t.Context(), &grpc_health_v1.HealthCheckRequest{})
+	require.NoError(t, err)
+
+	require.True(t, log.ContainsEntry(logger.LevelWarn, plaintextMessage))
+}
+
+func TestServeDoesNotWarnWhenServingTLS(t *testing.T) {
+	t.Parallel()
+
+	log := logger.NewTestLogger()
+	lis, roots := serveTLS(t, ext.WithLogger(log))
+
+	// ServerName because the certificate is issued for localhost and an in-memory
+	// listener has no name to match it against. Omitting it fails the handshake,
+	// which WaitForReady turns into a hang rather than an error.
+	client := grpc_health_v1.NewHealthClient(dial(t, lis, credentials.NewTLS(&tls.Config{
+		RootCAs:    roots,
+		ServerName: "localhost",
+		MinVersion: tls.VersionTLS12,
+	})))
+
+	_, err := client.Check(t.Context(), &grpc_health_v1.HealthCheckRequest{})
+	require.NoError(t, err)
+
+	require.False(t, log.Contains(plaintextMessage), "TLS via WithServerOption should be recognised")
+}
+
 // acceptExtToken is the stand-in for a real [ext.CredentialCheck]. A production
 // one compares in constant time; this one only has to be a function that agrees
 // with extToken.
@@ -497,7 +605,7 @@ func serve(t *testing.T, opts ...ext.Option) *bufconn.Listener {
 // listener along with a pool that trusts it. TLS arrives as a server option and
 // lands after Serve's own insecure default, which is what lets it win rather than
 // having to be unset first.
-func serveTLS(t *testing.T) (lis *bufconn.Listener, roots *x509.CertPool) {
+func serveTLS(t *testing.T, opts ...ext.Option) (lis *bufconn.Listener, roots *x509.CertPool) {
 	t.Helper()
 
 	certFile, keyFile := testutil.GenerateSelfSignedCert(t)
@@ -510,10 +618,12 @@ func serveTLS(t *testing.T) (lis *bufconn.Listener, roots *x509.CertPool) {
 	roots = x509.NewCertPool()
 	require.True(t, roots.AppendCertsFromPEM(pem))
 
-	return serve(t, ext.WithServerOption(grpc.Creds(credentials.NewTLS(&tls.Config{
-		Certificates: []tls.Certificate{cert},
-		MinVersion:   tls.VersionTLS12,
-	})))), roots
+	return serve(t, append([]ext.Option{
+		ext.WithServerOption(grpc.Creds(credentials.NewTLS(&tls.Config{
+			Certificates: []tls.Certificate{cert},
+			MinVersion:   tls.VersionTLS12,
+		}))),
+	}, opts...)...), roots
 }
 
 // waitFor reads from ch, failing the test rather than hanging until the package


### PR DESCRIPTION
Stop called GracefulStop with no bound and ignored its Context, so a handler parked on a backend that never answers held the process open indefinitely. The only thing intervening was fx's default stop timeout, and when that expires fx abandons the hooks still queued behind the dataplane's, leaving the metrics server, key rotation and the connection pool unstopped.

Stop now drains within whichever expires first, the WithShutdownTimeout budget or the Context it was given, and then closes the transports so a caller waiting on a call we gave up on finds out immediately rather than at its own timeout. The default is five seconds.

It still returns nil when it forces. The gateway proxies long-poll methods that block 60s+, so with any sane budget, forcing is the ordinary path on a restart rather than a fault; reporting it as an error would mean exiting non-zero on every rollout and would train operators to ignore the one signal that matters. The warning carries the budget instead.