### PR TITLE
[codec]: Add a shared payload codec chain

### DIFF
--- a/internal/dataplane/dataplane.go
+++ b/internal/dataplane/dataplane.go
@@ -317,21 +317,33 @@ func newUpstreamTier(
 		dialOpts = append(dialOpts, outbound.DialOptions(cp)...)
 	}
 
-	// A vault is present whenever encryption keys are configured, which may be
-	// true even when encryption is disabled; install the interceptor whenever one
-	// is present and pass Enabled so sealing is gated while inbound decryption
-	// always runs. That keeps payloads sealed earlier openable after encryption
-	// is turned off for new traffic. Added after translation so it is the
-	// innermost unary interceptor, sealing outbound payloads last and opening
-	// inbound payloads first.
-	if o.vault != nil {
-		enc, err := proxy.EncryptionInterceptor(cfg.Encryption.Enabled, o.vault, reps.encryption)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to build encryption interceptor for upstream %q: %w", up.Name, err)
-		}
+	// One interceptor applies every payload codec, so anything added to the chain
+	// travels this path without another interceptor here. It decides for itself
+	// which codecs a direction needs and skips a direction with none, so it is
+	// installed unconditionally rather than gated on any one codec's config. A
+	// vault is present whenever encryption keys are configured, which may be true
+	// even when encryption is disabled; passing Enabled gates sealing while
+	// inbound decryption always runs, keeping payloads sealed earlier openable
+	// after encryption is turned off for new traffic. Added after translation so
+	// it is the innermost unary interceptor, encoding outbound payloads last and
+	// decoding inbound payloads first.
+	codecOpts := proxy.CodecOptions{Encrypt: cfg.Encryption.Enabled}
 
-		dialOpts = append(dialOpts, grpc.WithChainUnaryInterceptor(enc))
+	// Only assign the vault once it is known to be there. o.vault is a concrete
+	// pointer and the field is an interface, so assigning unconditionally would
+	// hand over a non-nil interface holding a nil pointer, which reads as a vault
+	// being present and panics the first time a payload is opened.
+	if o.vault != nil {
+		codecOpts.Vault = o.vault
+		codecOpts.Reporter = reps.encryption
 	}
+
+	cdc, err := proxy.CodecInterceptor(codecOpts)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to build codec interceptor for upstream %q: %w", up.Name, err)
+	}
+
+	dialOpts = append(dialOpts, grpc.WithChainUnaryInterceptor(cdc))
 
 	res, err := proxy.ResolverFor(up, dialOpts, o.logger)
 	if err != nil {

--- a/internal/proxy/codec.go
+++ b/internal/proxy/codec.go
@@ -1,0 +1,105 @@
+package proxy
+
+import (
+	"context"
+	"errors"
+	"runtime"
+
+	"go.temporal.io/api/common/v1"
+	"go.temporal.io/api/proxy"
+	"google.golang.org/grpc"
+
+	"github.com/temporalio/temporal-proxy/internal/transport/meta"
+	"github.com/temporalio/temporal-proxy/pkg/codec"
+)
+
+type (
+	// CodecOptions selects the codecs a [CodecInterceptor] applies.
+	CodecOptions struct {
+		// Vault seals and opens payloads. With no Vault there is no encryption
+		// codec at all. Leave it nil rather than passing a nil concrete vault,
+		// which would read as present here and panic on first use.
+		Vault Vault
+
+		// Encrypt seals outbound payloads. Inbound payloads are opened whenever a
+		// Vault is present regardless, so payloads sealed earlier stay readable
+		// after sealing is turned off for new traffic.
+		Encrypt bool
+
+		// Reporter records the duration and result of each vault operation. It is
+		// required whenever a Vault is set.
+		Reporter *Reporter
+	}
+
+	// codecOpt builds the [codec.Option] for one codec, given the request the
+	// payloads belong to. A codec with no per-request state ignores both
+	// arguments; the encryption codec uses them to bind its cipher.
+	codecOpt func(ctx context.Context, ns string) codec.Option
+)
+
+// CodecInterceptor returns a unary client interceptor that runs payloads through
+// the codecs opts select: outbound requests are encoded and inbound responses are
+// decoded, each through a [codec.Chain] built for that request. A direction with
+// no codecs is skipped entirely rather than walked for nothing.
+//
+// Search attributes are never encoded, so they stay queryable upstream. The
+// namespace a codec is given is the one the request carries, read via
+// [meta.NamespaceFrom].
+func CodecInterceptor(opts CodecOptions) (grpc.UnaryClientInterceptor, error) {
+	if opts.Encrypt && opts.Vault == nil {
+		return nil, errors.New("proxy: encryption requires a vault")
+	}
+
+	// Every vault call is timed and counted, so a vault without somewhere to
+	// record is a wiring mistake. Catch it here rather than on the first payload.
+	if opts.Vault != nil && opts.Reporter == nil {
+		return nil, errors.New("proxy: a vault requires a reporter")
+	}
+
+	// Every codec is listed once, with the gate that decides whether it encodes.
+	// Decoding is ungated: a decoder recognizes its own output and passes anything
+	// else through, so including it costs nothing and keeps older data readable.
+	var outbound, inbound []codecOpt
+	if opts.Vault != nil {
+		enc := func(ctx context.Context, ns string) codec.Option {
+			return codec.WithCipher(&cipher{ctx: ctx, ns: ns, v: opts.Vault, r: opts.Reporter})
+		}
+
+		inbound = append(inbound, enc)
+		if opts.Encrypt {
+			outbound = append(outbound, enc)
+		}
+	}
+
+	return proxy.NewPayloadVisitorInterceptor(proxy.PayloadVisitorInterceptorOptions{
+		Inbound:  visitPayloads(inbound, codec.Chain.Decode),
+		Outbound: visitPayloads(outbound, codec.Chain.Encode),
+	})
+}
+
+// visitPayloads returns the options that build a chain from opts per request and
+// apply it with fn ([codec.Chain.Encode] or [codec.Chain.Decode]), or nil when
+// opts is empty so that direction is left alone.
+func visitPayloads(
+	opts []codecOpt,
+	fn func(codec.Chain, []*common.Payload) ([]*common.Payload, error),
+) *proxy.VisitPayloadsOptions {
+	if len(opts) == 0 {
+		return nil
+	}
+
+	return &proxy.VisitPayloadsOptions{
+		ConcurrencyLimit:     runtime.NumCPU(),
+		SkipSearchAttributes: true,
+		Visitor: func(ctx *proxy.VisitPayloadsContext, payloads []*common.Payload) ([]*common.Payload, error) {
+			ns := meta.NamespaceFrom(ctx)
+
+			chain := make([]codec.Option, len(opts))
+			for i, opt := range opts {
+				chain[i] = opt(ctx, ns)
+			}
+
+			return fn(codec.NewChain(chain...), payloads)
+		},
+	}
+}

--- a/internal/proxy/codec_test.go
+++ b/internal/proxy/codec_test.go
@@ -1,0 +1,95 @@
+package proxy_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/api/common/v1"
+	workflowservice "go.temporal.io/api/workflowservice/v1"
+	"google.golang.org/grpc"
+
+	"github.com/temporalio/temporal-proxy/internal/proxy"
+)
+
+// The codecs themselves are covered where they live: encryption through this
+// interceptor in encryption_test.go, and chain ordering in pkg/codec. What is left
+// to pin here is what the interceptor does when a direction has no codec at all.
+
+func TestCodecInterceptorRejectsIncompleteOptions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		opts proxy.CodecOptions
+		want string
+	}{
+		{
+			name: "encrypting without a vault",
+			opts: proxy.CodecOptions{Encrypt: true},
+			want: "encryption requires a vault",
+		},
+		{
+			name: "a vault without a reporter",
+			opts: proxy.CodecOptions{Vault: &fakeVault{}},
+			want: "a vault requires a reporter",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := proxy.CodecInterceptor(tc.opts)
+			require.ErrorContains(t, err, tc.want)
+		})
+	}
+}
+
+// A payload can arrive marked as encrypted even when this proxy has no vault,
+// because something upstream of it may have sealed it. With no vault there is no
+// decoder, so it has to travel through untouched rather than be handed to one.
+func TestCodecInterceptorWithoutAVaultIgnoresSealedPayloads(t *testing.T) {
+	t.Parallel()
+
+	interceptor, err := proxy.CodecInterceptor(proxy.CodecOptions{})
+	require.NoError(t, err)
+
+	sealed := sealedPayload(t, testPayload("json/plain", `"secret"`))
+	resp := &workflowservice.StartWorkflowExecutionRequest{}
+
+	require.NoError(t, interceptor(t.Context(), "/svc/Start", startRequest(), resp, nil, respondWith(sealed)))
+
+	require.Len(t, resp.Input.Payloads, 1)
+	require.Same(t, sealed, resp.Input.Payloads[0])
+}
+
+func TestCodecInterceptorWithoutCodecs(t *testing.T) {
+	t.Parallel()
+
+	interceptor, err := proxy.CodecInterceptor(proxy.CodecOptions{})
+	require.NoError(t, err)
+
+	out := testPayload("json/plain", `"out"`)
+	in := testPayload("json/plain", `"in"`)
+
+	req := startRequest(out)
+	resp := &workflowservice.StartWorkflowExecutionRequest{}
+
+	var sent *common.Payload
+	invoker := func(_ context.Context, _ string, gotReq, gotResp any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
+		sent = gotReq.(*workflowservice.StartWorkflowExecutionRequest).Input.Payloads[0]
+		gotResp.(*workflowservice.StartWorkflowExecutionRequest).Input = &common.Payloads{
+			Payloads: []*common.Payload{in},
+		}
+
+		return nil
+	}
+
+	require.NoError(t, interceptor(t.Context(), "/svc/Start", req, resp, nil, invoker))
+
+	// With no codec in either direction the payloads are not even rebuilt, so both
+	// sides travel by reference.
+	require.Same(t, out, sent)
+	require.Same(t, in, resp.Input.Payloads[0])
+}

