### PR TITLE
[docs]: Use consistent vocabulary and enforce it

### DIFF
--- a/.claude/skills/terminology/SKILL.md
+++ b/.claude/skills/terminology/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: terminology
+description: This project's canonical vocabulary. Use when writing or reviewing prose, doc comments, README or example docs, or commit messages, and when asked to check terminology or add a domain term.
+allowed-tools: Read, Grep, Glob, Bash
+---
+
+# Terminology
+
+Use these terms. The rejected column is not a style preference; each one was a
+real drift that got fixed, and the checker will fail the build on it.
+
+## Canonical terms
+
+| Term                   | Means                                                                       | Never say                           |
+| ---------------------- | --------------------------------------------------------------------------- | ----------------------------------- |
+| **Temporal Service**   | A Temporal deployment the proxy connects to: local dev, self-hosted, Cloud. | cluster, Temporal server, frontend  |
+| **gateway**            | The single inbound gRPC endpoint everything connects to.                    | front door, inbound server, ingress |
+| **upstream**           | A configured destination the proxy forwards to, identified by name.         | backend, target, destination        |
+| **per-upstream proxy** | The component bound to one upstream that translates, credentials, encrypts. | egress, forwarder                   |
+| **system upstream**    | Handles Namespace-less requests such as `GetSystemInfo`.                    | control upstream                    |
+| **default upstream**   | Where a request lands when no routing rule matched.                         | fallback upstream, catch-all        |
+| **extension server**   | A gRPC service the operator runs that the proxy delegates a decision to.    | external server, plugin, provider   |
+| **seal** / **open**    | Encrypt and decrypt a payload.                                              | encrypt/decrypt (at payload level)  |
+| **DEK** / **KEK**      | Per-payload data key; the key that wraps it.                                | data key, master key                |
+| **metric prefix**      | The string stamped on every metric name (`metrics.namespace` in config).    | metric namespace                    |
+
+## Casing
+
+Temporal's core nouns are proper nouns **in markdown prose**: Namespace, Worker,
+Workflow, Activity, Client. Lowercase stays correct inside code fences, inline
+code, config keys, CLI commands, log output, and link targets.
+
+Go doc comments are the exception. They use lowercase "namespace" throughout and
+are internally consistent, so leave them alone rather than starting a rewrite.
+
+## Standing exceptions
+
+- `rfc/` is a historical record. Report divergence, never edit it to match.
+- Test fakes may say "frontend": standing in for the Temporal frontend is the point.
+- `.github/` says "workflow" for GitHub Actions, which is not a Temporal Workflow.
+- `dev/config.yaml` keeps its `cluster-1/2/3` upstream names; that is dev-harness
+  naming, deliberately left alone.
+- `examples/authz` says "cluster-scoped" because that mirrors Temporal OSS's own
+  authorizer scope, not our upstream vocabulary.
+
+## Qualify the overloaded words
+
+`RoutingRule`, `NamespaceRules`, and `validation.Rule` are unrelated, as are
+`server.Server` (the gateway), `proxy.Server` (a per-upstream proxy), and the
+extension server. Never write "the rule" or "the server" unqualified in prose.
+
+## Checking
+
+`mise run lint:terms` runs the mechanical half: rejected phrases anywhere, plus
+prose casing in markdown. It cannot judge whether a given "client" means a
+Temporal Client or a gRPC client, so that part is on you.
+
+Adding or changing a term means editing both this file and
+`.claude/skills/terminology/terms.yaml`, which holds the enforced rules and the
+reason behind every exception.

--- a/.claude/skills/terminology/go.mod
+++ b/.claude/skills/terminology/go.mod
@@ -1,0 +1,5 @@
+module github.com/temporalio/temporal-proxy/skills/terminology
+
+go 1.26.4
+
+require github.com/goccy/go-yaml v1.19.2

--- a/.claude/skills/terminology/go.sum
+++ b/.claude/skills/terminology/go.sum
@@ -1,0 +1,2 @@
+github.com/goccy/go-yaml v1.19.2 h1:PmFC1S6h8ljIz6gMRBopkjP1TVT7xuwrButHID66PoM=
+github.com/goccy/go-yaml v1.19.2/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=

--- a/.claude/skills/terminology/main.go
+++ b/.claude/skills/terminology/main.go
@@ -1,0 +1,76 @@
+// Command terminology checks the repository against the project's canonical
+// vocabulary. It exits non-zero when it finds a violation, so it can run as a
+// lint step.
+package main
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"os/exec"
+	"slices"
+	"strings"
+
+	"github.com/temporalio/temporal-proxy/skills/terminology/terms"
+)
+
+// rules travels with the command so it reads the same rule set wherever it runs.
+//
+//go:embed terms.yaml
+var rules string
+
+func main() {
+	root := "../../../"
+	if len(os.Args) > 1 {
+		root = os.Args[1]
+	}
+
+	if err := run(root); err != nil {
+		fmt.Fprintln(os.Stderr, "terminology:", err)
+		os.Exit(2)
+	}
+}
+
+// gitFiles lists the files git knows about: tracked, plus untracked ones it is
+// not ignoring. Asking git rather than reading .gitignore keeps one source of
+// truth and picks up .git/info/exclude and nested ignore files for free.
+func gitFiles(root string) ([]string, error) {
+	cmd := exec.Command("git", "-C", root, "ls-files", "--cached", "--others", "--exclude-standard", "-z")
+
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("git ls-files in %s: %w", root, err)
+	}
+
+	return slices.DeleteFunc(strings.Split(string(out), "\x00"), func(p string) bool {
+		return p == ""
+	}), nil
+}
+
+// run reports every violation under root, and errors when there is at least one.
+func run(root string) error {
+	cfg, err := terms.Load(strings.NewReader(rules))
+	if err != nil {
+		return err
+	}
+
+	paths, err := gitFiles(root)
+	if err != nil {
+		return err
+	}
+
+	findings, err := terms.Run(cfg, os.DirFS(root), paths)
+	if err != nil {
+		return err
+	}
+
+	for _, f := range findings {
+		fmt.Printf("%s:%d: %s\n", f.Path, f.Line, f.Message)
+	}
+
+	if len(findings) > 0 {
+		return fmt.Errorf("%d terminology violation(s)", len(findings))
+	}
+
+	return nil
+}

