### PR TITLE
[server]: Publish a health entry per allowed service

### DIFF
--- a/internal/dataplane/dataplane.go
+++ b/internal/dataplane/dataplane.go
@@ -156,6 +156,9 @@ func New(ctx context.Context, cfg *config.Config, opts ...Option) (*Dataplane, e
 	gateway, err := server.New(
 		server.WithCredentials(cfg.Listen.TLS.Listener()),
 		server.WithServerCodec(router.Codec()),
+		// Health entries come from the allowlist, so what the gateway reports a
+		// status for is exactly what it will forward.
+		server.WithHealthServices(o.allowlist.ServiceNames()...),
 		server.WithStreamInterceptor(reps.server.StreamInterceptor()),
 		server.WithStreamInterceptor(auth.StreamServerInterceptor(o.auth, o.logger)),
 		server.WithUnknownServiceHandler(handler),

--- a/internal/dataplane/gateway_test.go
+++ b/internal/dataplane/gateway_test.go
@@ -159,6 +159,63 @@ func TestGatewayEndToEndAuth(t *testing.T) {
 	}
 }
 
+// TestGatewayHealthCoversEveryAllowedService proves the gateway's health service
+// is seeded from the allowlist. A client that probes one service by name (the
+// SDK's CheckHealth names WorkflowService) must get a status, and a service the
+// gateway will not forward must stay unknown rather than report SERVING.
+func TestGatewayHealthCoversEveryAllowedService(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		allowed  config.Services
+		serving  []string
+		notFound string
+	}{
+		{
+			// The configuration an SDK worker crashed behind: it names no services,
+			// so the entries have to come from the default set rather than from the
+			// raw field, or WorkflowService is unknown again.
+			name:     "a configuration naming no service publishes the default set",
+			allowed:  nil,
+			serving:  []string{"", services.WorkflowService, services.OperatorService},
+			notFound: services.Reflection,
+		},
+		{
+			// Allowing reflection admits its superseded spelling too, so both answer.
+			name:     "named services publish, compatibility aliases included",
+			allowed:  config.Services{services.WorkflowService, services.Reflection},
+			serving:  []string{"", services.WorkflowService, services.Reflection, services.ReflectionV1Alpha},
+			notFound: services.OperatorService,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := liveConfig(t)
+			cfg.AllowedServices = tt.allowed
+
+			dp := startPlane(t, newTestDeps(t, cfg))
+			client := grpc_health_v1.NewHealthClient(dialGateway(t, dp))
+
+			check := func(service string) (*grpc_health_v1.HealthCheckResponse, error) {
+				return client.Check(t.Context(), &grpc_health_v1.HealthCheckRequest{Service: service})
+			}
+
+			for _, svc := range tt.serving {
+				resp, err := check(svc)
+				require.NoError(t, err, "Check(%q)", svc)
+				require.Equal(t, grpc_health_v1.HealthCheckResponse_SERVING, resp.GetStatus(), "Check(%q)", svc)
+			}
+
+			_, err := check(tt.notFound)
+			require.Equal(t, codes.NotFound, status.Code(err), "Check(%q) must not report a status", tt.notFound)
+		})
+	}
+}
+
 // serveEcho starts a plaintext gRPC server hosting echoDesc and returns its
 // address for use as an upstream hostPort.
 func serveEcho(t *testing.T) string {

--- a/internal/router/handler_test.go
+++ b/internal/router/handler_test.go
@@ -530,6 +530,10 @@ func (stubReflector) Namespace(string, []byte) string { return "" }
 
 func (stubAllowlist) Allows(string) bool { return true }
 
+// ServiceNames has nothing to report: this stub admits by rule rather than from
+// a set, and the handler never enumerates.
+func (stubAllowlist) ServiceNames() []string { return nil }
+
 func (r *recordingReflector) Namespace(method string, payload []byte) string {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -23,8 +23,9 @@ type (
 		grpcSvr   *grpc.Server
 		healthSvr *health.Server
 
-		creds       Credentials
-		healthCheck HealthCheck
+		creds          Credentials
+		healthCheck    HealthCheck
+		healthServices []string
 
 		// mu guards logger and cancelFunc, which Start writes from its own
 		// goroutine while Stop reads them from the caller's goroutine.
@@ -49,6 +50,7 @@ type (
 	options struct {
 		creds              Credentials
 		healthCheck        HealthCheck
+		healthServices     []string
 		logger             logger.Logger
 		unaryInterceptors  []grpc.UnaryServerInterceptor
 		streamInterceptors []grpc.StreamServerInterceptor
@@ -84,16 +86,23 @@ func New(sopts ...Option) (*Server, error) {
 	hc := health.NewServer()
 	grpc_health_v1.RegisterHealthServer(svr, hc)
 
+	// Seeded here rather than in the health loop so every entry exists before the
+	// first connection is accepted.
+	for _, name := range opts.healthServices {
+		hc.SetServingStatus(name, grpc_health_v1.HealthCheckResponse_SERVING)
+	}
+
 	for _, register := range opts.services {
 		register(svr)
 	}
 
 	return &Server{
-		grpcSvr:     svr,
-		healthSvr:   hc,
-		creds:       opts.creds,
-		healthCheck: opts.healthCheck,
-		logger:      opts.logger,
+		grpcSvr:        svr,
+		healthSvr:      hc,
+		creds:          opts.creds,
+		healthCheck:    opts.healthCheck,
+		healthServices: opts.healthServices,
+		logger:         opts.logger,
 	}, nil
 }
 
@@ -139,6 +148,13 @@ func WithServerCodec(c encoding.CodecV2) Option {
 // service's serving status.
 func WithHealthCheck(hc HealthCheck) Option {
 	return optFunc(func(o *options) { o.healthCheck = hc })
+}
+
+// WithHealthServices names the services the health service answers for, by proto
+// full name. Each gets an entry reporting the same status as the unnamed one.
+// Names accumulate across calls.
+func WithHealthServices(names ...string) Option {
+	return optFunc(func(o *options) { o.healthServices = append(o.healthServices, names...) })
 }
 
 // WithLogger sets the logger used by the server.
@@ -198,7 +214,11 @@ func (s *Server) runHealthCheck(ctx context.Context) {
 	next := grpc_health_v1.HealthCheckResponse_SERVING
 
 	for {
+		// Every entry reports the same status: the server's health is process-wide.
 		s.healthSvr.SetServingStatus("", next)
+		for _, name := range s.healthServices {
+			s.healthSvr.SetServingStatus(name, next)
+		}
 
 		select {
 		case <-ctx.Done():

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -354,6 +354,69 @@ func TestWithServerCodec(t *testing.T) {
 	require.Positive(t, rec.calls.Load(), "forced server codec should be exercised")
 }
 
+func TestWithHealthServices(t *testing.T) {
+	t.Parallel()
+
+	// Literal names rather than the services package's constants: the server is
+	// generic and only publishes what it is handed.
+	const (
+		workflow = "temporal.api.workflowservice.v1.WorkflowService"
+		operator = "temporal.api.operatorservice.v1.OperatorService"
+	)
+
+	var serving atomic.Int32
+	serving.Store(int32(grpc_health_v1.HealthCheckResponse_SERVING))
+	hc := server.HealthCheckFunc(10*time.Millisecond, func(context.Context) grpc_health_v1.HealthCheckResponse_ServingStatus {
+		return grpc_health_v1.HealthCheckResponse_ServingStatus(serving.Load())
+	})
+
+	svr, err := server.New(
+		server.WithHealthCheck(hc),
+		server.WithHealthServices(workflow, operator),
+	)
+	require.NoError(t, err)
+
+	lis := bufconn.Listen(1024 * 1024)
+	defer func() { _ = lis.Close() }()
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- svr.Start(t.Context(), lis) }()
+
+	conn := newBufConnClient(t, lis)
+	defer func() { _ = conn.Close() }()
+
+	client := grpc_health_v1.NewHealthClient(conn)
+	check := func(service string) (*grpc_health_v1.HealthCheckResponse, error) {
+		return client.Check(t.Context(), &grpc_health_v1.HealthCheckRequest{Service: service})
+	}
+
+	// Asserted without Eventually: every entry exists from construction, so a
+	// client that connects the instant the server starts cannot see NOT_FOUND for
+	// a service the server advertises.
+	for _, service := range []string{"", workflow, operator} {
+		resp, err := check(service)
+		require.NoError(t, err, "Check(%q)", service)
+		require.Equal(t, grpc_health_v1.HealthCheckResponse_SERVING, resp.GetStatus(), "Check(%q)", service)
+	}
+
+	// A service that was not advertised stays unknown, so a client cannot read a
+	// status for something this server does not answer for.
+	_, err = check("temporal.api.adminservice.v1.AdminService")
+	require.Equal(t, codes.NotFound, status.Code(err))
+
+	// The periodic check drives every entry, not just the unnamed one.
+	serving.Store(int32(grpc_health_v1.HealthCheckResponse_NOT_SERVING))
+	for _, service := range []string{"", workflow, operator} {
+		require.Eventually(t, func() bool {
+			resp, err := check(service)
+			return err == nil && resp.GetStatus() == grpc_health_v1.HealthCheckResponse_NOT_SERVING
+		}, time.Second, 10*time.Millisecond, "Check(%q)", service)
+	}
+
+	require.NoError(t, svr.Stop(t.Context()))
+	<-errCh
+}
+
 func TestServerStartAndStop(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/allowlist.go
+++ b/internal/services/allowlist.go
@@ -1,12 +1,22 @@
 package services
 
+import (
+	"maps"
+	"slices"
+)
+
 type (
-	// Allowlist reports whether the proxy will forward the named service. Allows
-	// matches a service full name only, so a caller holding a gRPC full method
-	// must strip the method first. An Allowlist built from no names allows
-	// nothing.
+	// Allowlist is the set of services the proxy will forward. One built from no
+	// names admits nothing.
 	Allowlist interface {
+		// Allows reports whether the named service was admitted. It matches a
+		// service full name only, so a caller holding a gRPC full method must strip
+		// the method first.
 		Allows(string) bool
+
+		// ServiceNames returns the admitted names in sorted order, for callers that
+		// publish the set rather than query it.
+		ServiceNames() []string
 	}
 
 	// allowSet is the concrete admission set, keyed by proto full name. It admits
@@ -33,4 +43,10 @@ func NewAllowlist(names []string) Allowlist {
 func (s allowSet) Allows(name string) bool {
 	_, ok := s[name]
 	return ok
+}
+
+// ServiceNames returns every admitted name, aliases included, sorted so the
+// order does not shift between runs.
+func (s allowSet) ServiceNames() []string {
+	return slices.Sorted(maps.Keys(s))
 }

--- a/internal/services/allowlist_test.go
+++ b/internal/services/allowlist_test.go
@@ -104,6 +104,47 @@ func TestAllowlistAllows(t *testing.T) {
 	}
 }
 
+func TestAllowlistServiceNames(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		allowed []string
+		want    []string
+	}{
+		{
+			name:    "the default set names the two default services",
+			allowed: services.Default(),
+			want:    []string{services.OperatorService, services.WorkflowService},
+		},
+		{
+			name:    "reflection names both spellings, since both are admitted",
+			allowed: []string{services.Reflection},
+			want:    []string{services.Reflection, services.ReflectionV1Alpha},
+		},
+		{
+			name:    "a repeated name is named once",
+			allowed: []string{services.WorkflowService, services.WorkflowService},
+			want:    []string{services.WorkflowService},
+		},
+		{
+			name:    "an empty list names nothing",
+			allowed: nil,
+			want:    nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Sorted output, so callers publishing these (health entries, log
+			// lines) get a stable order rather than map iteration order.
+			require.Equal(t, tt.want, services.NewAllowlist(tt.allowed).ServiceNames())
+		})
+	}
+}
+
 func TestNewAllowlistToleratesDuplicates(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
The health service only ever answered for the empty service name, so a client that named a service got NOT_FOUND. That breaks the Go SDK's CheckHealth, which probes temporal.api.workflowservice.v1.WorkflowService, along with any per-service liveness probe pointed at the proxy. The Temporal frontend answers under each service's proto full name, so clients reasonably expect the proxy to do the same.

Servers now take WithHealthServices, which gives each named service its own entry reporting the same status as the empty one; the proxy's health is process-wide, so there is nothing per-service to distinguish yet. The gateway supplies those names from its allowlist through the new Allowlist.ServiceNames, so the set it reports a status for cannot drift from the set it will forward. Allowing reflection therefore publishes both the v1 and the v1alpha spelling, matching what is actually forwardable, while a service configuration did not allow stays NOT_FOUND instead of claiming a status.

Fixes #128