--- a/internal/proxy/encryption.go
+++ b/internal/proxy/encryption.go
@@ -2,149 +2,48 @@ package proxy
 
 import (
 	"context"
-	"fmt"
-	"runtime"
 	"time"
 
-	"go.temporal.io/api/common/v1"
-	"go.temporal.io/api/proxy"
-	"google.golang.org/grpc"
-
-	"github.com/temporalio/temporal-proxy/internal/transport/meta"
 	"github.com/temporalio/temporal-proxy/pkg/crypto"
 )
 
-// These keys form the on-the-wire contract for an encrypted payload: the
-// encoding marker lets decryptPayloads recognize its own output, and the key-ID
-// and wrapped-DEK entries carry the material needed to open it. They live in the
-// payload metadata so the ciphertext travels with everything required to
-// decrypt it.
-const (
-	metadataEncoding        = "encoding" // Copied to avoid importing SDK just for this
-	metadataEncryptionKeyID = "encryption-key-id"
-	metadataEncryptionDEK   = "encryption-dek"
-	encryptionEncoding      = "binary/encrypted"
+type (
+	// Vault seals and opens payloads using envelope encryption scoped by namespace.
+	// It is the subset of [crypto.Vault] the interceptor depends on.
+	Vault interface {
+		Seal(context.Context, string, []byte) (*crypto.Message, error)
+		Open(context.Context, *crypto.Message) ([]byte, error)
+	}
+
+	// cipher binds a Vault to a single request: the context its calls run under,
+	// the namespace whose DEK seals its payloads, and the reporter its timings go
+	// to. It is the [codec.Cipher] the encryption codec seals through.
+	cipher struct {
+		ctx context.Context
+		ns  string
+		v   Vault
+		r   *Reporter
+	}
 )
 
-// Vault seals and opens payloads using envelope encryption scoped by namespace.
-// It is the subset of [crypto.Vault] the interceptor depends on.
-type Vault interface {
-	Seal(context.Context, string, []byte) (*crypto.Message, error)
-	Open(context.Context, *crypto.Message) ([]byte, error)
+// Encrypt seals data under the request's namespace, recording the call through
+// VaultOp whatever the outcome. The vault's error is returned as it arrived; the
+// codec is what knows these bytes are a payload, so it supplies that context.
+func (c *cipher) Encrypt(data []byte) (*crypto.Message, error) {
+	start := time.Now()
+	msg, err := c.v.Seal(c.ctx, c.ns, data)
+	c.r.VaultOp("encrypt", resultLabel(err), c.ns, time.Since(start).Seconds())
+
+	return msg, err
 }
 
-// EncryptionInterceptor returns a unary client interceptor that opens inbound
-// response payloads using v and, when enabled is true, seals outbound request
-// payloads as well. Sealing is gated so encryption can be turned off for new
-// traffic while still opening data sealed earlier: inbound decryption always
-// runs. Each payload is sealed under the DEK for the request's namespace, read
-// from the outgoing gRPC metadata via [meta.NamespaceFrom], so the upstream
-// never sees plaintext while local workers still exchange cleartext. On the way
-// back only payloads this interceptor sealed (identified by the
-// encryptionEncoding marker) are opened; anything else passes through
-// untouched. Search attributes are skipped so they stay queryable upstream. r
-// records the duration and result of every seal/open through VaultOp. It
-// returns an error only if the underlying visitor interceptor cannot be
-// constructed.
-func EncryptionInterceptor(enabled bool, v Vault, r *Reporter) (grpc.UnaryClientInterceptor, error) {
-	var outbound *proxy.VisitPayloadsOptions
-	if enabled {
-		outbound = &proxy.VisitPayloadsOptions{
-			ConcurrencyLimit:     runtime.NumCPU(),
-			SkipSearchAttributes: true,
-			Visitor:              encryptPayloads(v, r),
-		}
-	}
+// Decrypt opens m, recording the call through VaultOp whatever the outcome.
+func (c *cipher) Decrypt(m *crypto.Message) ([]byte, error) {
+	start := time.Now()
+	pt, err := c.v.Open(c.ctx, m)
+	c.r.VaultOp("decrypt", resultLabel(err), c.ns, time.Since(start).Seconds())
 
-	return proxy.NewPayloadVisitorInterceptor(proxy.PayloadVisitorInterceptorOptions{
-		Inbound: &proxy.VisitPayloadsOptions{
-			ConcurrencyLimit:     runtime.NumCPU(),
-			SkipSearchAttributes: true,
-			Visitor:              decryptPayloads(v, r),
-		},
-		Outbound: outbound,
-	})
-}
-
-// encryptPayloads returns a payload visitor that marshals each payload, seals
-// the bytes under v for the context's namespace, and replaces it with a payload
-// whose data is the ciphertext and whose metadata carries the wrapped DEK
-// needed to open it. The entire original payload (metadata included) is sealed,
-// so decryptPayloads can restore it exactly. Each Seal call is timed end to
-// end and recorded via r.VaultOp, regardless of outcome.
-func encryptPayloads(v Vault, r *Reporter) func(*proxy.VisitPayloadsContext, []*common.Payload) ([]*common.Payload, error) {
-	return func(ctx *proxy.VisitPayloadsContext, payloads []*common.Payload) ([]*common.Payload, error) {
-		ns := meta.NamespaceFrom(ctx)
-
-		res := make([]*common.Payload, len(payloads))
-		for i, p := range payloads {
-			data, err := p.Marshal()
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal payload: %w", err)
-			}
-
-			start := time.Now()
-			msg, err := v.Seal(ctx, ns, data)
-			r.VaultOp("encrypt", resultLabel(err), ns, time.Since(start).Seconds())
-			if err != nil {
-				return nil, fmt.Errorf("failed to encrypt payload: %w", err)
-			}
-
-			res[i] = &common.Payload{
-				Metadata: map[string][]byte{
-					metadataEncoding:        []byte(encryptionEncoding),
-					metadataEncryptionKeyID: []byte(msg.KeyMaterial.KEKID),
-					metadataEncryptionDEK:   []byte(msg.KeyMaterial.EncryptedDEK),
-				},
-				Data: msg.Ciphertext,
-			}
-		}
-
-		return res, nil
-	}
-}
-
-// decryptPayloads returns a payload visitor that reverses encryptPayloads:
-// payloads carrying the encryptionEncoding marker are opened and unmarshaled
-// back into their original form, while any others pass through unchanged so
-// payloads produced elsewhere survive the round trip. Only payloads actually
-// opened are timed end to end and recorded via r.VaultOp; pass-through
-// payloads are not.
-func decryptPayloads(v Vault, r *Reporter) func(*proxy.VisitPayloadsContext, []*common.Payload) ([]*common.Payload, error) {
-	return func(ctx *proxy.VisitPayloadsContext, payloads []*common.Payload) ([]*common.Payload, error) {
-		ns := meta.NamespaceFrom(ctx)
-
-		res := make([]*common.Payload, len(payloads))
-		for i, p := range payloads {
-			// Only decrypt what we've encrypted
-			if enc := string(p.Metadata[metadataEncoding]); enc != encryptionEncoding {
-				res[i] = p
-				continue
-			}
-
-			start := time.Now()
-			pt, err := v.Open(ctx, &crypto.Message{
-				Ciphertext: p.Data,
-				KeyMaterial: &crypto.DEKMaterial{
-					KEKID:        string(p.Metadata[metadataEncryptionKeyID]),
-					EncryptedDEK: string(p.Metadata[metadataEncryptionDEK]),
-				},
-			})
-			r.VaultOp("decrypt", resultLabel(err), ns, time.Since(start).Seconds())
-			if err != nil {
-				return nil, fmt.Errorf("failed to decrypt payload: %w", err)
-			}
-
-			og := new(common.Payload)
-			if err := og.Unmarshal(pt); err != nil {
-				return nil, fmt.Errorf("failed to unmarshal payload: %w", err)
-			}
-
-			res[i] = og
-		}
-
-		return res, nil
-	}
+	return pt, err
 }
 
 // resultLabel maps an error to the "result" metric label value.
@@ -152,5 +51,6 @@ func resultLabel(err error) string {
 	if err != nil {
 		return "error"
 	}
+
 	return "success"
 }

--- a/internal/proxy/encryption_test.go
+++ b/internal/proxy/encryption_test.go
@@ -1,4 +1,4 @@
-package proxy
+package proxy_test
 
 import (
 	"bytes"
@@ -13,14 +13,15 @@ import (
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/require"
 	"go.temporal.io/api/common/v1"
-	"go.temporal.io/api/proxy"
 	workflowservice "go.temporal.io/api/workflowservice/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/temporalio/temporal-proxy/internal/metrics"
+	"github.com/temporalio/temporal-proxy/internal/proxy"
 	"github.com/temporalio/temporal-proxy/internal/transport/meta"
+	"github.com/temporalio/temporal-proxy/pkg/codec"
 	"github.com/temporalio/temporal-proxy/pkg/crypto"
 )
 
@@ -31,87 +32,87 @@ const (
 
 // fakeVault is a reversible in-memory Vault. Seal prefixes the plaintext with
 // sealPrefix (so sealed data is observably distinct from cleartext) and records
-// the namespace it was called with; Open strips the prefix. Errors and a fixed
-// Open result can be injected to exercise the interceptor's failure paths. It is
-// safe for concurrent use because the payload visitor may seal/open payloads
-// from multiple goroutines within a single call.
+// the namespace it was called with; Open strips the prefix. Errors can be
+// injected to exercise the interceptor's failure paths. It is safe for
+// concurrent use because the payload visitor may seal/open payloads from
+// multiple goroutines within a single call.
 type fakeVault struct {
 	mu         sync.Mutex
 	namespaces []string // namespaces passed to Seal, in call order
 	opens      int      // number of Open calls
 	sealErr    error    // when set, Seal returns it
 	openErr    error    // when set, Open returns it
-	openReturn []byte   // when set, Open returns these bytes instead of the unsealed plaintext
 }
 
-func TestEncryptionInterceptorRoundtrip(t *testing.T) {
+func TestEncryptionRoundtrip(t *testing.T) {
 	t.Parallel()
 
 	v := &fakeVault{}
-	interceptor, err := EncryptionInterceptor(true, v, newTestReporter(t))
+	interceptor, err := proxy.CodecInterceptor(proxy.CodecOptions{Vault: v, Encrypt: true, Reporter: newTestReporter(t)})
 	require.NoError(t, err)
 
-	input := &common.Payloads{Payloads: []*common.Payload{testPayload("json/plain", `"hi"`)}}
-	want := proto.Clone(input.Payloads[0]).(*common.Payload)
+	original := []*common.Payload{
+		testPayload("json/plain", `"first"`),
+		testPayload("json/plain", `"second"`),
+	}
+	want := []*common.Payload{
+		proto.Clone(original[0]).(*common.Payload),
+		proto.Clone(original[1]).(*common.Payload),
+	}
 
-	req := &workflowservice.StartWorkflowExecutionRequest{Namespace: "local", Input: input}
+	req := startRequest(original...)
 	resp := &workflowservice.StartWorkflowExecutionRequest{}
 
 	invoker := func(_ context.Context, _ string, gotReq, gotResp any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
-		// Outbound: the request payload reached the upstream sealed.
-		sent := gotReq.(*workflowservice.StartWorkflowExecutionRequest).Input.Payloads[0]
-		require.Equal(t, encryptionEncoding, string(sent.Metadata[metadataEncoding]))
-		require.True(t, bytes.HasPrefix(sent.Data, []byte(sealPrefix)))
+		// Outbound: every payload reached the upstream sealed. What the sealed form
+		// looks like is pinned in pkg/codec; what matters here is that the upstream
+		// sees ciphertext rather than the plaintext the caller handed in.
+		sent := gotReq.(*workflowservice.StartWorkflowExecutionRequest).Input.Payloads
+		require.Len(t, sent, len(original))
 
-		// Echo the sealed payload back so the inbound path can open it.
-		gotResp.(*workflowservice.StartWorkflowExecutionRequest).Input = &common.Payloads{
-			Payloads: []*common.Payload{sent},
+		for i, p := range sent {
+			require.Equal(t, codec.EncryptionEncoding, string(p.Metadata[codec.MetadataEncoding]))
+			require.True(t, bytes.HasPrefix(p.Data, []byte(sealPrefix)))
+			require.NotEqual(t, want[i].Data, p.Data)
 		}
+
+		// Echo the sealed payloads back so the inbound path can open them.
+		gotResp.(*workflowservice.StartWorkflowExecutionRequest).Input = &common.Payloads{Payloads: sent}
 		return nil
 	}
 
 	ctx := meta.WithNamespace(t.Context(), "orders")
 	require.NoError(t, interceptor(ctx, "/svc/Start", req, resp, nil, invoker))
 
-	require.Len(t, resp.Input.Payloads, 1)
-	require.True(t, proto.Equal(want, resp.Input.Payloads[0]))
-	require.Equal(t, []string{"orders"}, v.namespaces)
+	require.Len(t, resp.Input.Payloads, len(want))
+	for i := range want {
+		require.True(t, proto.Equal(want[i], resp.Input.Payloads[i]), "payload %d did not round-trip", i)
+	}
+
+	// One Seal per payload, each under the request's namespace.
+	require.Equal(t, []string{"orders", "orders"}, v.namespaces)
 }
 
-func TestEncryptionInterceptorDisabledSkipsOutbound(t *testing.T) {
+func TestEncryptionDisabledSkipsOutbound(t *testing.T) {
 	t.Parallel()
 
 	v := &fakeVault{}
-	interceptor, err := EncryptionInterceptor(false, v, newTestReporter(t))
+	interceptor, err := proxy.CodecInterceptor(proxy.CodecOptions{Vault: v, Reporter: newTestReporter(t)})
 	require.NoError(t, err)
 
-	// A response payload sealed exactly as fakeVault.Seal would produce it, so
-	// the inbound path can open it without the interceptor ever sealing.
 	orig := testPayload("json/plain", `"hi"`)
-	sealed := &common.Payload{
-		Metadata: map[string][]byte{
-			metadataEncoding:        []byte(encryptionEncoding),
-			metadataEncryptionKeyID: []byte(testKEKID),
-			metadataEncryptionDEK:   []byte("dek:orders"),
-		},
-		Data: append([]byte(sealPrefix), mustMarshal(t, orig)...),
-	}
-
-	req := &workflowservice.StartWorkflowExecutionRequest{
-		Namespace: "local",
-		Input:     &common.Payloads{Payloads: []*common.Payload{testPayload("json/plain", `"hi"`)}},
-	}
+	req := startRequest(testPayload("json/plain", `"hi"`))
 	resp := &workflowservice.StartWorkflowExecutionRequest{}
 
 	invoker := func(_ context.Context, _ string, gotReq, gotResp any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
 		// Outbound sealing is disabled: the request payload reaches the upstream
 		// as cleartext with its original encoding.
 		sent := gotReq.(*workflowservice.StartWorkflowExecutionRequest).Input.Payloads[0]
-		require.Equal(t, "json/plain", string(sent.Metadata[metadataEncoding]))
+		require.Equal(t, "json/plain", string(sent.Metadata[codec.MetadataEncoding]))
 		require.False(t, bytes.HasPrefix(sent.Data, []byte(sealPrefix)))
 
 		gotResp.(*workflowservice.StartWorkflowExecutionRequest).Input = &common.Payloads{
-			Payloads: []*common.Payload{sealed},
+			Payloads: []*common.Payload{sealedPayload(t, orig)},
 		}
 		return nil
 	}
@@ -126,21 +127,105 @@ func TestEncryptionInterceptorDisabledSkipsOutbound(t *testing.T) {
 	require.Empty(t, v.namespaces, "interceptor must not seal when disabled")
 }
 
-func TestEncryptionInterceptorRecordsVaultOps(t *testing.T) {
+func TestEncryptionNamespace(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		ctx  func(t *testing.T) context.Context
+		want string
+	}{
+		{
+			name: "namespace from metadata",
+			ctx:  func(t *testing.T) context.Context { return meta.WithNamespace(t.Context(), "orders") },
+			want: "orders",
+		},
+		{
+			name: "namespace appended to outgoing metadata",
+			ctx: func(t *testing.T) context.Context {
+				return metadata.AppendToOutgoingContext(t.Context(), meta.NamespaceHeader, "ns1")
+			},
+			want: "ns1",
+		},
+		{
+			name: "absent namespace seals under empty string",
+			ctx:  func(t *testing.T) context.Context { return t.Context() },
+			want: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			v := &fakeVault{}
+			interceptor, err := proxy.CodecInterceptor(proxy.CodecOptions{Vault: v, Encrypt: true, Reporter: newTestReporter(t)})
+			require.NoError(t, err)
+
+			req := startRequest(testPayload("json/plain", "x"))
+			resp := &workflowservice.StartWorkflowExecutionRequest{}
+			require.NoError(t, interceptor(tc.ctx(t), "/svc/Start", req, resp, nil, respondWith()))
+
+			require.Equal(t, []string{tc.want}, v.namespaces)
+		})
+	}
+}
+
+func TestEncryptionErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("seal error aborts before the call", func(t *testing.T) {
+		t.Parallel()
+
+		v := &fakeVault{sealErr: errors.New("kms unavailable")}
+		interceptor, err := proxy.CodecInterceptor(proxy.CodecOptions{Vault: v, Encrypt: true, Reporter: newTestReporter(t)})
+		require.NoError(t, err)
+
+		called := false
+		invoker := func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
+			called = true
+			return nil
+		}
+
+		req := startRequest(testPayload("json/plain", "x"))
+		resp := &workflowservice.StartWorkflowExecutionRequest{}
+		err = interceptor(t.Context(), "/svc/Start", req, resp, nil, invoker)
+
+		require.ErrorContains(t, err, "failed to encrypt payload")
+		require.False(t, called, "upstream must not be called when sealing fails")
+	})
+
+	// The remaining decode failures are pinned in pkg/codec. What is left to show
+	// here is that one surfaces as the call's error rather than being swallowed,
+	// leaving the caller to treat the response as unusable.
+	t.Run("open error fails the call", func(t *testing.T) {
+		t.Parallel()
+
+		v := &fakeVault{openErr: errors.New("unwrap failed")}
+		interceptor, err := proxy.CodecInterceptor(proxy.CodecOptions{Vault: v, Reporter: newTestReporter(t)})
+		require.NoError(t, err)
+
+		invoker := respondWith(sealedPayload(t, testPayload("json/plain", "x")))
+		resp := &workflowservice.StartWorkflowExecutionRequest{}
+		err = interceptor(t.Context(), "/svc/Start", startRequest(), resp, nil, invoker)
+
+		require.ErrorContains(t, err, "failed to decrypt payload")
+	})
+}
+
+func TestEncryptionRecordsVaultOps(t *testing.T) {
 	t.Parallel()
 
 	reg := prometheus.NewRegistry()
-	reporter := NewReporter(metrics.New("proxy", promauto.With(reg)).ForSubsystem("encryption"))
+	reporter := proxy.NewReporter(metrics.New("proxy", promauto.With(reg)).ForSubsystem("encryption"))
 
 	vault := &fakeVault{}
-	interceptor, err := EncryptionInterceptor(true, vault, reporter)
+	interceptor, err := proxy.CodecInterceptor(proxy.CodecOptions{Vault: vault, Encrypt: true, Reporter: reporter})
 	require.NoError(t, err)
 
 	ctx := metadata.AppendToOutgoingContext(t.Context(), meta.NamespaceHeader, "ns1")
 
-	req := &workflowservice.StartWorkflowExecutionRequest{
-		Input: &common.Payloads{Payloads: []*common.Payload{{Data: []byte("hi")}}},
-	}
+	req := startRequest(&common.Payload{Data: []byte("hi")})
 	resp := &workflowservice.StartWorkflowExecutionRequest{}
 
 	// Echo the sealed request payload back so the inbound path opens it,
@@ -165,31 +250,24 @@ func TestEncryptionInterceptorRecordsVaultOps(t *testing.T) {
 	require.True(t, hasLabels(dur, map[string]string{"operation": "decrypt", "namespace": "ns1"}))
 }
 
-func TestEncryptionInterceptorSkipsMetricsForPassThrough(t *testing.T) {
+func TestEncryptionSkipsMetricsForPassThrough(t *testing.T) {
 	t.Parallel()
 
 	reg := prometheus.NewRegistry()
-	reporter := NewReporter(metrics.New("proxy", promauto.With(reg)).ForSubsystem("encryption"))
+	reporter := proxy.NewReporter(metrics.New("proxy", promauto.With(reg)).ForSubsystem("encryption"))
 
 	vault := &fakeVault{}
-	interceptor, err := EncryptionInterceptor(true, vault, reporter)
+	interceptor, err := proxy.CodecInterceptor(proxy.CodecOptions{Vault: vault, Encrypt: true, Reporter: reporter})
 	require.NoError(t, err)
 
 	ctx := metadata.AppendToOutgoingContext(t.Context(), meta.NamespaceHeader, "ns1")
 
-	req := &workflowservice.StartWorkflowExecutionRequest{
-		Input: &common.Payloads{Payloads: []*common.Payload{{Data: []byte("hi")}}},
-	}
+	req := startRequest(&common.Payload{Data: []byte("hi")})
 	resp := &workflowservice.StartWorkflowExecutionRequest{}
 
 	// Return an unencrypted response payload; the inbound path must pass it
 	// through without opening it or recording a decrypt op.
-	invoker := func(_ context.Context, _ string, _, gotResp any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
-		gotResp.(*workflowservice.StartWorkflowExecutionRequest).Input = &common.Payloads{
-			Payloads: []*common.Payload{testPayload("json/plain", `"plain"`)},
-		}
-		return nil
-	}
+	invoker := respondWith(testPayload("json/plain", `"plain"`))
 	require.NoError(t, interceptor(ctx, "/method", req, resp, nil, invoker))
 
 	require.Equal(t, 0, vault.opens)
@@ -198,137 +276,6 @@ func TestEncryptionInterceptorSkipsMetricsForPassThrough(t *testing.T) {
 	require.NotNil(t, ops)
 	require.True(t, hasLabels(ops, map[string]string{"operation": "encrypt", "result": "success", "namespace": "ns1"}))
 	require.False(t, hasLabels(ops, map[string]string{"operation": "decrypt", "result": "success", "namespace": "ns1"}))
-}
-
-func TestEncryptDecryptPayloadsRoundtrip(t *testing.T) {
-	t.Parallel()
-
-	v := &fakeVault{}
-	r := newTestReporter(t)
-	vc := visitCtx(meta.WithNamespace(t.Context(), "ns1"))
-
-	original := []*common.Payload{
-		testPayload("json/plain", `"first"`),
-		testPayload("json/plain", `"second"`),
-	}
-	want := []*common.Payload{
-		proto.Clone(original[0]).(*common.Payload),
-		proto.Clone(original[1]).(*common.Payload),
-	}
-
-	sealed, err := encryptPayloads(v, r)(vc, original)
-	require.NoError(t, err)
-	require.Len(t, sealed, len(original))
-
-	for _, p := range sealed {
-		require.Equal(t, encryptionEncoding, string(p.Metadata[metadataEncoding]))
-		require.Equal(t, testKEKID, string(p.Metadata[metadataEncryptionKeyID]))
-		require.NotEmpty(t, p.Metadata[metadataEncryptionDEK])
-		// The data on the wire is ciphertext, never the marshaled plaintext.
-		require.True(t, bytes.HasPrefix(p.Data, []byte(sealPrefix)))
-	}
-
-	require.Equal(t, []string{"ns1", "ns1"}, v.namespaces)
-
-	opened, err := decryptPayloads(v, r)(vc, sealed)
-	require.NoError(t, err)
-	require.Len(t, opened, len(want))
-
-	for i := range want {
-		require.True(t, proto.Equal(want[i], opened[i]), "payload %d did not round-trip", i)
-	}
-}
-
-func TestDecryptPayloadsPassesThroughUnencrypted(t *testing.T) {
-	t.Parallel()
-
-	v := &fakeVault{}
-	r := newTestReporter(t)
-	vc := visitCtx(meta.WithNamespace(t.Context(), "ns1"))
-
-	orig := testPayload("json/plain", `"secret"`)
-	sealed, err := encryptPayloads(v, r)(vc, []*common.Payload{orig})
-	require.NoError(t, err)
-
-	plain := testPayload("json/plain", `"visible"`)
-
-	out, err := decryptPayloads(v, r)(vc, []*common.Payload{sealed[0], plain})
-	require.NoError(t, err)
-	require.Len(t, out, 2)
-	require.True(t, proto.Equal(orig, out[0]))
-	require.Same(t, plain, out[1], "unencrypted payload should pass through by reference")
-	require.Equal(t, 1, v.opens, "Open must be called only for the sealed payload")
-}
-
-func TestEncryptPayloadsNamespace(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name string
-		ctx  func(t *testing.T) context.Context
-		want string
-	}{
-		{
-			name: "namespace from metadata",
-			ctx:  func(t *testing.T) context.Context { return meta.WithNamespace(t.Context(), "orders") },
-			want: "orders",
-		},
-		{
-			name: "absent namespace seals under empty string",
-			ctx:  func(t *testing.T) context.Context { return t.Context() },
-			want: "",
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			v := &fakeVault{}
-			_, err := encryptPayloads(v, newTestReporter(t))(visitCtx(tc.ctx(t)), []*common.Payload{testPayload("json/plain", "x")})
-			require.NoError(t, err)
-			require.Equal(t, []string{tc.want}, v.namespaces)
-		})
-	}
-}
-
-func TestEncryptDecryptPayloadsErrors(t *testing.T) {
-	t.Parallel()
-
-	t.Run("seal error", func(t *testing.T) {
-		t.Parallel()
-
-		v := &fakeVault{sealErr: errors.New("kms unavailable")}
-		_, err := encryptPayloads(v, newTestReporter(t))(visitCtx(t.Context()), []*common.Payload{testPayload("json/plain", "x")})
-		require.ErrorContains(t, err, "failed to encrypt payload")
-	})
-
-	t.Run("open error", func(t *testing.T) {
-		t.Parallel()
-
-		v := &fakeVault{}
-		r := newTestReporter(t)
-		vc := visitCtx(meta.WithNamespace(t.Context(), "ns1"))
-		sealed, err := encryptPayloads(v, r)(vc, []*common.Payload{testPayload("json/plain", "x")})
-		require.NoError(t, err)
-
-		v.openErr = errors.New("unwrap failed")
-		_, err = decryptPayloads(v, r)(vc, sealed)
-		require.ErrorContains(t, err, "failed to decrypt payload")
-	})
-
-	t.Run("unmarshal error", func(t *testing.T) {
-		t.Parallel()
-
-		v := &fakeVault{openReturn: []byte{0xFF, 0xFF, 0xFF}}
-		r := newTestReporter(t)
-		vc := visitCtx(meta.WithNamespace(t.Context(), "ns1"))
-		sealed, err := encryptPayloads(v, r)(vc, []*common.Payload{testPayload("json/plain", "x")})
-		require.NoError(t, err)
-
-		_, err = decryptPayloads(v, r)(vc, sealed)
-		require.ErrorContains(t, err, "failed to unmarshal payload")
-	})
 }
 
 func (f *fakeVault) Seal(_ context.Context, ns string, data []byte) (*crypto.Message, error) {
@@ -354,9 +301,6 @@ func (f *fakeVault) Open(_ context.Context, msg *crypto.Message) ([]byte, error)
 	if f.openErr != nil {
 		return nil, f.openErr
 	}
-	if f.openReturn != nil {
-		return f.openReturn, nil
-	}
 
 	if !bytes.HasPrefix(msg.Ciphertext, []byte(sealPrefix)) {
 		return nil, fmt.Errorf("ciphertext was not sealed by fakeVault")
@@ -367,29 +311,60 @@ func (f *fakeVault) Open(_ context.Context, msg *crypto.Message) ([]byte, error)
 
 func testPayload(encoding, data string) *common.Payload {
 	return &common.Payload{
-		Metadata: map[string][]byte{metadataEncoding: []byte(encoding)},
+		Metadata: map[string][]byte{codec.MetadataEncoding: []byte(encoding)},
 		Data:     []byte(data),
 	}
 }
 
-func mustMarshal(t *testing.T, p *common.Payload) []byte {
+// sealedPayload returns p as [fakeVault.Seal] would have sealed it, so a
+// response payload can arrive already encrypted without the interceptor having
+// sealed it on the way out.
+func sealedPayload(t *testing.T, p *common.Payload) *common.Payload {
 	t.Helper()
 
 	data, err := p.Marshal()
 	require.NoError(t, err)
-	return data
+
+	return &common.Payload{
+		Metadata: map[string][]byte{
+			codec.MetadataEncoding:        []byte(codec.EncryptionEncoding),
+			codec.MetadataEncryptionKeyID: []byte(testKEKID),
+			codec.MetadataEncryptionDEK:   []byte("dek:orders"),
+		},
+		Data: append([]byte(sealPrefix), data...),
+	}
 }
 
-func visitCtx(ctx context.Context) *proxy.VisitPayloadsContext {
-	return &proxy.VisitPayloadsContext{Context: ctx}
+// startRequest builds the request the interceptor is handed, carrying payloads
+// as its workflow input. StartWorkflowExecution is used throughout because its
+// input is the payload field the visitor walks.
+func startRequest(payloads ...*common.Payload) *workflowservice.StartWorkflowExecutionRequest {
+	req := &workflowservice.StartWorkflowExecutionRequest{Namespace: "local"}
+	if len(payloads) > 0 {
+		req.Input = &common.Payloads{Payloads: payloads}
+	}
+
+	return req
+}
+
+// respondWith returns an invoker that ignores the request and hands back
+// payloads as the response's workflow input.
+func respondWith(payloads ...*common.Payload) grpc.UnaryInvoker {
+	return func(_ context.Context, _ string, _, gotResp any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
+		if len(payloads) > 0 {
+			gotResp.(*workflowservice.StartWorkflowExecutionRequest).Input = &common.Payloads{Payloads: payloads}
+		}
+
+		return nil
+	}
 }
 
 // newTestReporter builds a Reporter backed by its own private registry, so
 // call sites under test have a Reporter to record into without colliding with
 // any other test's metrics.
-func newTestReporter(t *testing.T) *Reporter {
+func newTestReporter(t *testing.T) *proxy.Reporter {
 	t.Helper()
-	return NewReporter(metrics.New("test", promauto.With(prometheus.NewRegistry())).ForSubsystem("encryption"))
+	return proxy.NewReporter(metrics.New("test", promauto.With(prometheus.NewRegistry())).ForSubsystem("encryption"))
 }
 
 // gatherFamily returns the metric family named name from reg, or nil if no

--- a/pkg/codec/chain.go
+++ b/pkg/codec/chain.go
@@ -1,0 +1,85 @@
+package codec
+
+import (
+	"go.temporal.io/api/common/v1"
+)
+
+type (
+	// Codec transforms payloads on their way to an upstream and back. The method
+	// set matches the Temporal SDK's converter.PayloadCodec, so an implementation
+	// satisfies both without this package depending on the SDK.
+	Codec interface {
+		Encode([]*common.Payload) ([]*common.Payload, error)
+		Decode([]*common.Payload) ([]*common.Payload, error)
+	}
+
+	// Chain applies a set of codecs as one. Encode runs them in the order the
+	// chain holds them and Decode runs them in reverse, so a payload is
+	// compressed before it is sealed and unsealed before it is decompressed.
+	// Note that this is the opposite of the SDK's own convention, where a
+	// multi-codec list encodes last to first; a Chain is handed to the SDK whole,
+	// as a single codec, so its order stays its own concern.
+	Chain struct {
+		codecs []Codec
+	}
+
+	// Option enables a codec in a [Chain].
+	Option func(*options)
+
+	options struct {
+		cipher Cipher
+	}
+)
+
+// NewChain returns the Chain implied by opts, holding every codec they enable in
+// the order it has to be applied. A Chain with no codecs is a no-op.
+func NewChain(opts ...Option) Chain {
+	o := &options{}
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	// Application order, outbound. Compression belongs ahead of encryption
+	// because ciphertext does not compress.
+	var codecs []Codec
+	if o.cipher != nil {
+		codecs = append(codecs, NewEncryptor(o.cipher))
+	}
+
+	return Chain{codecs: codecs}
+}
+
+// WithCipher seals and opens payloads through c. A nil c is ignored, leaving the
+// chain without encryption.
+func WithCipher(c Cipher) Option {
+	return func(o *options) {
+		if c != nil {
+			o.cipher = c
+		}
+	}
+}
+
+// Encode runs payloads through every codec in order.
+func (c Chain) Encode(payloads []*common.Payload) ([]*common.Payload, error) {
+	var err error
+	for _, cd := range c.codecs {
+		if payloads, err = cd.Encode(payloads); err != nil {
+			return nil, err
+		}
+	}
+
+	return payloads, nil
+}
+
+// Decode reverses [Chain.Encode], running payloads back through every codec in
+// reverse order.
+func (c Chain) Decode(payloads []*common.Payload) ([]*common.Payload, error) {
+	var err error
+	for i := len(c.codecs) - 1; i >= 0; i-- {
+		if payloads, err = c.codecs[i].Decode(payloads); err != nil {
+			return nil, err
+		}
+	}
+
+	return payloads, nil
+}

--- a/pkg/codec/chain_internal_test.go
+++ b/pkg/codec/chain_internal_test.go
@@ -1,0 +1,99 @@
+// These tests live in package codec because NewChain hides its codec list, so a
+// chain of more than one codec cannot be built from outside the package until a
+// second codec exists. The order Chain applies codecs in is the thing most likely
+// to break silently when one does, so it is pinned here rather than left untested.
+package codec
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/api/common/v1"
+)
+
+// markerCodec appends its own name to a payload's data on Encode and requires it
+// to be the trailing marker on Decode, so a chain that applies codecs in the
+// wrong order fails loudly instead of quietly producing the wrong bytes.
+type markerCodec struct {
+	name string
+}
+
+func TestChainAppliesCodecsInOrder(t *testing.T) {
+	t.Parallel()
+
+	chain := Chain{codecs: []Codec{&markerCodec{name: "A"}, &markerCodec{name: "B"}}}
+
+	encoded, err := chain.Encode([]*common.Payload{{Data: []byte("data")}})
+	require.NoError(t, err)
+	require.Len(t, encoded, 1)
+
+	// A ran first, then B, so B's marker is outermost. Reversed, this would read
+	// "dataBA".
+	require.Equal(t, "dataAB", string(encoded[0].Data))
+}
+
+func TestChainDecodesInReverseOrder(t *testing.T) {
+	t.Parallel()
+
+	chain := Chain{codecs: []Codec{&markerCodec{name: "A"}, &markerCodec{name: "B"}}}
+
+	decoded, err := chain.Decode([]*common.Payload{{Data: []byte("dataAB")}})
+	require.NoError(t, err)
+	require.Len(t, decoded, 1)
+	require.Equal(t, "data", string(decoded[0].Data))
+}
+
+func TestChainRoundtripsThroughEveryCodec(t *testing.T) {
+	t.Parallel()
+
+	chain := Chain{codecs: []Codec{&markerCodec{name: "A"}, &markerCodec{name: "B"}}}
+	original := []*common.Payload{{Data: []byte("data")}}
+
+	encoded, err := chain.Encode(original)
+	require.NoError(t, err)
+
+	decoded, err := chain.Decode(encoded)
+	require.NoError(t, err)
+	require.Equal(t, "data", string(decoded[0].Data))
+}
+
+func TestChainStopsAtTheFirstError(t *testing.T) {
+	t.Parallel()
+
+	// "B" is missing from the data, so B's Decode fails and A's never runs. If it
+	// did run, it would fail differently: on the missing "A" marker.
+	chain := Chain{codecs: []Codec{&markerCodec{name: "A"}, &markerCodec{name: "B"}}}
+
+	_, err := chain.Decode([]*common.Payload{{Data: []byte("data")}})
+	require.ErrorContains(t, err, `marker "B" not found`)
+}
+
+func (m *markerCodec) Encode(payloads []*common.Payload) ([]*common.Payload, error) {
+	res := make([]*common.Payload, len(payloads))
+	for i, p := range payloads {
+		res[i] = &common.Payload{
+			Metadata: p.Metadata,
+			Data:     append(bytes.Clone(p.Data), m.name...),
+		}
+	}
+
+	return res, nil
+}
+
+func (m *markerCodec) Decode(payloads []*common.Payload) ([]*common.Payload, error) {
+	res := make([]*common.Payload, len(payloads))
+	for i, p := range payloads {
+		if !bytes.HasSuffix(p.Data, []byte(m.name)) {
+			return nil, fmt.Errorf("marker %q not found", m.name)
+		}
+
+		res[i] = &common.Payload{
+			Metadata: p.Metadata,
+			Data:     bytes.TrimSuffix(bytes.Clone(p.Data), []byte(m.name)),
+		}
+	}
+
+	return res, nil
+}

--- a/pkg/codec/chain_test.go
+++ b/pkg/codec/chain_test.go
@@ -1,0 +1,94 @@
+package codec_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/api/common/v1"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/temporalio/temporal-proxy/pkg/codec"
+)
+
+func TestNewChainNoCodecs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		opts []codec.Option
+	}{
+		{name: "no options"},
+		{name: "nil cipher is ignored", opts: []codec.Option{codec.WithCipher(nil)}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			chain := codec.NewChain(tc.opts...)
+			payloads := []*common.Payload{testPayload("json/plain", `"hi"`)}
+
+			// A chain with no codecs hands payloads straight back.
+			encoded, err := chain.Encode(payloads)
+			require.NoError(t, err)
+			require.Len(t, encoded, 1)
+			require.Same(t, payloads[0], encoded[0])
+
+			decoded, err := chain.Decode(payloads)
+			require.NoError(t, err)
+			require.Len(t, decoded, 1)
+			require.Same(t, payloads[0], decoded[0])
+		})
+	}
+}
+
+func TestNewChainWithCipher(t *testing.T) {
+	t.Parallel()
+
+	original := []*common.Payload{testPayload("json/plain", `"hi"`)}
+	want := proto.Clone(original[0]).(*common.Payload)
+
+	chain := codec.NewChain(codec.WithCipher(&fakeCipher{}))
+
+	sealed, err := chain.Encode(original)
+	require.NoError(t, err)
+	require.Len(t, sealed, 1)
+
+	// The chain seals exactly as the encryption codec alone does.
+	direct, err := codec.NewEncryptor(&fakeCipher{}).Encode([]*common.Payload{want})
+	require.NoError(t, err)
+	require.True(t, proto.Equal(direct[0], sealed[0]))
+
+	opened, err := chain.Decode(sealed)
+	require.NoError(t, err)
+	require.Len(t, opened, 1)
+	require.True(t, proto.Equal(want, opened[0]))
+}
+
+func TestChainCipherErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("encode", func(t *testing.T) {
+		t.Parallel()
+
+		chain := codec.NewChain(codec.WithCipher(&fakeCipher{encErr: errors.New("kms unavailable")}))
+
+		_, err := chain.Encode([]*common.Payload{testPayload("json/plain", "x")})
+		require.ErrorContains(t, err, "failed to encrypt payload")
+	})
+
+	t.Run("decode", func(t *testing.T) {
+		t.Parallel()
+
+		c := &fakeCipher{}
+		chain := codec.NewChain(codec.WithCipher(c))
+
+		sealed, err := chain.Encode([]*common.Payload{testPayload("json/plain", "x")})
+		require.NoError(t, err)
+
+		c.decErr = errors.New("unwrap failed")
+		_, err = chain.Decode(sealed)
+		require.ErrorContains(t, err, "failed to decrypt payload")
+	})
+}

--- a/pkg/codec/doc.go
+++ b/pkg/codec/doc.go
@@ -1,0 +1,16 @@
+// Package codec converts Temporal payloads on their way to and from an upstream.
+//
+// [Encryptor] seals payloads with envelope encryption through a [Cipher] and opens
+// them again. A sealed payload is self-describing: the ciphertext travels with
+// the ID of the key that wrapped its DEK and the wrapped DEK itself, so opening
+// one needs nothing but the payload and a Cipher that can reach that key.
+//
+// [NewChain] assembles the codecs its options enable into a single [Chain] in the
+// order they have to be applied, so callers say what they want enabled rather
+// than what order it happens in.
+//
+// A [Chain] satisfies the Temporal SDK's converter.PayloadCodec, so it can be
+// handed to converter.NewCodecDataConverter for an SDK client or to
+// converter.NewPayloadCodecHTTPHandler for a codec server, with the SDK imported
+// at the call site rather than here.
+package codec

--- a/pkg/codec/encryptor.go
+++ b/pkg/codec/encryptor.go
@@ -1,0 +1,120 @@
+package codec
+
+import (
+	"fmt"
+
+	"go.temporal.io/api/common/v1"
+
+	"github.com/temporalio/temporal-proxy/pkg/crypto"
+)
+
+// These keys form the on-the-wire contract for a sealed payload: the encoding
+// marker lets Decode recognize its own output, and the key-ID and wrapped-DEK
+// entries carry the material needed to open it.
+const (
+	// MetadataEncoding is the payload metadata key holding the encoding name.
+	MetadataEncoding = "encoding"
+
+	// MetadataEncryptionKeyID is the payload metadata key holding the ID of the
+	// KEK that wrapped the DEK.
+	MetadataEncryptionKeyID = "encryption-key-id"
+
+	// MetadataEncryptionDEK is the payload metadata key holding the wrapped DEK.
+	MetadataEncryptionDEK = "encryption-dek"
+
+	// EncryptionEncoding is the encoding a sealed payload is marked with.
+	EncryptionEncoding = "binary/encrypted"
+)
+
+type (
+	// Encryptor seals payloads with envelope encryption and opens them again.
+	Encryptor struct {
+		cipher Cipher
+	}
+
+	// Cipher encrypts and decrypts bytes. It is the subset of a key-management
+	// backend, typically a [crypto.Vault], that [Encryptor] depends on.
+	Cipher interface {
+		Encrypt([]byte) (*crypto.Message, error)
+		Decrypt(*crypto.Message) ([]byte, error)
+	}
+)
+
+// NewEncryptor returns an [Encryptor] that seals and opens payloads through c.
+func NewEncryptor(c Cipher) *Encryptor {
+	return &Encryptor{cipher: c}
+}
+
+// Encode seals every payload in payloads, returning payloads whose data is the
+// ciphertext and whose metadata carries the wrapped DEK needed to open it. Each
+// original payload is sealed whole, metadata included, so [Encryptor.Decode]
+// restores it exactly.
+func (c *Encryptor) Encode(payloads []*common.Payload) ([]*common.Payload, error) {
+	res := make([]*common.Payload, len(payloads))
+	for i, p := range payloads {
+		data, err := p.Marshal()
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal payload: %w", err)
+		}
+
+		msg, err := c.cipher.Encrypt(data)
+		if err != nil {
+			return nil, fmt.Errorf("failed to encrypt payload: %w", err)
+		}
+
+		res[i] = &common.Payload{
+			Metadata: map[string][]byte{
+				MetadataEncoding:        []byte(EncryptionEncoding),
+				MetadataEncryptionKeyID: []byte(msg.KeyMaterial.KEKID),
+				MetadataEncryptionDEK:   []byte(msg.KeyMaterial.EncryptedDEK),
+			},
+			Data: msg.Ciphertext,
+		}
+	}
+
+	return res, nil
+}
+
+// Decode reverses [Encryptor.Encode]: a payload carrying the full sealed-payload
+// contract, the EncryptionEncoding marker plus both key-material entries, is opened
+// and restored to its original form. Anything else passes through unchanged so
+// payloads produced elsewhere survive the round trip, including ones that use the
+// same encoding name without our key material.
+func (c *Encryptor) Decode(payloads []*common.Payload) ([]*common.Payload, error) {
+	res := make([]*common.Payload, len(payloads))
+	for i, p := range payloads {
+		// Only decrypt what we've encrypted
+		if enc := string(p.Metadata[MetadataEncoding]); enc != EncryptionEncoding {
+			res[i] = p
+			continue
+		}
+
+		// The marker alone is not proof we sealed this: anything else using the
+		// same encoding name would carry no key material of ours. Treat the full
+		// set as the claim of ownership and pass through what doesn't make it.
+		if len(p.Metadata[MetadataEncryptionKeyID]) == 0 || len(p.Metadata[MetadataEncryptionDEK]) == 0 {
+			res[i] = p
+			continue
+		}
+
+		pt, err := c.cipher.Decrypt(&crypto.Message{
+			Ciphertext: p.Data,
+			KeyMaterial: &crypto.DEKMaterial{
+				KEKID:        string(p.Metadata[MetadataEncryptionKeyID]),
+				EncryptedDEK: string(p.Metadata[MetadataEncryptionDEK]),
+			},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to decrypt payload: %w", err)
+		}
+
+		og := new(common.Payload)
+		if err := og.Unmarshal(pt); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal payload: %w", err)
+		}
+
+		res[i] = og
+	}
+
+	return res, nil
+}

--- a/pkg/codec/encryptor_test.go
+++ b/pkg/codec/encryptor_test.go
@@ -1,0 +1,308 @@
+package codec_test
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"maps"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/api/common/v1"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/temporalio/temporal-proxy/pkg/codec"
+	"github.com/temporalio/temporal-proxy/pkg/crypto"
+)
+
+const (
+	testKEKID  = "test-kek"
+	testDEK    = "wrapped-dek"
+	sealPrefix = "sealed:"
+)
+
+// fakeCipher is a reversible in-memory Cipher: Encrypt prefixes the plaintext
+// with sealPrefix so ciphertext is observably distinct from cleartext, and
+// Decrypt strips it. It records what it was handed, and errors or a fixed
+// Decrypt result can be injected to exercise the failure paths. Recording is
+// unsynchronized, so each test (or parallel subtest) needs its own.
+type fakeCipher struct {
+	encrypted [][]byte          // plaintexts passed to Encrypt, in call order
+	decrypted []*crypto.Message // messages passed to Decrypt, in call order
+	encErr    error             // when set, Encrypt returns it
+	decErr    error             // when set, Decrypt returns it
+	decReturn []byte            // when set, Decrypt returns these bytes instead of the unsealed plaintext
+}
+
+func TestEncryptorRoundtrip(t *testing.T) {
+	t.Parallel()
+
+	c := &fakeCipher{}
+	original := []*common.Payload{
+		testPayload("json/plain", `"first"`),
+		testPayload("binary/null", ""),
+	}
+	want := []*common.Payload{
+		proto.Clone(original[0]).(*common.Payload),
+		proto.Clone(original[1]).(*common.Payload),
+	}
+
+	sealed, err := codec.NewEncryptor(c).Encode(original)
+	require.NoError(t, err)
+	require.Len(t, sealed, len(original))
+
+	for i, p := range sealed {
+		require.Equal(t, codec.EncryptionEncoding, string(p.Metadata[codec.MetadataEncoding]))
+		require.Equal(t, testKEKID, string(p.Metadata[codec.MetadataEncryptionKeyID]))
+		require.Equal(t, testDEK, string(p.Metadata[codec.MetadataEncryptionDEK]))
+		// The data is ciphertext, never the payload's own plaintext.
+		require.True(t, bytes.HasPrefix(p.Data, []byte(sealPrefix)))
+		require.NotEqual(t, want[i].Data, p.Data)
+	}
+
+	opened, err := codec.NewEncryptor(c).Decode(sealed)
+	require.NoError(t, err)
+	require.Len(t, opened, len(want))
+
+	// Each payload is restored whole, original metadata included.
+	for i := range want {
+		require.True(t, proto.Equal(want[i], opened[i]), "payload %d did not round-trip", i)
+	}
+}
+
+func TestEncryptorEncodeSealsEachPayloadWhole(t *testing.T) {
+	t.Parallel()
+
+	c := &fakeCipher{}
+	p := testPayload("json/plain", `"one"`)
+
+	_, err := codec.NewEncryptor(c).Encode([]*common.Payload{p, p})
+	require.NoError(t, err)
+
+	// One Encrypt per payload, each handed the marshaled payload rather than
+	// just its data, which is what lets Decode restore the metadata too.
+	require.Len(t, c.encrypted, 2)
+	for _, got := range c.encrypted {
+		require.Equal(t, mustMarshal(t, p), got)
+	}
+}
+
+func TestEncryptorEncodeEmpty(t *testing.T) {
+	t.Parallel()
+
+	c := &fakeCipher{}
+
+	out, err := codec.NewEncryptor(c).Encode(nil)
+	require.NoError(t, err)
+	require.Empty(t, out)
+	require.Empty(t, c.encrypted)
+}
+
+func TestEncryptorDecodePassesThrough(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		payload *common.Payload
+	}{
+		{
+			name:    "another encoding",
+			payload: testPayload("json/plain", `"visible"`),
+		},
+		{
+			name:    "no encoding key",
+			payload: &common.Payload{Data: []byte("raw")},
+		},
+		{
+			name:    "no metadata at all",
+			payload: &common.Payload{},
+		},
+		{
+			name:    "encoding is a prefix of the marker",
+			payload: testPayload("binary", "x"),
+		},
+		{
+			name:    "marked with no key material at all",
+			payload: markedPayload(nil),
+		},
+		{
+			name: "marked with no key ID",
+			payload: markedPayload(map[string][]byte{
+				codec.MetadataEncryptionDEK: []byte(testDEK),
+			}),
+		},
+		{
+			name: "marked with no wrapped DEK",
+			payload: markedPayload(map[string][]byte{
+				codec.MetadataEncryptionKeyID: []byte(testKEKID),
+			}),
+		},
+		{
+			name: "marked with an empty key ID",
+			payload: markedPayload(map[string][]byte{
+				codec.MetadataEncryptionKeyID: {},
+				codec.MetadataEncryptionDEK:   []byte(testDEK),
+			}),
+		},
+		{
+			name: "marked with an empty wrapped DEK",
+			payload: markedPayload(map[string][]byte{
+				codec.MetadataEncryptionKeyID: []byte(testKEKID),
+				codec.MetadataEncryptionDEK:   {},
+			}),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			c := &fakeCipher{}
+			out, err := codec.NewEncryptor(c).Decode([]*common.Payload{tc.payload})
+			require.NoError(t, err)
+
+			require.Len(t, out, 1)
+			require.Same(t, tc.payload, out[0], "an unsealed payload should pass through untouched")
+			require.Empty(t, c.decrypted, "Decrypt must not be called for an unsealed payload")
+		})
+	}
+}
+
+func TestEncryptorDecodeMixedBatch(t *testing.T) {
+	t.Parallel()
+
+	c := &fakeCipher{}
+	orig := testPayload("json/plain", `"secret"`)
+	plain := testPayload("json/plain", `"visible"`)
+
+	sealed, err := codec.NewEncryptor(c).Encode([]*common.Payload{orig})
+	require.NoError(t, err)
+
+	out, err := codec.NewEncryptor(c).Decode([]*common.Payload{plain, sealed[0], plain})
+	require.NoError(t, err)
+
+	// Order is preserved and only the sealed payload is opened.
+	require.Len(t, out, 3)
+	require.Same(t, plain, out[0])
+	require.True(t, proto.Equal(orig, out[1]))
+	require.Same(t, plain, out[2])
+	require.Len(t, c.decrypted, 1)
+}
+
+func TestEncryptorDecodePassesKeyMaterial(t *testing.T) {
+	t.Parallel()
+
+	c := &fakeCipher{}
+	sealed := &common.Payload{
+		Metadata: map[string][]byte{
+			codec.MetadataEncoding:        []byte(codec.EncryptionEncoding),
+			codec.MetadataEncryptionKeyID: []byte("kek-from-metadata"),
+			codec.MetadataEncryptionDEK:   []byte("dek-from-metadata"),
+		},
+		Data: append([]byte(sealPrefix), mustMarshal(t, testPayload("json/plain", "x"))...),
+	}
+
+	_, err := codec.NewEncryptor(c).Decode([]*common.Payload{sealed})
+	require.NoError(t, err)
+
+	// The key material the cipher needs is read back off the payload, which is
+	// what makes a sealed payload openable on its own.
+	require.Len(t, c.decrypted, 1)
+	require.Equal(t, sealed.Data, c.decrypted[0].Ciphertext)
+	require.Equal(t, "kek-from-metadata", c.decrypted[0].KeyMaterial.KEKID)
+	require.Equal(t, "dek-from-metadata", c.decrypted[0].KeyMaterial.EncryptedDEK)
+}
+
+func TestEncryptorErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("encrypt error", func(t *testing.T) {
+		t.Parallel()
+
+		c := &fakeCipher{encErr: errors.New("kms unavailable")}
+
+		_, err := codec.NewEncryptor(c).Encode([]*common.Payload{testPayload("json/plain", "x")})
+		require.ErrorContains(t, err, "failed to encrypt payload")
+		require.ErrorContains(t, err, "kms unavailable")
+	})
+
+	t.Run("decrypt error", func(t *testing.T) {
+		t.Parallel()
+
+		c := &fakeCipher{}
+		sealed, err := codec.NewEncryptor(c).Encode([]*common.Payload{testPayload("json/plain", "x")})
+		require.NoError(t, err)
+
+		c.decErr = errors.New("unwrap failed")
+		_, err = codec.NewEncryptor(c).Decode(sealed)
+		require.ErrorContains(t, err, "failed to decrypt payload")
+		require.ErrorContains(t, err, "unwrap failed")
+	})
+
+	t.Run("plaintext is not a payload", func(t *testing.T) {
+		t.Parallel()
+
+		c := &fakeCipher{}
+		sealed, err := codec.NewEncryptor(c).Encode([]*common.Payload{testPayload("json/plain", "x")})
+		require.NoError(t, err)
+
+		c.decReturn = []byte{0xFF, 0xFF, 0xFF}
+		_, err = codec.NewEncryptor(c).Decode(sealed)
+		require.ErrorContains(t, err, "failed to unmarshal payload")
+	})
+}
+
+func (f *fakeCipher) Encrypt(data []byte) (*crypto.Message, error) {
+	if f.encErr != nil {
+		return nil, f.encErr
+	}
+
+	f.encrypted = append(f.encrypted, bytes.Clone(data))
+
+	return &crypto.Message{
+		Ciphertext:  append([]byte(sealPrefix), data...),
+		KeyMaterial: &crypto.DEKMaterial{KEKID: testKEKID, EncryptedDEK: testDEK},
+	}, nil
+}
+
+func (f *fakeCipher) Decrypt(msg *crypto.Message) ([]byte, error) {
+	f.decrypted = append(f.decrypted, msg)
+
+	if f.decErr != nil {
+		return nil, f.decErr
+	}
+	if f.decReturn != nil {
+		return f.decReturn, nil
+	}
+
+	if !bytes.HasPrefix(msg.Ciphertext, []byte(sealPrefix)) {
+		return nil, fmt.Errorf("ciphertext was not sealed by fakeCipher")
+	}
+
+	return bytes.TrimPrefix(msg.Ciphertext, []byte(sealPrefix)), nil
+}
+
+func testPayload(encoding, data string) *common.Payload {
+	return &common.Payload{
+		Metadata: map[string][]byte{codec.MetadataEncoding: []byte(encoding)},
+		Data:     []byte(data),
+	}
+}
+
+// markedPayload builds a payload carrying the sealed-payload encoding marker
+// plus md, so a test can vary the key material a marked payload claims to have.
+func markedPayload(md map[string][]byte) *common.Payload {
+	meta := map[string][]byte{codec.MetadataEncoding: []byte(codec.EncryptionEncoding)}
+	maps.Copy(meta, md)
+
+	return &common.Payload{Metadata: meta, Data: []byte("ciphertext")}
+}
+
+func mustMarshal(t *testing.T, p *common.Payload) []byte {
+	t.Helper()
+
+	data, err := p.Marshal()
+	require.NoError(t, err)
+
+	return data
+}


### PR DESCRIPTION
Encryption was wired as its own client interceptor, so every payload transform added later would need another interceptor and another walk over the message tree.

pkg/codec introduces a Codec interface and a Chain that applies a set of them as one. Encode runs codecs in order and Decode in reverse. When applicable, a Chain is handed to the SDK whole, as a single codec, so its order stays its own concern. Chain satisfies converter.PayloadCodec, so the same chain can back an SDK client or a codec server without pkg/codec importing the SDK.

internal/proxy now installs one CodecInterceptor that builds a chain per request, skipping a direction with no codecs. Inbound decoding stays ungated so payloads sealed earlier remain readable after encryption is turned off for new traffic; outbound sealing follows the Enabled flag.

The dataplane assigns the vault only when the concrete pointer is set, since a nil pointer in a non-nil interface would make an absent vault look present. The sealed wire format is unchanged.