--- a/.claude/skills/terminology/terms.yaml
+++ b/.claude/skills/terminology/terms.yaml
@@ -1,0 +1,56 @@
+# The project's canonical vocabulary, enforced by `mise run lint:terms`.
+# Every exception carries the reason it exists, so the next person can tell a
+# deliberate choice from an oversight.
+
+# The checker lints what `git ls-files` reports, so .gitignore and
+# .git/info/exclude already keep build output, worktrees, and local notes out.
+# Only paths git tracks but we still do not want checked belong here.
+ignorePaths:
+  # Historical records. They describe the design as it was proposed, and are
+  # never edited to match shipped code.
+  - rfc/
+  # The rule set, its tests, and the skill all quote the rejected terms in order
+  # to reject them. Only reachable once the skill is committed, since .claude/
+  # is otherwise ignored, but wrong the moment it is.
+  - .claude/skills/terminology/
+
+banned:
+  - phrase: Temporal cluster
+    use: Temporal Service
+  - phrase: upstream cluster
+    use: upstream Temporal Service
+  - phrase: remote cluster
+    use: remote Temporal Service
+  - phrase: inbound server
+    use: gateway
+    except:
+      # gRPC's own name for the two ends of a forwarded call is the inbound
+      # server stream and the outbound client stream. Nothing to do with the
+      # gateway, and the phrasing is the clearest available.
+      - internal/rpc/
+  - phrase: front door
+    use: gateway
+  - phrase: frontdoor
+    use: gateway
+  - phrase: Temporal frontend
+    use: Temporal Service
+    except:
+      # Standing in for the Temporal frontend is the whole point of the fakes.
+      - _test.go
+      - dataplanetest/
+  - phrase: upstream frontend
+    use: upstream Temporal Service
+    except:
+      - _test.go
+      - dataplanetest/
+
+# Temporal's core nouns are proper nouns in prose. Markdown only: Go comments in
+# this repository use lowercase throughout and are consistent as they are.
+capitalize:
+  - word: namespace
+  - word: worker
+  - word: workflow
+    except:
+      # GitHub Actions calls its pipelines workflows. Not Temporal Workflows.
+      - .github/
+  - word: activity

--- a/.claude/skills/terminology/terms/terms.go
+++ b/.claude/skills/terminology/terms/terms.go
@@ -1,0 +1,252 @@
+// Package terms checks the repository against the project's canonical
+// vocabulary: phrases that have been rejected in favour of another term, and
+// Temporal's core nouns, which are proper nouns in prose.
+package terms
+
+import (
+	"fmt"
+	"io"
+	"io/fs"
+	"path"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/goccy/go-yaml"
+)
+
+var (
+	// protected masks the markdown spans that are not prose: inline code, link
+	// destinations, and autolinks. Lowercase inside them is correct, since they
+	// carry config keys, CLI commands, and URLs.
+	protected = regexp.MustCompile("`[^`\n]*`" + `|\]\([^)]*\)|<[^>\s]+>`)
+
+	// refDef matches a link reference definition, which is all target and no prose.
+	refDef = regexp.MustCompile(`^\[[^\]]+\]:`)
+)
+
+type (
+	// Banned is one rejected phrase and the term to use instead. Except lists
+	// path fragments where the phrase is legitimate.
+	Banned struct {
+		Phrase string   `yaml:"phrase"`
+		Use    string   `yaml:"use"`
+		Except []string `yaml:"except"`
+	}
+
+	// Core is a Temporal noun that is a proper noun in prose. Except lists path
+	// fragments where the lowercase spelling means something else.
+	Core struct {
+		Word   string   `yaml:"word"`
+		Except []string `yaml:"except"`
+	}
+
+	// Config is the rule set the checker enforces.
+	Config struct {
+		IgnorePaths []string `yaml:"ignorePaths"`
+		Banned      []Banned `yaml:"banned"`
+		Capitalize  []Core   `yaml:"capitalize"`
+	}
+
+	// Finding is one violation, located for an editor to jump to.
+	Finding struct {
+		Path    string
+		Line    int
+		Message string
+	}
+)
+
+// Check reports the terminology violations in content. Casing rules apply to
+// markdown only: Go comments in this repo use lowercase "namespace" throughout
+// and are consistent as they are.
+func Check(cfg Config, path, content string) []Finding {
+	if ignored(cfg.IgnorePaths, path) {
+		return nil
+	}
+
+	var (
+		out      []Finding
+		inFence  bool
+		markdown = strings.HasSuffix(path, ".md")
+		casing   = casingRules(cfg.Capitalize, path)
+	)
+
+	for i, line := range strings.Split(content, "\n") {
+		if markdown && strings.HasPrefix(strings.TrimSpace(line), "```") {
+			inFence = !inFence
+
+			continue
+		}
+
+		if inFence {
+			continue
+		}
+
+		out = append(out, bannedIn(cfg, path, line, i+1)...)
+
+		if markdown {
+			out = append(out, miscasedIn(casing, path, mask(line), i+1)...)
+		}
+	}
+
+	return out
+}
+
+// Load reads a rule set. Unknown keys are an error: a typo in the rule set
+// would otherwise silently disable a rule rather than report one.
+func Load(r io.Reader) (Config, error) {
+	var cfg Config
+
+	if err := yaml.NewDecoder(r, yaml.DisallowUnknownField()).Decode(&cfg); err != nil {
+		return Config{}, fmt.Errorf("decode terms: %w", err)
+	}
+
+	return cfg, nil
+}
+
+// Run checks paths against cfg, reading each one from fsys, and reports the
+// violations sorted by location so output is stable across runs. The caller
+// chooses the paths: which files are in scope is git's business, not ours.
+func Run(cfg Config, fsys fs.FS, paths []string) ([]Finding, error) {
+	var out []Finding
+
+	for _, p := range paths {
+		if !checkable(p) || ignored(cfg.IgnorePaths, p) {
+			continue
+		}
+
+		b, err := fs.ReadFile(fsys, p)
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", p, err)
+		}
+
+		out = append(out, Check(cfg, p, string(b))...)
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Path != out[j].Path {
+			return out[i].Path < out[j].Path
+		}
+
+		if out[i].Line != out[j].Line {
+			return out[i].Line < out[j].Line
+		}
+
+		return out[i].Message < out[j].Message
+	})
+
+	return out, nil
+}
+
+// bannedIn reports the rejected phrases appearing on one line.
+func bannedIn(cfg Config, path, line string, num int) []Finding {
+	var (
+		out   []Finding
+		lower = strings.ToLower(line)
+	)
+
+	for _, b := range cfg.Banned {
+		if exempt(b.Except, path) {
+			continue
+		}
+
+		if strings.Contains(lower, strings.ToLower(b.Phrase)) {
+			out = append(out, Finding{
+				Path:    path,
+				Line:    num,
+				Message: fmt.Sprintf("%q: use %q instead", b.Phrase, b.Use),
+			})
+		}
+	}
+
+	return out
+}
+
+// checkable reports whether a file's contents are prose the checker understands.
+func checkable(p string) bool {
+	switch path.Ext(p) {
+	case ".go", ".md", ".yaml", ".yml":
+		return true
+	default:
+		return false
+	}
+}
+
+// casingRules compiles one word-boundary matcher per core noun that applies to
+// path. The match is case sensitive so an already-capitalised term is left
+// alone, and the optional plural keeps "namespaced" from matching.
+func casingRules(words []Core, path string) map[string]*regexp.Regexp {
+	rules := make(map[string]*regexp.Regexp, len(words))
+
+	for _, w := range words {
+		if exempt(w.Except, path) {
+			continue
+		}
+
+		rules[w.Word] = regexp.MustCompile(`\b` + regexp.QuoteMeta(w.Word) + `s?\b`)
+	}
+
+	return rules
+}
+
+// exempt reports whether path matches one of a phrase's allowed locations. Each
+// entry is a plain substring, so a directory ("dataplanetest/") and a file
+// suffix ("_test.go") are both expressible without glob syntax.
+func exempt(patterns []string, path string) bool {
+	for _, p := range patterns {
+		if strings.Contains(path, p) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// ignored reports whether path sits under one of the ignored prefixes.
+func ignored(prefixes []string, path string) bool {
+	for _, p := range prefixes {
+		if strings.HasPrefix(path, p) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// mask blanks the spans of a markdown line that are not prose, preserving
+// length so the remaining text keeps its offsets.
+func mask(line string) string {
+	if refDef.MatchString(strings.TrimSpace(line)) {
+		return ""
+	}
+
+	return protected.ReplaceAllStringFunc(line, func(m string) string {
+		return strings.Repeat(" ", len(m))
+	})
+}
+
+// miscasedIn reports the core nouns written lowercase in one line of prose.
+func miscasedIn(rules map[string]*regexp.Regexp, path, prose string, num int) []Finding {
+	var out []Finding
+
+	for word, re := range rules {
+		for range re.FindAllString(prose, -1) {
+			out = append(out, Finding{
+				Path:    path,
+				Line:    num,
+				Message: fmt.Sprintf("%q in prose: capitalise as %q", word, title(word)),
+			})
+		}
+	}
+
+	return out
+}
+
+// title upper-cases the first letter of a lowercase term.
+func title(w string) string {
+	if w == "" {
+		return w
+	}
+
+	return strings.ToUpper(w[:1]) + w[1:]
+}

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -30,7 +30,7 @@ upstream defined in `dev/config.yaml`:
 | `localhost:7234` | `test`                     | `cluster-2` |
 | `localhost:7235` | `test2`                    | `cluster-3` |
 
-The proxy itself listens on `localhost:8444` with TLS terminated using the dev certs in `dev/certs/`. The inbound server
+The proxy itself listens on `localhost:8444` with TLS terminated using the dev certs in `dev/certs/`. The gateway
 requires a client certificate (mTLS), so requests must present `dev/certs/client.crt`.
 
 In a second shell, use the `grpc` task to send requests. It wraps `buf curl` with the dev certs and gRPC-over-HTTP2
@@ -45,15 +45,15 @@ path. Pass `-H`/`--header` (repeatable) to attach gRPC metadata, for example `-H
 
 ### Confirming requests are forwarded upstream
 
-`GetSystemInfo` takes no namespace and is the cleanest proof that a request is relayed to the real Temporal frontend:
+`GetSystemInfo` takes no Namespace and is the cleanest proof that a request is relayed to the real Temporal Service:
 
 ```sh
 mise run grpc GetSystemInfo
 ```
 
-A response with the upstream's capabilities means the call traversed the proxy and reached the frontend.
+A response with the upstream's capabilities means the call traversed the proxy and reached the Temporal Service.
 
-To exercise a namespace-scoped call, use `DescribeNamespace`. Send the local alias; the proxy rewrites it to the
+To exercise a Namespace-scoped call, use `DescribeNamespace`. Send the local alias; the proxy rewrites it to the
 upstream name before forwarding, per the matched upstream's `upstream.namespaces.rules` in `dev/config.yaml`:
 
 ```sh
@@ -62,20 +62,20 @@ mise run grpc DescribeNamespace '{"namespace":"ns1"}'
 
 > [!NOTE]
 >
-> The default upstream applies `suffix: .remote`, so the local alias `ns1` reaches the frontend as `ns1.remote`, and the
-> name in the response is translated back to `ns1`. The `ns3 -> ns2.remote` override maps the local alias `ns3` to
-> `ns2.remote` upstream. `cluster-3` configures no rules, so calls routed there are forwarded verbatim.
+> The default upstream applies `suffix: .remote`, so the local alias `ns1` reaches the Temporal Service as `ns1.remote`,
+> and the name in the response is translated back to `ns1`. The `ns3 -> ns2.remote` override maps the local alias `ns3`
+> to `ns2.remote` upstream. `cluster-3` configures no rules, so calls routed there are forwarded verbatim.
 
 ### Confirming per-request routing
 
 The proxy picks an upstream per request from the `routing` rules in `dev/config.yaml`, evaluated in order (first match
 wins):
 
-1. namespace `test` -> `cluster-2`
+1. Namespace `test` -> `cluster-2`
 2. metadata `x-cluster: 3` -> `cluster-3`
 
-Everything else, including requests with no namespace (such as `GetSystemInfo`), falls through to the `default` upstream
-(`cluster-1`). A namespace-scoped call to `test` lands on the second dev server:
+Everything else, including requests with no Namespace (such as `GetSystemInfo`), falls through to the `default` upstream
+(`cluster-1`). A Namespace-scoped call to `test` lands on the second dev server:
 
 ```sh
 mise run grpc DescribeNamespace '{"namespace":"test"}'
@@ -83,8 +83,8 @@ mise run grpc DescribeNamespace '{"namespace":"test"}'
 
 #### Routing on metadata
 
-The second rule routes on request metadata rather than namespace, so any request carrying `x-cluster: 3` goes to
-`cluster-3` regardless of namespace. `cluster-3` (`localhost:7235`) is the only dev server with the `test2` namespace,
+The second rule routes on request metadata rather than Namespace, so any request carrying `x-cluster: 3` goes to
+`cluster-3` regardless of Namespace. `cluster-3` (`localhost:7235`) is the only dev server with the `test2` Namespace,
 which makes the routing observable:
 
 ```sh
@@ -100,7 +100,7 @@ The differing results confirm the metadata rule selected the upstream. Metadata 
 
 ### Checking the gateway (not proxied)
 
-The health service is answered locally by the inbound server, so it verifies the gateway is up but does not prove
+The gateway answers the health service locally, so a response proves it is accepting but says nothing about
 forwarding. It uses a different schema, so call `buf curl` directly:
 
 ```sh

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -91,6 +91,23 @@ exposes a `Module`.
   so goroutines can't leak on shutdown.
 - Prefer immutable data passed by value over shared mutable state.
 
+## Terminology
+
+- The project keeps a canonical vocabulary in
+  `.claude/skills/terminology/SKILL.md`: each accepted term next to the aliases
+  it replaces, and the standing exceptions. Invoke the `terminology` skill when
+  reviewing if your tooling supports skills, otherwise read that file. Flag
+  rejected aliases against it rather than from memory; the list is deliberately
+  not duplicated here so there is one source of truth.
+- Temporal's core nouns are proper nouns in markdown prose: Namespace, Worker,
+  Workflow, Activity, Client. Go doc comments deliberately use the lowercase
+  spelling and are internally consistent, so leave those as they are.
+- `mise run lint:terms` enforces the mechanical half and runs as part of
+  `mise run lint`. It cannot tell a Temporal Client from a gRPC client, nor
+  judge a term the rule set does not list, so those stay review comments.
+- Watch for the overloaded words the checker cannot catch: "the server" and
+  "the rule" are ambiguous in this codebase and should always be qualified.
+
 ## Consistency with the Codebase
 
 - Follow patterns already established here: fx for wiring, the `pkg/validation`

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -83,10 +83,11 @@ release:
   header: |
     ## Temporal Proxy {{ .Version }}
 
-    A gRPC proxy that sits between Temporal SDK clients, workers, and the UI on one side and one or more
-    upstream Temporal clusters (a local dev cluster, a self-hosted deployment, or Temporal Cloud) on the
-    other. It handles namespace translation and TLS termination so applications target a single local
-    endpoint while the proxy routes each request to the right upstream.
+    A gRPC proxy that sits between Temporal SDK Clients, Workers, and the Temporal UI on one side and one
+    or more upstream Temporal Services on the other. It handles Namespace translation, TLS termination,
+    and payload encryption so applications can target a single local endpoint while the proxy fans
+    requests out to the right upstream (a local dev Temporal Service, a self-hosted deployment, Temporal
+    Cloud, or some mix).
 
     ### Installation
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ carry no Cloud configuration talk plaintext to `localhost:7233`, and the proxy a
 rewrite on the way to Cloud. Follow its README to run it end to end.
 
 The [KMS extension server example](examples/kms) shows the pluggable key management path end to end: a local dev server,
-a key provider you run, and workflow payloads that the Temporal Service only ever stores as ciphertext. It is built on
+a key provider you run, and Workflow payloads that the Temporal Service only ever stores as ciphertext. It is built on
 [`pkg/ext`](pkg/ext), which supplies the gRPC surface, the credential check, TLS, and graceful shutdown, so writing your
 own extension server means implementing the key handling and little else.
 
@@ -167,7 +167,7 @@ history but not start a Workflow.
 | upstream         | A configured destination the proxy forwards to: a Temporal Service (local dev, self-hosted, or Temporal Cloud), or another Temporal Proxy.                                                     |
 | system upstream  | The upstream that handles Namespace-less requests, such as the SDK's `GetSystemInfo` call on connect.                                                                                          |
 | extension server | A gRPC service you run that the proxy calls out to for a capability it has no built-in backend for: wrapping DEKs, or deciding if a call may proceed. Build one with [`pkg/ext`](pkg/ext).     |
-| Temporal Service | A Temporal frontend the proxy connects to.                                                                                                                                                     |
+| Temporal Service | A Temporal deployment the proxy connects to: a local dev server, a self-hosted deployment, or Temporal Cloud.                                                                                  |
 
 ## Development
 

--- a/dev/config.yaml
+++ b/dev/config.yaml
@@ -23,7 +23,7 @@ upstreams:
         # Always add .remote on the way out, and remove it on the way in.
         suffix: .remote
         overrides:
-          # Makes ns2 and ns3 both use ns2.remote on the remote cluster.
+          # Makes ns2 and ns3 both use ns2.remote on the upstream Temporal Service.
           - local: ns3
             remote: ns2.remote
 
@@ -34,7 +34,7 @@ upstreams:
         # Always add .remote on the way out, and remove it on the way in.
         suffix: .remote
         overrides:
-          # Makes ns2 and ns3 both use ns2.remote on the remote cluster.
+          # Makes ns2 and ns3 both use ns2.remote on the upstream Temporal Service.
           - local: ns3
             remote: ns2.remote
 

--- a/e2e/doc.go
+++ b/e2e/doc.go
@@ -1,4 +1,4 @@
 // Package e2e contains black-box, full-stack integration tests that drive the
-// proxy the way production does: a client through the inbound server, router,
+// proxy the way production does: a client through the gateway, router,
 // per-upstream proxy, and out to a fake upstream.
 package e2e

--- a/e2e/encryption_test.go
+++ b/e2e/encryption_test.go
@@ -30,7 +30,7 @@ const (
 )
 
 // TestEndToEndPayloadEncryption drives a QueryWorkflow call through the full
-// stack (client -> inbound server -> router -> per-upstream proxy -> fake
+// stack (client -> gateway -> router -> per-upstream proxy -> fake
 // upstream) with encryption enabled via a local testing:// key, and proves the
 // interceptor is wired in both directions: the upstream receives sealed
 // QueryArgs (outbound encryption), and the client receives the original

--- a/e2e/inbound_auth_strip_test.go
+++ b/e2e/inbound_auth_strip_test.go
@@ -15,16 +15,16 @@ import (
 )
 
 // TestEndToEndInboundAuthStrippedOutboundCredentialAttached drives a request
-// through the full stack (client -> inbound server with StaticToken auth ->
-// router -> per-upstream proxy -> fake TLS upstream) and proves the inbound and
-// outbound header strips compose: the caller's worker token authenticates at
-// the inbound server but never reaches the upstream, and the upstream sees
-// exactly one authorization value, the configured static API key.
+// through the full stack (client -> gateway with StaticToken auth -> router ->
+// per-upstream proxy -> fake TLS upstream) and proves the inbound and outbound
+// header strips compose: the caller's worker token authenticates at the
+// gateway but never reaches the upstream, and the upstream sees exactly one
+// authorization value, the configured static API key.
 //
 // TestProxyAttachesUpstreamCredential (in upstream_credential_socket_test.go)
 // dials the per-upstream proxy's socket directly and so cannot exercise the
-// inbound server or router at all; this test is the only one that proves both
-// strips hold together end to end.
+// gateway or router at all; this test is the only one that proves both strips
+// hold together end to end.
 func TestEndToEndInboundAuthStrippedOutboundCredentialAttached(t *testing.T) {
 	t.Parallel()
 

--- a/examples/authz/README.md
+++ b/examples/authz/README.md
@@ -5,8 +5,8 @@ steps Temporal OSS splits across its `ClaimMapper` and `Authorizer` plugins. Her
 run yourself, an extension server, which the proxy asks about every stream it accepts: one RPC maps the claims and
 returns the verdict.
 
-What that buys is access decided per namespace and per method. A worker scoped to one namespace cannot touch another,
-and an auditor can read history but cannot start a workflow.
+What that buys is access decided per Namespace and per method. A Worker scoped to one Namespace cannot touch another,
+and an auditor can read history but cannot start a Workflow.
 
 ```mermaid
 flowchart LR
@@ -56,10 +56,10 @@ export AUTHZ_ADMIN=$(go run ./gentoken -sub acme-admin -system admin)
 
 | Token | Holds | What it can do |
 | --- | --- | --- |
-| `acme-worker` | `worker`, `reader`, `writer` in `default` | run a worker and start workflows in `default` |
+| `acme-worker` | `worker`, `reader`, `writer` in `default` | run a Worker and start Workflows in `default` |
 | `acme-auditor` | `reader` in `default` | read history in `default`, and nothing else |
 | `acme-payments` | `reader`, `writer` in `payments` | nothing in `default` |
-| `acme-admin` | `admin` at the system scope | everything, in every namespace |
+| `acme-admin` | `admin` at the system scope | everything, in every Namespace |
 
 `-claims` writes the token body to stderr while the token itself goes to stdout, so redirecting the token away leaves
 just the claims. It is the clearest way to see what you minted:
@@ -134,7 +134,7 @@ go run ./cmd/proxy serve -c examples/authz/config.yaml
 The two `Running with insecure credentials` warnings are expected: they describe the local gateway and an internal
 socket, the plaintext hops on this machine. They say nothing about whether callers are being authorized.
 
-Terminal 4, in `examples/authz`, starts the worker with the worker token:
+Terminal 4, in `examples/authz`, starts the Worker with the Worker token:
 
 ```bash
 AUTHZ_TOKEN=$AUTHZ_WORKER go run ./worker
@@ -145,7 +145,7 @@ AUTHZ_TOKEN=$AUTHZ_WORKER go run ./worker
 2026/08/13 14:25:38 INFO  Started Worker Namespace default TaskQueue authz-example WorkerID 63509@MutoBookPro.local@
 ```
 
-With all four running, start the workflow from `examples/authz`:
+With all four running, start the Workflow from `examples/authz`:
 
 ```bash
 AUTHZ_TOKEN=$AUTHZ_WORKER go run ./starter
@@ -161,7 +161,7 @@ Your run ID and timestamps will differ.
 ## What just happened
 
 Every stream the proxy accepted became one `Auth` RPC. The extension server's log is the whole story of the run, with
-the worker's repeated task-queue polls removed:
+the Worker's repeated task-queue polls removed:
 
 ```text
 {"level":"info","component":"examples","method":"/temporal.api.workflowservice.v1.WorkflowService/GetSystemInfo","time":"2026-08-13T14:25:38-04:00","message":"Allowed without reading a credential"}
@@ -203,7 +203,7 @@ claims{
 }
 ```
 
-Roles are a bitmask, so they combine, and system roles apply in every namespace. A role name the server does not
+Roles are a bitmask, so they combine, and system roles apply in every Namespace. A role name the server does not
 recognize is logged and skipped rather than failing the token, which is what Temporal's own JWT claim mapper does with a
 permission it cannot parse. That is forgiving in a way you can see. Mint a token with `writer` deliberately misspelled:
 
@@ -229,7 +229,7 @@ about what the caller is trying to reach.
 1. If the method is one every caller needs, allow it, before the credential is read.
 2. Turn the credential into claims, or fail.
 3. Look up what the method costs.
-4. `have := claims.system | claims.namespaces[namespace]` for a namespace-scoped method, `claims.system` alone for a
+4. `have := claims.system | claims.namespaces[namespace]` for a Namespace-scoped method, `claims.system` alone for a
    cluster-scoped one.
 5. Allow when `have >= need`.
 
@@ -251,7 +251,7 @@ read-only needs `reader`, write needs `writer`, anything else needs `admin`.
 
 A method the table does not list is charged as cluster-scoped admin, so a gap denies a caller rather than waving it
 through. That default is load bearing, and it fires in practice: the first version of this example was missing
-`RecordWorkerHeartbeat`, and the worker complained on startup while everything else kept working.
+`RecordWorkerHeartbeat`, and the Worker complained on startup while everything else kept working.
 
 ```text
 2026/08/13 14:20:59 WARN  Failed to send heartbeat Error caller is not permitted
@@ -302,7 +302,7 @@ systems, and it never reaches the caller.
 
 ## When it breaks
 
-**A token for the wrong namespace.** The `payments` token is not weaker than the auditor's; it is simply irrelevant
+**A token for the wrong Namespace.** The `payments` token is not weaker than the auditor's; it is simply irrelevant
 here, and it reads as holding nothing:
 
 ```bash
@@ -313,7 +313,7 @@ AUTHZ_TOKEN=$AUTHZ_PAYMENTS go run ./starter
 {"level":"warn","method":"/temporal.api.workflowservice.v1.WorkflowService/StartWorkflowExecution","code":"PermissionDenied","reason":"external auth: subject \"acme-payments\" holds none in namespace default, and /temporal.api.workflowservice.v1.WorkflowService/StartWorkflowExecution calls for writer","time":"2026-08-13T14:23:31-04:00","message":"inbound authentication rejected"}
 ```
 
-The `payments` namespace does not even exist on the dev server, and it did not need to: the proxy refused the call
+The `payments` Namespace does not even exist on the dev server, and it did not need to: the proxy refused the call
 before routing it anywhere.
 
 **An expired token.** Mint one that lasts a second, wait, and use it:
@@ -368,13 +368,13 @@ fails closed. Nothing is admitted, and the code says retryable rather than refus
 {"level":"warn","method":"/temporal.api.workflowservice.v1.WorkflowService/PollWorkflowTaskQueue","code":"Unavailable","reason":"external auth: connection error: desc = \"transport: Error while dialing: dial tcp 127.0.0.1:9444: connect: connection refused\"","time":"2026-08-13T14:22:00-04:00","message":"inbound authentication rejected"}
 ```
 
-The worker keeps trying, which is the right thing for it to do:
+The Worker keeps trying, which is the right thing for it to do:
 
 ```text
 2026/08/13 14:21:59 WARN  Failed to poll for task. Namespace default TaskQueue authz-example WorkerID 62321@MutoBookPro.local@ WorkerType WorkflowWorker Error authentication temporarily unavailable
 ```
 
-Start the extension server again and the worker recovers on its own. An authorizer that fails open would have been
+Start the extension server again and the Worker recovers on its own. An authorizer that fails open would have been
 worse than one that is down.
 
 ## What this is not
@@ -393,18 +393,18 @@ This is a teaching aid, not an authorization system:
   credential here, but adding it alone is not enough: the proxy will not put a credential on a plaintext connection, so
   guarding this server also means serving TLS and adding `tls` and `credentials` blocks to the extension server's entry
   in `config.yaml`. The kms example shows that arrangement in full, including generating throwaway certificates.
-- **Every stream is a separate `Auth` RPC**, including every worker poll, and nothing caches a verdict. That is fine
+- **Every stream is a separate `Auth` RPC**, including every Worker poll, and nothing caches a verdict. That is fine
   against an in-process check like this one and worth measuring before pointing it at a slow identity backend.
 
 ## Running it again
 
-The starter always uses the fixed workflow ID `authz-example-greeting`. Run it again after the previous run has
-completed and you get a fresh run ID, since the server's default workflow ID reuse policy allows a new run once the old
-one has closed.
+The starter always uses the fixed Workflow ID `authz-example-greeting`. Run it again after the previous run has
+completed and you get a fresh run ID, since the dev server's default Workflow ID reuse policy allows a new run once the
+old one has closed.
 
-The case worth knowing about is a still-open execution, for example one started while the worker was stopped, or while
-the worker's token could not poll. `ExecuteWorkflow` attaches to the open run rather than reporting an error, so the
-starter blocks waiting for a result no worker is producing. Bring a worker back with a token that can poll, or clear
+The case worth knowing about is a still-open execution, for example one started while the Worker was stopped, or while
+the Worker's token could not poll. `ExecuteWorkflow` attaches to the open run rather than reporting an error, so the
+starter blocks waiting for a result no Worker is producing. Bring a Worker back with a token that can poll, or clear
 the run:
 
 ```bash

--- a/examples/cloud/README.md
+++ b/examples/cloud/README.md
@@ -1,7 +1,7 @@
 # Temporal Cloud via the proxy
 
-Connect a worker to a Temporal Cloud namespace through the proxy using an API key. The worker and starter carry **no**
-Cloud configuration: they talk plaintext to `localhost:7233`, and the proxy adds TLS, the API key, and the namespace
+Connect a Worker to a Temporal Cloud Namespace through the proxy using an API key. The Worker and starter carry **no**
+Cloud configuration: they talk plaintext to `localhost:7233`, and the proxy adds TLS, the API key, and the Namespace
 rewrite on the way to Cloud.
 
 ```mermaid
@@ -16,17 +16,17 @@ flowchart LR
 
 ## Prerequisites
 
-- A Temporal Cloud namespace. Note its fully-qualified name, shown in the Cloud UI as `<namespace>.<account>` (for
+- A Temporal Cloud Namespace. Note its fully-qualified name, shown in the Cloud UI as `<namespace>.<account>` (for
   example `quickstart.a1b2c`); you split it across two environment variables below. See
   [Namespaces](https://docs.temporal.io/cloud/namespaces).
-- An API key, and API key authentication enabled on the namespace (namespaces default to mTLS, so this is a separate
+- An API key, and API key authentication enabled on the Namespace (Namespaces default to mTLS, so this is a separate
   step). See [API keys](https://docs.temporal.io/cloud/api-keys).
 - Go, and a checkout of this repository (the proxy runs from source).
 
 ## Configure
 
-Set three environment variables. `TEMPORAL_NAMESPACE` is your namespace's short name and `TEMPORAL_ACCOUNT` is the
-account id after the dot in the fully-qualified name (a namespace `quickstart.a1b2c` means
+Set three environment variables. `TEMPORAL_NAMESPACE` is your Namespace's short name and `TEMPORAL_ACCOUNT` is the
+account id after the dot in the fully-qualified name (a Namespace `quickstart.a1b2c` means
 `TEMPORAL_NAMESPACE=quickstart` and `TEMPORAL_ACCOUNT=a1b2c`):
 
 ```bash
@@ -47,7 +47,7 @@ cd ../../ && go run ./cmd/proxy serve -c examples/cloud/config.yaml
 The proxy logs `Running with insecure credentials` for the local gateway and its internal sockets. That is expected:
 those are local hops. The connection to Temporal Cloud is TLS.
 
-Start the worker:
+Start the Worker:
 
 ```bash
 go run ./worker
@@ -65,37 +65,37 @@ The starter prints:
 Hello, Temporal!
 ```
 
-The workflow execution is also visible in the Temporal Cloud UI for your namespace.
+The Workflow execution is also visible in the Temporal Cloud UI for your Namespace.
 
 ## What just happened
 
-The worker and starter connected to the proxy on `localhost:7233` with no TLS and no credentials, using the short
-namespace name `quickstart`. For each request the proxy:
+The Worker and starter connected to the proxy on `localhost:7233` with no TLS and no credentials, using the short
+Namespace name `quickstart`. For each request the proxy:
 
 1. terminated the local plaintext connection and dialed Temporal Cloud over TLS;
 2. attached the API key as an `Authorization: Bearer` header; and
-3. rewrote the namespace from `quickstart` to `quickstart.<account>` (and back on responses).
+3. rewrote the Namespace from `quickstart` to `quickstart.<account>` (and back on responses).
 
 ## How the config routes
 
-`config.yaml` uses two upstreams, which is the pattern for reaching Temporal Cloud by namespace endpoint:
+`config.yaml` uses two upstreams, which is the pattern for reaching Temporal Cloud by Namespace endpoint:
 
 - **`cloud`** handles namespaced requests. Its `hostPort` is a template (`{{ .RemoteNamespace }}.tmprl.cloud:7233`)
-  resolved per request from the translated namespace, so one config serves any number of namespaces - point more workers
-  at the proxy with different namespaces and each reaches its own Cloud endpoint, no config change.
-- **`system`** handles the namespace-less calls the SDK makes (for example `GetSystemInfo` on connect). With no
-  namespace there is nothing to derive a host from, so this upstream uses a fixed endpoint. Any namespace endpoint in
+  resolved per request from the translated Namespace, so one config serves any number of Namespaces - point more Workers
+  at the proxy with different Namespaces and each reaches its own Cloud endpoint, no config change.
+- **`system`** handles the Namespace-less calls the SDK makes (for example `GetSystemInfo` on connect). With no
+  Namespace there is nothing to derive a host from, so this upstream uses a fixed endpoint. Any Namespace endpoint in
   the account answers these calls.
 
 > [!NOTE]
 >
-> With a single namespace both upstreams resolve to the same host; the split is what lets the same config scale to many.
+> With a single Namespace both upstreams resolve to the same host; the split is what lets the same config scale to many.
 
 ## Optional: encrypt payloads to Cloud
 
-`config.yaml` ends with a commented-out `encryption:` block. Uncomment it and restart the proxy to encrypt workflow and
-activity payloads on the hop to Cloud: the worker and starter keep exchanging cleartext, the proxy seals payloads before
-they leave and opens them on the way back, and Cloud only ever stores ciphertext (workflow inputs and results show as
+`config.yaml` ends with a commented-out `encryption:` block. Uncomment it and restart the proxy to encrypt Workflow and
+Activity payloads on the hop to Cloud: the Worker and starter keep exchanging cleartext, the proxy seals payloads before
+they leave and opens them on the way back, and Cloud only ever stores ciphertext (Workflow inputs and results show as
 encrypted bytes in the Cloud UI).
 
 The block uses a `testing://` key, which holds its key material in the config itself with no cloud KMS. That is fine for

--- a/examples/kms/README.md
+++ b/examples/kms/README.md
@@ -20,7 +20,7 @@ flowchart LR
 ## Prerequisites
 
 - Go and a checkout of this repository; the proxy and the example both run from source.
-- The `temporal` CLI, for the dev server and for inspecting workflow history.
+- The `temporal` CLI, for the dev server and for inspecting Workflow history.
 - No cloud account and no credentials: everything in this example runs on localhost.
 
 Everything under `examples` is one Go module, and its `go.mod` builds the proxy from this working tree with a `replace`
@@ -53,7 +53,7 @@ export KMS_MASTER_SECRET=example-master-secret
 ```
 
 The proxy only needs `KMS_API_KEY`, the bearer token it presents to the extension server. The extension server needs
-both: the same API key to authenticate callers, and the master secret every namespace's wrapping key is derived from.
+both: the same API key to authenticate callers, and the master secret every Namespace's wrapping key is derived from.
 
 ## Run
 
@@ -91,11 +91,11 @@ KMS_API_KEY=example-token go run ./cmd/proxy serve -c examples/kms/config.yaml
 ```
 
 The two `Running with insecure credentials` warnings are expected, not a sign anything is broken: they describe the
-local gateway and an internal socket, the plaintext hops between the worker/starter and the proxy on this machine. They
+local gateway and an internal socket, the plaintext hops between the Worker/starter and the proxy on this machine. They
 say nothing about whether payloads get sealed or about the TLS connection to the extension server; both of those are
 unaffected.
 
-Terminal 4, in `examples/kms`, starts the worker:
+Terminal 4, in `examples/kms`, starts the Worker:
 
 ```bash
 go run ./worker
@@ -105,7 +105,7 @@ go run ./worker
 2026/07/29 15:26:27 worker listening on task queue "kms-example" (namespace "default")
 ```
 
-With all four running, start the workflow from `examples/kms`:
+With all four running, start the Workflow from `examples/kms`:
 
 ```bash
 go run ./starter
@@ -120,18 +120,18 @@ Your run ID and timestamps will differ.
 
 ## What just happened
 
-The worker and starter never saw an encryption key: they dialed the proxy at `127.0.0.1:7234` in plaintext and exchanged
-the plain string `"Temporal"` and the plain string `"Hello, Temporal!"`. For the workflow's first payload, the proxy:
+The Worker and starter never saw an encryption key: they dialed the proxy at `127.0.0.1:7234` in plaintext and exchanged
+the plain string `"Temporal"` and the plain string `"Hello, Temporal!"`. For the Workflow's first payload, the proxy:
 
 1. generated a random 32-byte DEK;
 2. called the extension server's `Encrypt` RPC over TLS, with a bearer token, asking it to wrap that DEK under the
-   namespace `default` - this is the only thing that crossed the wire to `127.0.0.1:9443`, no payload plaintext ever
+   Namespace `default` - this is the only thing that crossed the wire to `127.0.0.1:9443`, no payload plaintext ever
    went there;
 3. sealed the payload locally with the DEK and recorded the wrapped DEK, and the key's URI, in the payload's metadata;
    and
 4. sent the sealed payload on to the dev server at `127.0.0.1:7233`.
 
-Every later payload in the same run, the activity's input and result and the workflow's own result, reused the cached
+Every later payload in the same run, the Activity's input and result and the Workflow's own result, reused the cached
 DEK instead of asking the extension server to wrap a new one; see "The cache is working" below.
 
 ## See the ciphertext
@@ -203,8 +203,8 @@ The one wrap is the number to watch, and it is the same on every run. The unwrap
 to run. The read-side cache is filled after the first miss and has no single-flight, so payloads opened concurrently can
 all miss it together and each ask the extension server for the same DEK.
 
-Meanwhile the workflow's history carries four payloads sealed under that one DEK: the workflow input, the activity's
-input and result, and the workflow's result each carry an `encryption-dek` entry in their metadata. Two separate
+Meanwhile the Workflow's history carries four payloads sealed under that one DEK: the Workflow input, the Activity's
+input and result, and the Workflow's result each carry an `encryption-dek` entry in their metadata. Two separate
 settings in `config.yaml` are behind that, and they govern different sides of the exchange. `duration: 1h` is how long
 the proxy reuses one sealed-side DEK before wrapping a fresh one, which is why sealing four payloads in this run only
 cost one wrap call. `cacheSize: 200` is unrelated to sealing: it bounds a separate LRU of unwrapped DEKs the proxy keeps
@@ -225,22 +225,22 @@ Every ciphertext the provider produces is a self-contained frame:
 [ version: 1 byte ][ namespace length: 2 bytes ][ namespace ][ nonce: 12 bytes ][ ciphertext + GCM tag ]
 ```
 
-`Decrypt` receives nothing but that ciphertext, no namespace and no other context, so `Unwrap` has to read the namespace
-back out of the frame before it can derive the matching key. The namespace also doubles as the GCM additional data, so a
-ciphertext relabelled with a different namespace fails to open rather than silently decrypting under the wrong key. It
-is also why the `default` namespace's ciphertext above is 70 bytes while the `payments` namespace's, in the optional
-section below, is 71: the only difference is one extra byte of namespace name carried inside the frame.
+`Decrypt` receives nothing but that ciphertext, no Namespace and no other context, so `Unwrap` has to read the Namespace
+back out of the frame before it can derive the matching key. The Namespace also doubles as the GCM additional data, so a
+ciphertext relabelled with a different Namespace fails to open rather than silently decrypting under the wrong key. It
+is also why the `default` Namespace's ciphertext above is 70 bytes while the `payments` Namespace's, in the optional
+section below, is 71: the only difference is one extra byte of Namespace name carried inside the frame.
 
-Three things worth being honest about. First, a namespace is not secret, but a real provider that would rather not carry
+Three things worth being honest about. First, a Namespace is not secret, but a real provider that would rather not carry
 a plaintext tenant name in its ciphertexts could use an opaque key identifier instead and resolve it internally. Second,
 the `payloads` segment in `config.yaml`'s key URI (`extension://kms/payloads`) never reaches the extension server; the
-provider selects a key by namespace alone, nothing else. That segment exists only on the proxy's side, as the identifier
+provider selects a key by Namespace alone, nothing else. That segment exists only on the proxy's side, as the identifier
 it uses to pick the same key policy again when opening a payload later, but it does have to be globally unique across
 `default` and every entry in `overrides`: two policies sharing a URI fail proxy startup with a `duplicate key id` error
-(see the optional section below). Third, the namespace the provider receives is always the local, pre-translation
-namespace, never a translated remote name; this example configures no translation so it never comes up here, but a
-provider paired with namespace translation has to key on that same local name, or its per-namespace keys end up
-misaligned with the namespace a caller actually asked for.
+(see the optional section below). Third, the Namespace the provider receives is always the local, pre-translation
+Namespace, never a translated remote name; this example configures no translation so it never comes up here, but a
+provider paired with Namespace translation has to key on that same local name, or its per-Namespace keys end up
+misaligned with the Namespace a caller actually asked for.
 
 ## When it breaks
 
@@ -258,12 +258,12 @@ namespace: default, failed to encrypt DEK, id: extension://kms/payloads, err: rp
 desc = invalid credentials
 ```
 
-The workflow never starts; no execution shows up in `temporal workflow list`. The error surfaces only on the starter's
+The Workflow never starts; no execution shows up in `temporal workflow list`. The error surfaces only on the starter's
 side. The proxy's own log stays silent about it.
 
 **Wrong certificate name.** Removing `serverName: localhost` from `config.yaml`'s extension server block does not stop
 the proxy from starting: nothing dials the extension server until the first payload needs a key, so a mismatched server
-name is invisible at boot. The first workflow start after that just hangs and times out, rather than failing with a
+name is invisible at boot. The first Workflow start after that just hangs and times out, rather than failing with a
 clear error:
 
 ```text
@@ -289,10 +289,10 @@ This provider is a teaching aid, not a key manager:
 - the master secret lives in a plain environment variable (`KMS_MASTER_SECRET`);
 - that secret also has to be actual secret material: HKDF extracts entropy from it rather than adding any, so it needs
   to be at least 32 bytes of cryptographic randomness, for example from `openssl rand -base64 32`, not a human-chosen
-  passphrase. A passphrase here is directly brute-forceable, and recovering it yields every per-namespace key at once.
+  passphrase. A passphrase here is directly brute-forceable, and recovering it yields every per-Namespace key at once.
   This example's own value, `example-master-secret`, is a passphrase, and that is fine only because this is a localhost
   demo, not something to copy into a real deployment;
-- nothing on the provider side rotates: the same secret derives the same per-namespace key forever; and
+- nothing on the provider side rotates: the same secret derives the same per-Namespace key forever; and
 - losing that secret loses every payload ever sealed under it, with no recovery path.
 
 Also worth flagging: the extension server here authenticates only with a bearer token over TLS, which is the right
@@ -305,14 +305,14 @@ For a real deployment, point the proxy's `encryption` block at one of the built-
 
 ## Running it again
 
-The starter always uses the fixed workflow ID `kms-example-greeting`. Run it again after the previous run has completed
-and nothing special happens: the server's default workflow ID reuse policy allows a new run once the old one has closed,
+The starter always uses the fixed Workflow ID `kms-example-greeting`. Run it again after the previous run has completed
+and nothing special happens: the server's default Workflow ID reuse policy allows a new run once the old one has closed,
 so you get a fresh run ID and `Hello, Temporal!` again with no cleanup required.
 
-The case worth knowing about is a still-open execution, for example one started while the worker was stopped. Here
+The case worth knowing about is a still-open execution, for example one started while the Worker was stopped. Here
 neither the SDK nor the CLI report an already-started error the way you might expect: `ExecuteWorkflow` and
 `temporal workflow start` both attach to the open run instead of rejecting the request, so the starter just blocks
-waiting for a result that will not arrive until a worker picks the run up. If that happens, either bring the worker back
+waiting for a result that will not arrive until a Worker picks the run up. If that happens, either bring the Worker back
 so the open run can finish, clear it directly with:
 
 ```bash
@@ -321,13 +321,13 @@ temporal workflow terminate --workflow-id kms-example-greeting --namespace defau
 
 or restart the dev server, whose state lives entirely in memory.
 
-## Optional: per-namespace keys
+## Optional: per-Namespace keys
 
 Restarting the dev server below discards the `kms-example-greeting` execution from the sections above, since its state
 lives entirely in memory; that is fine for this section, which stands on its own, but do it only once you are done
 inspecting that execution.
 
-Start the dev server with a second namespace:
+Start the dev server with a second Namespace:
 
 ```bash
 temporal server start-dev -n payments
@@ -353,8 +353,8 @@ encryption:
 
 The override's URI has to differ from the default key's URI even though both point at the same extension server: as
 noted above, reusing `extension://kms/payloads` for both fails proxy startup with
-`duplicate key id: extension://kms/payloads`. Restart the proxy, then start a workflow against the new namespace; no
-worker is needed for this check, since the key exchange happens on the way in:
+`duplicate key id: extension://kms/payloads`. Restart the proxy, then start a Workflow against the new Namespace; no
+Worker is needed for this check, since the key exchange happens on the way in:
 
 ```bash
 temporal workflow start --address 127.0.0.1:7234 --namespace payments --task-queue kms-example \
@@ -369,7 +369,7 @@ wrapped a DEK: namespace=default plaintext=32B ciphertext=70B
 wrapped a DEK: namespace=payments plaintext=32B ciphertext=71B
 ```
 
-Same master secret, same extension server connection, but a different derived key per namespace. Clean up with:
+Same master secret, same extension server connection, but a different derived key per Namespace. Clean up with:
 
 ```bash
 temporal workflow terminate --workflow-id kms-payments-demo --namespace payments --address 127.0.0.1:7234

--- a/internal/config/upstream.go
+++ b/internal/config/upstream.go
@@ -9,10 +9,10 @@ import (
 )
 
 type (
-	// Upstream describes a single upstream Temporal cluster the proxy connects
-	// workers to along with configuration for that remote cluster. Name
-	// identifies the upstream so routing rules can refer to it; it must be
-	// unique within the config.
+	// Upstream describes a single upstream Temporal Service the proxy connects
+	// workers to, along with the configuration for reaching it. Name identifies
+	// the upstream so routing rules can refer to it; it must be unique within
+	// the config.
 	//
 	// Cloud declares the upstream to be Temporal Cloud, which turns on
 	// Cloud-specific namespace rules. It is only needed for an address
@@ -34,7 +34,8 @@ type (
 	}
 
 	// NamespaceRules translates namespace names between the local view that
-	// workers use and the remote names registered on the upstream cluster.
+	// workers use and the remote names registered on the upstream Temporal
+	// Service.
 	//
 	// The default translation is to wrap or unwrap a Prefix and Suffix:
 	// Remote("payments") returns Prefix+"payments"+Suffix, and Local of that

--- a/internal/proxy/doc.go
+++ b/internal/proxy/doc.go
@@ -1,5 +1,5 @@
 // Package proxy serves every allowlisted service on a local unix socket,
-// forwarding each request to an upstream Temporal frontend over gRPC. The
+// forwarding each request to an upstream Temporal Service over gRPC. The
 // socket path is derived from the upstream host:port, so local workers connect
 // without TLS while the upstream hop stays secured.
 package proxy

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -15,9 +15,9 @@ import (
 
 type (
 	// Server proxies the Temporal WorkflowService. It re-serves an upstream
-	// frontend on a local unix socket, letting local workers connect without TLS
-	// while the upstream hop stays secured. The upstream connection(s) it
-	// forwards to are owned by the shared [connect.Pool], not by this Server.
+	// Temporal Service on a local unix socket, letting local workers connect
+	// without TLS while the upstream hop stays secured. The upstream connection(s)
+	// it forwards to are owned by the shared [connect.Pool], not by this Server.
 	Server struct {
 		svr  *server.Server
 		path string // path to unix socket

--- a/internal/router/doc.go
+++ b/internal/router/doc.go
@@ -1,7 +1,7 @@
 // Package router transparently forwards inbound gRPC traffic to an upstream
 // connection without decoding it.
 //
-// It provides two pieces that are wired onto the inbound server:
+// It provides two pieces that are wired onto the gateway:
 //
 //   - Codec returns a hybrid [google.golang.org/grpc/encoding.CodecV2] that
 //     passes relayed frames through as raw bytes and delegates every other

--- a/mise.toml
+++ b/mise.toml
@@ -72,7 +72,12 @@ buf curl --protocol grpc --http2-prior-knowledge \
 
 [tasks.lint]
 description = "Lint files"
-run = [{ task = "lint:go" }, { task = "lint:md" }, { task = "lint:protos" }]
+run = [
+  { task = "lint:go" },
+  { task = "lint:md" },
+  { task = "lint:protos" },
+  { task = "lint:terms" },
+]
 
 [tasks."lint:go"]
 description = "Lint Go files"
@@ -81,6 +86,11 @@ run = ["golangci-lint run ./..."]
 [tasks."lint:md"]
 description = "Lint markdown files"
 run = ["markdownlint-cli2 '**/*.md' --config markdownlint.yaml"]
+
+[tasks."lint:terms"]
+description = "Check the project's canonical vocabulary"
+dir = ".claude/skills/terminology"
+run = ["go run ./"]
 
 [tasks."lint:protos"]
 description = "Lint proto files"


### PR DESCRIPTION
The README terms table has named this project's vocabulary for a while, but nothing has ensured those terms are used. Upstream config and the proxy package still refer to a Temporal Service as a cluster or a frontend. The goreleaser blurb shipped the wrong word in every release note, etc.

Settle all of it on the canonical terms, then add a checker so it stays settled. `mise run lint:terms` (runs in CI) flags rejected phrases in Go, Markdown and YAML, and enforces the core nouns as proper nouns in Markdown prose only. Scope comes from `git ls-files`, so .gitignore and .git/info/exclude already decide what is in play and terms.yaml defines any ignores git cannot infer. Every exception records why it is there.

The checker is its own Go module, so the root go.mod gains no dependency, and SKILL.md doubles as the reference a reviewer reads. The Copilot review instructions point at it instead of restating the term list, so the two cannot drift, and the review skill inherits that through its existing include.