### PR TITLE
[dataplane]: Translate the methods Cloud does not serve on a frontend

### DIFF
--- a/e2e/method_translation_test.go
+++ b/e2e/method_translation_test.go
@@ -1,0 +1,308 @@
+package e2e
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/workflowservice/v1"
+	cloudservice "go.temporal.io/cloud-sdk/api/cloudservice/v1"
+	cloudnamespace "go.temporal.io/cloud-sdk/api/namespace/v1"
+	"go.temporal.io/cloud-sdk/api/resource/v1"
+	"go.temporal.io/cloud-sdk/cloudclient"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+
+	"github.com/temporalio/temporal-proxy/internal/config"
+	"github.com/temporalio/temporal-proxy/internal/dataplane/dataplanetest"
+)
+
+// cloudUpstream is a fake Temporal Cloud control plane. It serves CloudService
+// and nothing else, the way saas-api does, and records the request and metadata
+// it was called with. It is local to this test rather than folded into
+// dataplanetest.Upstream because WorkflowService and CloudService both declare
+// UpdateNamespace, so one struct cannot embed both unimplemented servers.
+type cloudUpstream struct {
+	cloudservice.UnimplementedCloudServiceServer
+
+	addr string
+
+	mu   sync.Mutex
+	got  *cloudservice.GetNamespacesRequest
+	md   metadata.MD
+	page []*cloudnamespace.Namespace
+}
+
+// TestEndToEndListNamespacesTranslatesOntoCloudService drives the full stack the
+// way the listnamespace example does: a client calls WorkflowService.ListNamespaces
+// against the gateway, it is routed to the ordinary frontend like everything
+// else, and the translation captures it there and answers it over the Cloud API
+// connection instead. The client gets a ListNamespacesResponse back without ever
+// knowing a different service on a different host answered it.
+//
+// This is the whole path - gateway, peek, router, per-upstream proxy, forwarder,
+// translation interceptor - rather than the interceptor in isolation.
+func TestEndToEndListNamespacesTranslatesOntoCloudService(t *testing.T) {
+	t.Parallel()
+
+	frontend := dataplanetest.NewUpstream(t)
+	cloud := newCloudUpstream(t)
+	cloud.setPage(&cloudnamespace.Namespace{
+		Namespace: "payments.a1b2c",
+		State:     resource.ResourceState_RESOURCE_STATE_ACTIVE,
+		Spec: &cloudnamespace.NamespaceSpec{
+			Name:          "payments",
+			RetentionDays: 30,
+			Replicas: []*cloudnamespace.ReplicaSpec{
+				{Region: "aws-us-east-1"},
+				{Region: "aws-us-west-2"},
+			},
+		},
+	})
+
+	f := dataplanetest.StartApp(t, &config.Config{
+		Routing: config.Routing{DefaultUpstream: "frontend", SystemUpstream: "frontend"},
+		Upstreams: config.UpstreamList{{
+			Name:   "frontend",
+			Cloud:  true,
+			Listen: config.ListenConfig{HostPort: frontend.Addr()},
+		}},
+		APITranslations: cloudAPIAt(cloud.addr),
+	})
+
+	reply, err := f.Client().ListNamespaces(
+		f.Context(),
+		&workflowservice.ListNamespacesRequest{PageSize: 7},
+		grpc.WaitForReady(true),
+	)
+	require.NoError(t, err)
+
+	// The caller's request became a CloudService one on the wire.
+	got := cloud.request()
+	require.NotNil(t, got, "the Cloud upstream must have been called")
+	require.Equal(t, int32(7), got.GetPageSize())
+
+	// The API version header the Cloud API requires was stamped by the proxy, not
+	// by the caller, which sent none.
+	require.Equal(t,
+		[]string{cloudclient.DefaultAPIVersion()},
+		cloud.metadata().Get(cloudclient.TemporalCloudAPIVersionHeader()),
+	)
+
+	// And the caller got a WorkflowService reply built from the Cloud response.
+	require.Len(t, reply.GetNamespaces(), 1)
+	ns := reply.GetNamespaces()[0]
+	require.Equal(t, "payments.a1b2c", ns.GetNamespaceInfo().GetName())
+	require.Equal(t, enumspb.NAMESPACE_STATE_REGISTERED, ns.GetNamespaceInfo().GetState())
+	require.True(t, ns.GetIsGlobalNamespace())
+}
+
+// TestEndToEndOnlyTranslatedMethodsReachTheCloudAPI proves the capture is
+// surgical. GetSystemInfo carries no namespace either, and travels the same
+// upstream connection the translation is installed on, so only the registry
+// distinguishes them. Every SDK calls GetSystemInfo on connect, so diverting it
+// to a host that does not serve WorkflowService would break every client.
+func TestEndToEndOnlyTranslatedMethodsReachTheCloudAPI(t *testing.T) {
+	t.Parallel()
+
+	frontend := dataplanetest.NewUpstream(t)
+	cloud := newCloudUpstream(t)
+
+	f := dataplanetest.StartApp(t, &config.Config{
+		Routing: config.Routing{DefaultUpstream: "frontend", SystemUpstream: "frontend"},
+		Upstreams: config.UpstreamList{{
+			Name:   "frontend",
+			Cloud:  true,
+			Listen: config.ListenConfig{HostPort: frontend.Addr()},
+		}},
+		APITranslations: cloudAPIAt(cloud.addr),
+	})
+
+	_, err := f.Client().GetSystemInfo(
+		f.Context(),
+		&workflowservice.GetSystemInfoRequest{},
+		grpc.WaitForReady(true),
+	)
+	require.NoError(t, err)
+
+	require.NotNil(t, frontend.Metadata(), "GetSystemInfo must still reach the frontend")
+	require.Nil(t, cloud.request(), "and must not be diverted to the Cloud API")
+}
+
+// TestEndToEndANonCloudUpstreamTranslatesNothing is the negative control for the
+// test above: the same fixture with an upstream that is not Cloud. It establishes
+// that being a Cloud upstream is what diverts the call, rather than it reaching
+// the Cloud API by some other path.
+//
+// It asserts on the Cloud fake rather than on the frontend, because the frontend
+// fake only records the handlers it implements: ListNamespaces falls through to
+// its embedded Unimplemented stub, so "the frontend recorded nothing" would hold
+// whether or not the call reached it.
+func TestEndToEndANonCloudUpstreamTranslatesNothing(t *testing.T) {
+	t.Parallel()
+
+	cloud := newCloudUpstream(t)
+
+	f := dataplanetest.StartApp(t, &config.Config{
+		Routing: config.Routing{DefaultUpstream: "frontend", SystemUpstream: "frontend"},
+		Upstreams: config.UpstreamList{{
+			Name:   "frontend",
+			Listen: config.ListenConfig{HostPort: dataplanetest.NewUpstream(t).Addr()},
+		}},
+	})
+
+	// The frontend fake does not implement ListNamespaces, so this is the error a
+	// real Temporal frontend's answer stands in for. What matters is where it came
+	// from, not that it failed.
+	_, err := f.Client().ListNamespaces(
+		f.Context(),
+		&workflowservice.ListNamespacesRequest{},
+		grpc.WaitForReady(true),
+	)
+	require.Error(t, err)
+	require.Nil(t, cloud.request(), "a non-Cloud upstream must translate nothing")
+}
+
+// newCloudUpstream starts a fake CloudService on a loopback port and stops it
+// when the test ends.
+func newCloudUpstream(t *testing.T) *cloudUpstream {
+	t.Helper()
+
+	up := new(cloudUpstream)
+
+	svr := grpc.NewServer()
+	cloudservice.RegisterCloudServiceServer(svr, up)
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	go func() { _ = svr.Serve(lis) }()
+	t.Cleanup(svr.Stop)
+
+	up.addr = lis.Addr().String()
+
+	return up
+}
+
+// GetNamespaces records the call and answers with the configured page.
+func (u *cloudUpstream) GetNamespaces(
+	ctx context.Context, req *cloudservice.GetNamespacesRequest,
+) (*cloudservice.GetNamespacesResponse, error) {
+	md, _ := metadata.FromIncomingContext(ctx)
+
+	u.mu.Lock()
+	defer u.mu.Unlock()
+
+	u.got = req
+	u.md = md
+
+	return &cloudservice.GetNamespacesResponse{Namespaces: u.page}, nil
+}
+
+func (u *cloudUpstream) setPage(ns ...*cloudnamespace.Namespace) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+
+	u.page = ns
+}
+
+// request is the most recent GetNamespaces request, or nil before the first one
+// arrives.
+func (u *cloudUpstream) request() *cloudservice.GetNamespacesRequest {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+
+	return u.got
+}
+
+func (u *cloudUpstream) metadata() metadata.MD {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+
+	return u.md.Copy()
+}
+
+// TestEndToEndNamespaceRulesApplyToATranslatedReply pins the interceptor's
+// position in the chain, which nothing else would catch.
+//
+// Via leaves the interceptor chain when a translation fires, so whatever sits
+// below method translation never runs for a translated call. Installed
+// innermost, as it is, the namespace translator above it still sees the
+// converted reply and rewrites the names in it; moved any higher, the call
+// leaves before the namespace translator is reached and the caller gets raw
+// Cloud names instead. Both orderings compile and leave every other test
+// passing.
+func TestEndToEndNamespaceRulesApplyToATranslatedReply(t *testing.T) {
+	t.Parallel()
+
+	cloud := newCloudUpstream(t)
+	cloud.setPage(&cloudnamespace.Namespace{
+		Namespace: "payments.a1b2c",
+		State:     resource.ResourceState_RESOURCE_STATE_ACTIVE,
+	})
+
+	f := dataplanetest.StartApp(t, &config.Config{
+		Routing: config.Routing{DefaultUpstream: "frontend", SystemUpstream: "frontend"},
+		Upstreams: config.UpstreamList{{
+			Name:       "frontend",
+			Cloud:      true,
+			Listen:     config.ListenConfig{HostPort: dataplanetest.NewUpstream(t).Addr()},
+			Namespaces: config.NamespaceConfig{Rules: config.NamespaceRules{Suffix: ".a1b2c"}},
+		}},
+		APITranslations: cloudAPIAt(cloud.addr),
+	})
+
+	reply, err := f.Client().ListNamespaces(
+		f.Context(),
+		&workflowservice.ListNamespacesRequest{},
+		grpc.WaitForReady(true),
+	)
+	require.NoError(t, err)
+
+	require.Len(t, reply.GetNamespaces(), 1)
+	require.Equal(t, "payments", reply.GetNamespaces()[0].GetNamespaceInfo().GetName(),
+		"the namespace translator must still see the converted reply")
+}
+
+// cloudAPIAt points method translation at a fake control plane. Nil TLS dials it
+// in plaintext, which the real address never would.
+func cloudAPIAt(hostPort string) *config.APITranslations {
+	return &config.APITranslations{
+		CloudAPI: &config.CloudAPI{Listen: config.ListenConfig{HostPort: hostPort}},
+	}
+}
+
+// TestEndToEndTranslationCanBeDisabled covers the operator override: a Cloud
+// upstream that would be translated, opting out. The call then fails the way it
+// does without the proxy, which is the point - an operator who prefers the
+// untranslated failure to a translated answer can have it.
+func TestEndToEndTranslationCanBeDisabled(t *testing.T) {
+	t.Parallel()
+
+	cloud := newCloudUpstream(t)
+
+	off := false
+	translations := cloudAPIAt(cloud.addr)
+	translations.Enabled = &off
+
+	f := dataplanetest.StartApp(t, &config.Config{
+		Routing: config.Routing{DefaultUpstream: "frontend", SystemUpstream: "frontend"},
+		Upstreams: config.UpstreamList{{
+			Name:   "frontend",
+			Cloud:  true,
+			Listen: config.ListenConfig{HostPort: dataplanetest.NewUpstream(t).Addr()},
+		}},
+		APITranslations: translations,
+	})
+
+	_, err := f.Client().ListNamespaces(
+		f.Context(),
+		&workflowservice.ListNamespacesRequest{},
+		grpc.WaitForReady(true),
+	)
+	require.Error(t, err, "the call is forwarded untranslated, and the frontend does not serve it")
+	require.Nil(t, cloud.request(), "and the control plane is never reached")
+}

--- a/e2e/method_translation_test.go
+++ b/e2e/method_translation_test.go
@@ -270,33 +270,37 @@ func TestEndToEndNamespaceRulesApplyToATranslatedReply(t *testing.T) {
 // cloudAPIAt points method translation at a fake control plane. The fake serves
 // plaintext, so it has to say so: a dialled target with no tls block verifies
 // against the system roots, which is what the real address wants.
-func cloudAPIAt(hostPort string) *config.APITranslations {
-	return &config.APITranslations{
-		CloudAPI: &config.CloudAPI{Listen: config.ListenConfig{HostPort: hostPort, Insecure: true}},
+func cloudAPIAt(hostPort string) config.APITranslations {
+	return config.APITranslations{
+		CloudAPI: config.CloudAPI{Listen: config.ListenConfig{HostPort: hostPort, Insecure: true}},
 	}
 }
 
-// TestEndToEndTranslationCanBeDisabled covers the operator override: a Cloud
-// upstream that would be translated, opting out. The call then fails the way it
-// does without the proxy, which is the point - an operator who prefers the
-// untranslated failure to a translated answer can have it.
-func TestEndToEndTranslationCanBeDisabled(t *testing.T) {
+// TestEndToEndACloudUpstreamServingNoNamespacelessRequestsTranslatesNothing is
+// the hybrid case, and what replaced the operator's on/off switch. Temporal Cloud
+// serves this deployment's namespaced traffic by rule, while namespace-less
+// requests are routed to a Temporal Service that answers them itself. Translation
+// follows the request rather than the upstream, so nothing is translated here and
+// the operator who wants Cloud's own answer back says so in routing.
+func TestEndToEndACloudUpstreamServingNoNamespacelessRequestsTranslatesNothing(t *testing.T) {
 	t.Parallel()
 
 	cloud := newCloudUpstream(t)
 
-	off := false
-	translations := cloudAPIAt(cloud.addr)
-	translations.Enabled = &off
-
 	f := dataplanetest.StartApp(t, &config.Config{
-		Routing: config.Routing{DefaultUpstream: "frontend", SystemUpstream: "frontend"},
-		Upstreams: config.UpstreamList{{
-			Name:   "frontend",
-			Cloud:  true,
-			Listen: dataplanetest.NewUpstream(t).Listen(),
-		}},
-		APITranslations: translations,
+		Routing: config.Routing{
+			DefaultUpstream: "onprem",
+			SystemUpstream:  "onprem",
+			Rules: []config.RoutingRule{{
+				Upstream: "cloud",
+				Match:    config.RoutingMatch{Namespace: "*.a1b2c"},
+			}},
+		},
+		Upstreams: config.UpstreamList{
+			{Name: "onprem", Listen: dataplanetest.NewUpstream(t).Listen()},
+			{Name: "cloud", Cloud: true, Listen: dataplanetest.NewUpstream(t).Listen()},
+		},
+		APITranslations: cloudAPIAt(cloud.addr),
 	})
 
 	_, err := f.Client().ListNamespaces(
@@ -304,6 +308,39 @@ func TestEndToEndTranslationCanBeDisabled(t *testing.T) {
 		&workflowservice.ListNamespacesRequest{},
 		grpc.WaitForReady(true),
 	)
-	require.Error(t, err, "the call is forwarded untranslated, and the frontend does not serve it")
+	require.Error(t, err, "the request went to the upstream serving namespace-less traffic, untranslated")
 	require.Nil(t, cloud.request(), "and the control plane is never reached")
+}
+
+// TestEndToEndTheDefaultUpstreamCarriesNamespacelessRequests covers the ordinary
+// single-upstream config, which names no system upstream at all. Namespace-less
+// requests fall through to the default, so translation has to follow them there
+// or ListNamespaces stays broken for the configuration most operators write.
+func TestEndToEndTheDefaultUpstreamCarriesNamespacelessRequests(t *testing.T) {
+	t.Parallel()
+
+	cloud := newCloudUpstream(t)
+	cloud.setPage(&cloudnamespace.Namespace{
+		Namespace: "payments.a1b2c",
+		State:     resource.ResourceState_RESOURCE_STATE_ACTIVE,
+	})
+
+	f := dataplanetest.StartApp(t, &config.Config{
+		Routing: config.Routing{DefaultUpstream: "frontend"},
+		Upstreams: config.UpstreamList{{
+			Name:   "frontend",
+			Cloud:  true,
+			Listen: dataplanetest.NewUpstream(t).Listen(),
+		}},
+		APITranslations: cloudAPIAt(cloud.addr),
+	})
+
+	reply, err := f.Client().ListNamespaces(
+		f.Context(),
+		&workflowservice.ListNamespacesRequest{},
+		grpc.WaitForReady(true),
+	)
+	require.NoError(t, err)
+	require.Len(t, reply.GetNamespaces(), 1)
+	require.NotNil(t, cloud.request(), "the default upstream is where a namespace-less request lands")
 }

--- a/e2e/method_translation_test.go
+++ b/e2e/method_translation_test.go
@@ -68,7 +68,7 @@ func TestEndToEndListNamespacesTranslatesOntoCloudService(t *testing.T) {
 		Upstreams: config.UpstreamList{{
 			Name:   "frontend",
 			Cloud:  true,
-			Listen: config.ListenConfig{HostPort: frontend.Addr()},
+			Listen: frontend.Listen(),
 		}},
 		APITranslations: cloudAPIAt(cloud.addr),
 	})
@@ -116,7 +116,7 @@ func TestEndToEndOnlyTranslatedMethodsReachTheCloudAPI(t *testing.T) {
 		Upstreams: config.UpstreamList{{
 			Name:   "frontend",
 			Cloud:  true,
-			Listen: config.ListenConfig{HostPort: frontend.Addr()},
+			Listen: frontend.Listen(),
 		}},
 		APITranslations: cloudAPIAt(cloud.addr),
 	})
@@ -150,7 +150,7 @@ func TestEndToEndANonCloudUpstreamTranslatesNothing(t *testing.T) {
 		Routing: config.Routing{DefaultUpstream: "frontend", SystemUpstream: "frontend"},
 		Upstreams: config.UpstreamList{{
 			Name:   "frontend",
-			Listen: config.ListenConfig{HostPort: dataplanetest.NewUpstream(t).Addr()},
+			Listen: dataplanetest.NewUpstream(t).Listen(),
 		}},
 	})
 
@@ -249,7 +249,7 @@ func TestEndToEndNamespaceRulesApplyToATranslatedReply(t *testing.T) {
 		Upstreams: config.UpstreamList{{
 			Name:       "frontend",
 			Cloud:      true,
-			Listen:     config.ListenConfig{HostPort: dataplanetest.NewUpstream(t).Addr()},
+			Listen:     dataplanetest.NewUpstream(t).Listen(),
 			Namespaces: config.NamespaceConfig{Rules: config.NamespaceRules{Suffix: ".a1b2c"}},
 		}},
 		APITranslations: cloudAPIAt(cloud.addr),
@@ -267,11 +267,12 @@ func TestEndToEndNamespaceRulesApplyToATranslatedReply(t *testing.T) {
 		"the namespace translator must still see the converted reply")
 }
 
-// cloudAPIAt points method translation at a fake control plane. Nil TLS dials it
-// in plaintext, which the real address never would.
+// cloudAPIAt points method translation at a fake control plane. The fake serves
+// plaintext, so it has to say so: a dialled target with no tls block verifies
+// against the system roots, which is what the real address wants.
 func cloudAPIAt(hostPort string) *config.APITranslations {
 	return &config.APITranslations{
-		CloudAPI: &config.CloudAPI{Listen: config.ListenConfig{HostPort: hostPort}},
+		CloudAPI: &config.CloudAPI{Listen: config.ListenConfig{HostPort: hostPort, Insecure: true}},
 	}
 }
 
@@ -293,7 +294,7 @@ func TestEndToEndTranslationCanBeDisabled(t *testing.T) {
 		Upstreams: config.UpstreamList{{
 			Name:   "frontend",
 			Cloud:  true,
-			Listen: config.ListenConfig{HostPort: dataplanetest.NewUpstream(t).Addr()},
+			Listen: dataplanetest.NewUpstream(t).Listen(),
 		}},
 		APITranslations: translations,
 	})

--- a/internal/cloud/endpoint.go
+++ b/internal/cloud/endpoint.go
@@ -8,6 +8,11 @@ import (
 // endpointSuffix is the domain Temporal Cloud serves its endpoints from.
 const endpointSuffix = ".tmprl.cloud"
 
+// APIHostPort is Temporal Cloud's control plane, which serves CloudService. It
+// answers the methods Cloud does not serve on a namespace frontend, and is the
+// same address the Cloud SDK dials by default.
+const APIHostPort = "saas-api" + endpointSuffix + ":443"
+
 // IsEndpoint reports whether hostPort addresses Temporal Cloud. The port is
 // optional, and a template action in place of the host is tolerated, since a
 // templated address is rendered per request but keeps its domain.

--- a/internal/config/cloudapi.go
+++ b/internal/config/cloudapi.go
@@ -1,0 +1,147 @@
+package config
+
+import (
+	"github.com/temporalio/temporal-proxy/internal/cloud"
+	"github.com/temporalio/temporal-proxy/pkg/validation"
+)
+
+// APITranslations governs rewriting a method an upstream does not serve into the
+// one that does. It is optional and usually absent: an upstream that
+// [Upstream.IsCloud] recognizes has the methods Temporal Cloud does not serve on
+// a frontend translated automatically, over a connection derived from it.
+//
+// Enabled turns that off. It defaults to on, so an absent block and an absent
+// enabled both translate; only "enabled: false" does not. Nothing else can
+// disable it, because whether an upstream needs translation is detected rather
+// than configured - this is the operator's override of that detection, for a
+// Cloud upstream whose untranslated failure is preferred to a translated answer.
+type APITranslations struct {
+	Enabled  *bool     `yaml:"enabled"`
+	CloudAPI *CloudAPI `yaml:"cloudApi"`
+}
+
+// CloudAPI overrides how the proxy reaches Temporal Cloud's control plane, which
+// answers the methods Cloud does not serve on a namespace frontend.
+//
+// The block is optional and usually absent. An upstream that [Upstream.IsCloud]
+// recognizes gets method translation on its own, over a connection to
+// [cloud.APIHostPort] carrying that upstream's credentials - the same API key
+// authorizes both, so there is nothing more to say.
+//
+// It is required in one case. The Cloud Ops API accepts an API key only; unlike a
+// namespace frontend it does not accept mTLS. An upstream authenticating with a
+// client certificate therefore has no credential to inherit, and must name an API
+// key here or its translated methods are refused. Beyond that, configure this
+// only to reach a different Cloud environment.
+//
+// See https://docs.temporal.io/ops.
+//
+// It is deliberately not an entry in Upstreams: an upstream is a server - a
+// socket, a proxy.Server, and a routing destination - and the control plane is
+// only ever a client connection. Declaring it there would give it three things
+// it cannot use and one it should not have: routability.
+type CloudAPI struct {
+	Listen      ListenConfig      `yaml:",inline"`
+	Credentials *CredentialConfig `yaml:"credentials"`
+}
+
+// Upstream renders the control plane as an [Upstream] for the Cloud upstream
+// src, so its connection is dialled by the same resolver, TLS, and credential
+// machinery as any other rather than by a second code path. A nil receiver is
+// the unconfigured case and yields the inherited defaults, so callers need not
+// branch on whether the block is present.
+//
+// Credentials are inherited from src because a Temporal Cloud API key authorizes
+// the control plane as well as the frontend. TLS is not: the control plane is a
+// different host, so src's server name or client certificate would not apply to
+// it, and a default outbound TLS configuration is used instead.
+//
+// When this block is present its own tls is authoritative, absent included, the
+// same way it is on an upstream - an absent tls dials in plaintext. That is only
+// reachable for a control plane with no credentials, since Validate rejects
+// credentials without TLS, so a key still cannot be sent in the clear.
+//
+// The name is derived from src rather than fixed, so two Cloud upstreams with
+// different credentials get distinct connections instead of sharing whichever
+// was dialled first.
+func (c *CloudAPI) Upstream(src *Upstream) *Upstream {
+	up := &Upstream{
+		Name:        src.Name + "/cloud-api",
+		Cloud:       true,
+		Listen:      ListenConfig{HostPort: cloud.APIHostPort, TLS: &TLSConfig{}},
+		Credentials: src.Credentials,
+	}
+
+	if c == nil {
+		return up
+	}
+
+	if c.Listen.HostPort != "" {
+		up.Listen.HostPort = c.Listen.HostPort
+	}
+
+	up.Listen.TLS = c.Listen.TLS
+
+	if c.Credentials != nil {
+		up.Credentials = c.Credentials
+	}
+
+	return up
+}
+
+// IsEndpoint reports whether the configured control plane addresses Temporal
+// Cloud. It is false only when an operator pointed the block somewhere else,
+// which is legitimate for a test double or a private environment, so callers
+// report it rather than reject it.
+func (c *CloudAPI) IsEndpoint() bool {
+	if c == nil || c.Listen.HostPort == "" {
+		return true
+	}
+
+	return cloud.IsEndpoint(c.Listen.HostPort)
+}
+
+// Validate checks the control plane as it will actually be dialled, by
+// validating the [Upstream] it renders to. That covers the same ground as any
+// upstream - dial target, outbound TLS, credentials, and credentials requiring
+// TLS - without restating the rules, and checks the effective configuration
+// (the defaulted address included) rather than only the fields an operator
+// supplied.
+//
+// An address that is not a Cloud endpoint is not rejected. Nothing but a Cloud
+// deployment serves CloudService, but a test double or a private environment
+// legitimately does not carry the Cloud domain, and the proxy has no way to tell
+// that apart from a typo. It is reported at startup instead, which mirrors how a
+// namespace Cloud would reject is handled for a templated upstream.
+func (c *CloudAPI) Validate() error {
+	return c.Upstream(&Upstream{Name: "cloudApi"}).Validate()
+}
+
+// IsEnabled reports whether method translation should be installed. An absent
+// block, or a block that does not mention enabled, translates; only an explicit
+// "enabled: false" does not. Default-on is deliberate - translation makes a
+// method work that cannot work otherwise, so an operator opts out of a fix
+// rather than into one.
+func (t *APITranslations) IsEnabled() bool {
+	return t == nil || t.Enabled == nil || *t.Enabled
+}
+
+// Cloud returns the Cloud API override, or nil when none is configured, so
+// callers need not branch on whether the enclosing block is present.
+func (t *APITranslations) Cloud() *CloudAPI {
+	if t == nil {
+		return nil
+	}
+
+	return t.CloudAPI
+}
+
+// Validate checks the Cloud API override when one is configured. Enabled needs no
+// checking: any value is meaningful, and its absence is the default.
+func (t *APITranslations) Validate() error {
+	if t.CloudAPI == nil {
+		return nil
+	}
+
+	return validation.Validate("", validation.Nested("cloudApi", t.CloudAPI))
+}

--- a/internal/config/cloudapi.go
+++ b/internal/config/cloudapi.go
@@ -5,19 +5,28 @@ import (
 	"github.com/temporalio/temporal-proxy/pkg/validation"
 )
 
-// APITranslations governs rewriting a method an upstream does not serve into the
-// one that does. It is optional and usually absent: an upstream that
-// [Upstream.IsCloud] recognizes has the methods Temporal Cloud does not serve on
-// a frontend translated automatically, over a connection derived from it.
+// APITranslations configures rewriting a method an upstream does not serve into
+// the one that does. It is optional and usually absent, and it carries no switch:
+// whether a method is translated is derived from the rest of the configuration
+// rather than declared.
 //
-// Enabled turns that off. It defaults to on, so an absent block and an absent
-// enabled both translate; only "enabled: false" does not. Nothing else can
-// disable it, because whether an upstream needs translation is detected rather
-// than configured - this is the operator's override of that detection, for a
-// Cloud upstream whose untranslated failure is preferred to a translated answer.
+// What derives it is [Routing.NamespacelessUpstream]. The methods Temporal Cloud
+// does not serve on a namespace endpoint are the ones carrying no namespace, so
+// they land on the upstream serving namespace-less requests, and that upstream
+// being Cloud is both necessary and sufficient for a translation to be reachable.
+// An operator who wants the untranslated failure back routes those requests at a
+// Temporal Service that serves them, which is the same statement made where it
+// belongs.
+//
+// This block exists for the two things detection cannot know: which Cloud
+// environment the control plane lives in, and the API key an mTLS upstream has
+// none of to inherit.
+//
+// The zero value is the block an operator did not write, which is what almost
+// every configuration has, and it answers for the default - so nothing here is a
+// pointer and no caller has to check before asking. The same holds for [CloudAPI].
 type APITranslations struct {
-	Enabled  *bool     `yaml:"enabled"`
-	CloudAPI *CloudAPI `yaml:"cloudApi"`
+	CloudAPI CloudAPI `yaml:"cloudApi"`
 }
 
 // CloudAPI overrides how the proxy reaches Temporal Cloud's control plane, which
@@ -66,16 +75,12 @@ type CloudAPI struct {
 // The name is derived from src rather than fixed, so two Cloud upstreams with
 // different credentials get distinct connections instead of sharing whichever
 // was dialled first.
-func (c *CloudAPI) Upstream(src *Upstream) *Upstream {
+func (c CloudAPI) Upstream(src *Upstream) *Upstream {
 	up := &Upstream{
 		Name:        src.Name + "/cloud-api",
 		Cloud:       true,
 		Listen:      ListenConfig{HostPort: cloud.APIHostPort},
 		Credentials: src.Credentials,
-	}
-
-	if c == nil {
-		return up
 	}
 
 	if c.Listen.HostPort != "" {
@@ -92,12 +97,12 @@ func (c *CloudAPI) Upstream(src *Upstream) *Upstream {
 	return up
 }
 
-// IsEndpoint reports whether the configured control plane addresses Temporal
-// Cloud. It is false only when an operator pointed the block somewhere else,
-// which is legitimate for a test double or a private environment, so callers
-// report it rather than reject it.
-func (c *CloudAPI) IsEndpoint() bool {
-	if c == nil || c.Listen.HostPort == "" {
+// IsSaasAPI reports whether the configured control plane addresses Temporal
+// Cloud's own API rather than somewhere else. It is false only when an operator
+// pointed the block elsewhere, which is legitimate for a test double or a
+// private environment, so callers report it rather than reject it.
+func (c CloudAPI) IsSaasAPI() bool {
+	if c.Listen.HostPort == "" {
 		return true
 	}
 
@@ -116,35 +121,19 @@ func (c *CloudAPI) IsEndpoint() bool {
 // legitimately does not carry the Cloud domain, and the proxy has no way to tell
 // that apart from a typo. It is reported at startup instead, which mirrors how a
 // namespace Cloud would reject is handled for a templated upstream.
-func (c *CloudAPI) Validate() error {
+func (c CloudAPI) Validate() error {
 	return c.Upstream(&Upstream{Name: "cloudApi"}).Validate()
 }
 
-// IsEnabled reports whether method translation should be installed. An absent
-// block, or a block that does not mention enabled, translates; only an explicit
-// "enabled: false" does not. Default-on is deliberate - translation makes a
-// method work that cannot work otherwise, so an operator opts out of a fix
-// rather than into one.
-func (t *APITranslations) IsEnabled() bool {
-	return t == nil || t.Enabled == nil || *t.Enabled
-}
-
-// Cloud returns the Cloud API override, or nil when none is configured, so
-// callers need not branch on whether the enclosing block is present.
-func (t *APITranslations) Cloud() *CloudAPI {
-	if t == nil {
-		return nil
-	}
-
-	return t.CloudAPI
-}
-
-// Validate checks the Cloud API override when one is configured. Enabled needs no
-// checking: any value is meaningful, and its absence is the default.
-func (t *APITranslations) Validate() error {
-	if t.CloudAPI == nil {
-		return nil
-	}
-
+// Validate checks the Cloud API override as it will be dialled. An override
+// nobody wrote is the zero one, which describes the defaults and passes.
+func (t APITranslations) Validate() error {
 	return validation.Validate("", validation.Nested("cloudApi", t.CloudAPI))
+}
+
+// IsZero reports whether the override says nothing at all, which is what an
+// absent block leaves behind. Callers use it to tell a configuration that asked
+// for something from one that never mentioned it.
+func (c CloudAPI) IsZero() bool {
+	return c == CloudAPI{}
 }

--- a/internal/config/cloudapi.go
+++ b/internal/config/cloudapi.go
@@ -54,12 +54,14 @@ type CloudAPI struct {
 // Credentials are inherited from src because a Temporal Cloud API key authorizes
 // the control plane as well as the frontend. TLS is not: the control plane is a
 // different host, so src's server name or client certificate would not apply to
-// it, and a default outbound TLS configuration is used instead.
+// it, and the dial default stands instead - verification against the system root
+// pool, which is what the real control plane presents.
 //
-// When this block is present its own tls is authoritative, absent included, the
-// same way it is on an upstream - an absent tls dials in plaintext. That is only
-// reachable for a control plane with no credentials, since Validate rejects
-// credentials without TLS, so a key still cannot be sent in the clear.
+// When this block is present its tls and insecure are authoritative, the same way
+// they are on an upstream: an absent tls still verifies against the system roots,
+// and plaintext has to be asked for. That is only reachable for a control plane
+// with no credentials, since Validate rejects credentials on an insecure hop, so
+// a key still cannot be sent in the clear.
 //
 // The name is derived from src rather than fixed, so two Cloud upstreams with
 // different credentials get distinct connections instead of sharing whichever
@@ -68,7 +70,7 @@ func (c *CloudAPI) Upstream(src *Upstream) *Upstream {
 	up := &Upstream{
 		Name:        src.Name + "/cloud-api",
 		Cloud:       true,
-		Listen:      ListenConfig{HostPort: cloud.APIHostPort, TLS: &TLSConfig{}},
+		Listen:      ListenConfig{HostPort: cloud.APIHostPort},
 		Credentials: src.Credentials,
 	}
 
@@ -81,6 +83,7 @@ func (c *CloudAPI) Upstream(src *Upstream) *Upstream {
 	}
 
 	up.Listen.TLS = c.Listen.TLS
+	up.Listen.Insecure = c.Listen.Insecure
 
 	if c.Credentials != nil {
 		up.Credentials = c.Credentials

--- a/internal/config/cloudapi_test.go
+++ b/internal/config/cloudapi_test.go
@@ -1,0 +1,168 @@
+package config_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/temporalio/temporal-proxy/internal/cloud"
+	"github.com/temporalio/temporal-proxy/internal/config"
+)
+
+// TestCloudAPIUpstreamsAreDistinctPerSource pins the property the pooled
+// connection depends on. Every Cloud upstream's control plane resolves to the
+// same address, and a pooled connection is keyed by this name; if two upstreams
+// produced the same one they would share a connection, and the second would
+// silently send the first's credentials.
+func TestCloudAPIUpstreamsAreDistinctPerSource(t *testing.T) {
+	t.Parallel()
+
+	a := (&config.CloudAPI{}).Upstream(&config.Upstream{Name: "alpha"})
+	b := (&config.CloudAPI{}).Upstream(&config.Upstream{Name: "beta"})
+
+	require.Equal(t, a.Listen.HostPort, b.Listen.HostPort, "both reach the same control plane")
+	require.NotEqual(t, a.Name, b.Name, "but must not share a pooled connection")
+}
+
+// TestCloudAPIUpstreamDefaults covers the unconfigured case, which is the one
+// almost every deployment takes.
+func TestCloudAPIUpstreamDefaults(t *testing.T) {
+	t.Parallel()
+
+	var unset *config.CloudAPI
+	src := &config.Upstream{Name: "frontend"}
+
+	api := unset.Upstream(src)
+	require.Equal(t, cloud.APIHostPort, api.Listen.HostPort)
+	require.NotNil(t, api.Listen.TLS, "the real control plane is always TLS")
+	require.True(t, api.IsCloud())
+}
+
+func TestLoad_CloudUpstreamNeedsNoTranslationConfig(t *testing.T) {
+	t.Parallel()
+
+	// No routing rule and no cloudApi block. A .tmprl.cloud address is recognized
+	// as Cloud on its own, which is all translation needs.
+	const yaml = `
+hostPort: 127.0.0.1:7233
+routing:
+  default: frontend
+  system: frontend
+upstreams:
+  - name: frontend
+    hostPort: ns.acct.tmprl.cloud:7233
+    tls: {}
+    credentials:
+      static:
+        apiKey: sekrit
+`
+
+	cfg, err := config.Load(strings.NewReader(yaml))
+	require.NoError(t, err)
+	require.NoError(t, cfg.Validate())
+
+	require.Empty(t, cfg.Routing.Rules, "translation needs no routing rule")
+	require.Nil(t, cfg.APITranslations, "and no cloudApi block")
+	require.True(t, cfg.Upstreams[0].IsCloud())
+
+	// The control plane is derived from the upstream: its own address, and the
+	// upstream's credentials, since one API key authorizes both.
+	api := cfg.APITranslations.Cloud().Upstream(&cfg.Upstreams[0])
+	require.Equal(t, cloud.APIHostPort, api.Listen.HostPort)
+	require.Equal(t, cfg.Upstreams[0].Credentials, api.Credentials)
+	require.NotEqual(t, cfg.Upstreams[0].Name, api.Name, "distinct name keeps the pooled connections apart")
+}
+
+func TestLoad_CloudAPIOverridesTheDerivedControlPlane(t *testing.T) {
+	t.Parallel()
+
+	const yaml = `
+hostPort: 127.0.0.1:7233
+routing:
+  default: frontend
+upstreams:
+  - name: frontend
+    hostPort: ns.acct.tmprl.cloud:7233
+    tls: {}
+    credentials:
+      static:
+        apiKey: upstream-key
+apiTranslations:
+  cloudApi:
+    hostPort: saas-api.staging.tmprl.cloud:443
+    tls: {}
+    credentials:
+      static:
+        apiKey: control-plane-key
+`
+
+	cfg, err := config.Load(strings.NewReader(yaml))
+	require.NoError(t, err)
+	require.NoError(t, cfg.Validate())
+
+	api := cfg.APITranslations.Cloud().Upstream(&cfg.Upstreams[0])
+	require.Equal(t, "saas-api.staging.tmprl.cloud:443", api.Listen.HostPort)
+	require.NotEqual(t, cfg.Upstreams[0].Credentials, api.Credentials, "the override wins over inheritance")
+	require.True(t, cfg.APITranslations.Cloud().IsEndpoint())
+}
+
+func TestLoad_CloudAPIRejectsCredentialsWithoutTLS(t *testing.T) {
+	t.Parallel()
+
+	const yaml = `
+hostPort: 127.0.0.1:7233
+routing:
+  default: frontend
+upstreams:
+  - name: frontend
+    hostPort: ns.acct.tmprl.cloud:7233
+apiTranslations:
+  cloudApi:
+    credentials:
+      static:
+        apiKey: sekrit
+`
+
+	cfg, err := config.Load(strings.NewReader(yaml))
+	require.NoError(t, err)
+	require.ErrorContains(t, cfg.Validate(), "requires TLS")
+}
+
+func TestAPITranslationsIsEnabled(t *testing.T) {
+	t.Parallel()
+
+	// Default-on: translation makes a method work that cannot work otherwise, so
+	// an operator opts out of a fix rather than into one.
+	var absent *config.APITranslations
+	require.True(t, absent.IsEnabled(), "an absent block translates")
+	require.True(t, (&config.APITranslations{}).IsEnabled(), "so does one that says nothing about it")
+
+	on, off := true, false
+	require.True(t, (&config.APITranslations{Enabled: &on}).IsEnabled())
+	require.False(t, (&config.APITranslations{Enabled: &off}).IsEnabled(), "only an explicit false opts out")
+}
+
+func TestLoad_APITranslationsCanBeDisabled(t *testing.T) {
+	t.Parallel()
+
+	// A Cloud upstream that would otherwise be translated, opting out.
+	const yaml = `
+hostPort: 127.0.0.1:7233
+routing:
+  default: frontend
+upstreams:
+  - name: frontend
+    hostPort: ns.acct.tmprl.cloud:7233
+    tls: {}
+apiTranslations:
+  enabled: false
+`
+
+	cfg, err := config.Load(strings.NewReader(yaml))
+	require.NoError(t, err)
+	require.NoError(t, cfg.Validate())
+
+	require.True(t, cfg.Upstreams[0].IsCloud(), "still detected as Cloud")
+	require.False(t, cfg.APITranslations.IsEnabled(), "but opted out of translation")
+}

--- a/internal/config/cloudapi_test.go
+++ b/internal/config/cloudapi_test.go
@@ -18,8 +18,8 @@ import (
 func TestCloudAPIUpstreamsAreDistinctPerSource(t *testing.T) {
 	t.Parallel()
 
-	a := (&config.CloudAPI{}).Upstream(&config.Upstream{Name: "alpha"})
-	b := (&config.CloudAPI{}).Upstream(&config.Upstream{Name: "beta"})
+	a := config.CloudAPI{}.Upstream(&config.Upstream{Name: "alpha"})
+	b := config.CloudAPI{}.Upstream(&config.Upstream{Name: "beta"})
 
 	require.Equal(t, a.Listen.HostPort, b.Listen.HostPort, "both reach the same control plane")
 	require.NotEqual(t, a.Name, b.Name, "but must not share a pooled connection")
@@ -30,13 +30,28 @@ func TestCloudAPIUpstreamsAreDistinctPerSource(t *testing.T) {
 func TestCloudAPIUpstreamDefaults(t *testing.T) {
 	t.Parallel()
 
-	var unset *config.CloudAPI
+	var unset config.CloudAPI
 	src := &config.Upstream{Name: "frontend"}
 
 	api := unset.Upstream(src)
 	require.Equal(t, cloud.APIHostPort, api.Listen.HostPort)
 	require.False(t, api.Listen.Insecure, "the real control plane is always TLS")
 	require.True(t, api.IsCloud())
+}
+
+// TestAPITranslationsZeroValueIsTheUnconfiguredCase pins what the block an
+// operator did not write answers. Every deployment that says nothing about
+// apiTranslations reaches these on the zero value, so it has to describe the
+// defaults rather than need a check in front of it.
+func TestAPITranslationsZeroValueIsTheUnconfiguredCase(t *testing.T) {
+	t.Parallel()
+
+	var absent config.APITranslations
+
+	require.True(t, absent.CloudAPI.IsZero(), "an absent block configures no control plane of its own")
+	require.NoError(t, absent.Validate())
+	require.True(t, absent.CloudAPI.IsSaasAPI(), "and the derived control plane is Cloud's own")
+	require.Equal(t, cloud.APIHostPort, absent.CloudAPI.Upstream(&config.Upstream{Name: "frontend"}).Listen.HostPort)
 }
 
 func TestLoad_CloudUpstreamNeedsNoTranslationConfig(t *testing.T) {
@@ -62,12 +77,12 @@ upstreams:
 	require.NoError(t, cfg.Validate())
 
 	require.Empty(t, cfg.Routing.Rules, "translation needs no routing rule")
-	require.Nil(t, cfg.APITranslations, "and no cloudApi block")
+	require.True(t, cfg.APITranslations.CloudAPI.IsZero(), "and no cloudApi block")
 	require.True(t, cfg.Upstreams[0].IsCloud())
 
 	// The control plane is derived from the upstream: its own address, and the
 	// upstream's credentials, since one API key authorizes both.
-	api := cfg.APITranslations.Cloud().Upstream(&cfg.Upstreams[0])
+	api := cfg.APITranslations.CloudAPI.Upstream(&cfg.Upstreams[0])
 	require.Equal(t, cloud.APIHostPort, api.Listen.HostPort)
 	require.Equal(t, cfg.Upstreams[0].Credentials, api.Credentials)
 	require.NotEqual(t, cfg.Upstreams[0].Name, api.Name, "distinct name keeps the pooled connections apart")
@@ -98,10 +113,10 @@ apiTranslations:
 	require.NoError(t, err)
 	require.NoError(t, cfg.Validate())
 
-	api := cfg.APITranslations.Cloud().Upstream(&cfg.Upstreams[0])
+	api := cfg.APITranslations.CloudAPI.Upstream(&cfg.Upstreams[0])
 	require.Equal(t, "saas-api.staging.tmprl.cloud:443", api.Listen.HostPort)
 	require.NotEqual(t, cfg.Upstreams[0].Credentials, api.Credentials, "the override wins over inheritance")
-	require.True(t, cfg.APITranslations.Cloud().IsEndpoint())
+	require.True(t, cfg.APITranslations.CloudAPI.IsSaasAPI())
 }
 
 func TestLoad_CloudAPIRejectsCredentialsOnAnInsecureHop(t *testing.T) {
@@ -127,41 +142,4 @@ apiTranslations:
 	cfg, err := config.Load(strings.NewReader(yaml))
 	require.NoError(t, err)
 	require.ErrorContains(t, cfg.Validate(), "requires TLS")
-}
-
-func TestAPITranslationsIsEnabled(t *testing.T) {
-	t.Parallel()
-
-	// Default-on: translation makes a method work that cannot work otherwise, so
-	// an operator opts out of a fix rather than into one.
-	var absent *config.APITranslations
-	require.True(t, absent.IsEnabled(), "an absent block translates")
-	require.True(t, (&config.APITranslations{}).IsEnabled(), "so does one that says nothing about it")
-
-	on, off := true, false
-	require.True(t, (&config.APITranslations{Enabled: &on}).IsEnabled())
-	require.False(t, (&config.APITranslations{Enabled: &off}).IsEnabled(), "only an explicit false opts out")
-}
-
-func TestLoad_APITranslationsCanBeDisabled(t *testing.T) {
-	t.Parallel()
-
-	// A Cloud upstream that would otherwise be translated, opting out.
-	const yaml = `
-hostPort: 127.0.0.1:7233
-routing:
-  default: frontend
-upstreams:
-  - name: frontend
-    hostPort: ns.acct.tmprl.cloud:7233
-apiTranslations:
-  enabled: false
-`
-
-	cfg, err := config.Load(strings.NewReader(yaml))
-	require.NoError(t, err)
-	require.NoError(t, cfg.Validate())
-
-	require.True(t, cfg.Upstreams[0].IsCloud(), "still detected as Cloud")
-	require.False(t, cfg.APITranslations.IsEnabled(), "but opted out of translation")
 }

--- a/internal/config/cloudapi_test.go
+++ b/internal/config/cloudapi_test.go
@@ -35,7 +35,7 @@ func TestCloudAPIUpstreamDefaults(t *testing.T) {
 
 	api := unset.Upstream(src)
 	require.Equal(t, cloud.APIHostPort, api.Listen.HostPort)
-	require.NotNil(t, api.Listen.TLS, "the real control plane is always TLS")
+	require.False(t, api.Listen.Insecure, "the real control plane is always TLS")
 	require.True(t, api.IsCloud())
 }
 
@@ -52,7 +52,6 @@ routing:
 upstreams:
   - name: frontend
     hostPort: ns.acct.tmprl.cloud:7233
-    tls: {}
     credentials:
       static:
         apiKey: sekrit
@@ -84,14 +83,12 @@ routing:
 upstreams:
   - name: frontend
     hostPort: ns.acct.tmprl.cloud:7233
-    tls: {}
     credentials:
       static:
         apiKey: upstream-key
 apiTranslations:
   cloudApi:
     hostPort: saas-api.staging.tmprl.cloud:443
-    tls: {}
     credentials:
       static:
         apiKey: control-plane-key
@@ -107,9 +104,11 @@ apiTranslations:
 	require.True(t, cfg.APITranslations.Cloud().IsEndpoint())
 }
 
-func TestLoad_CloudAPIRejectsCredentialsWithoutTLS(t *testing.T) {
+func TestLoad_CloudAPIRejectsCredentialsOnAnInsecureHop(t *testing.T) {
 	t.Parallel()
 
+	// An absent tls block is TLS, so plaintext is what has to be asked for - and
+	// asking for it with a key configured is what the rule refuses.
 	const yaml = `
 hostPort: 127.0.0.1:7233
 routing:
@@ -119,6 +118,7 @@ upstreams:
     hostPort: ns.acct.tmprl.cloud:7233
 apiTranslations:
   cloudApi:
+    insecure: true
     credentials:
       static:
         apiKey: sekrit
@@ -154,7 +154,6 @@ routing:
 upstreams:
   - name: frontend
     hostPort: ns.acct.tmprl.cloud:7233
-    tls: {}
 apiTranslations:
   enabled: false
 `

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,7 @@ type (
 	// Config is the top-level proxy configuration.
 	Config struct {
 		Listen           ListenConfig        `yaml:",inline"`
+		APITranslations  *APITranslations    `yaml:"apiTranslations"`
 		AllowedServices  Services            `yaml:"allowedServices"`
 		Auth             *AuthConfig         `yaml:"auth"`
 		Encryption       Encryption          `yaml:"encryption"`
@@ -97,6 +98,10 @@ func (c *Config) Validate() error {
 		validation.Nested("metrics", &c.Metrics),
 		validation.Nested("routing", &c.Routing),
 		validation.WhenRules(func() bool { return c.Auth != nil }, validation.Nested("auth", c.Auth)),
+		validation.WhenRules(
+			func() bool { return c.APITranslations != nil },
+			validation.Nested("apiTranslations", c.APITranslations),
+		),
 		validation.Nested("upstreams", &c.Upstreams),
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,7 +17,7 @@ type (
 	// Config is the top-level proxy configuration.
 	Config struct {
 		Listen           ListenConfig        `yaml:",inline"`
-		APITranslations  *APITranslations    `yaml:"apiTranslations"`
+		APITranslations  APITranslations     `yaml:"apiTranslations"`
 		AllowedServices  Services            `yaml:"allowedServices"`
 		Auth             *AuthConfig         `yaml:"auth"`
 		Encryption       Encryption          `yaml:"encryption"`
@@ -98,10 +98,7 @@ func (c *Config) Validate() error {
 		validation.Nested("metrics", &c.Metrics),
 		validation.Nested("routing", &c.Routing),
 		validation.WhenRules(func() bool { return c.Auth != nil }, validation.Nested("auth", c.Auth)),
-		validation.WhenRules(
-			func() bool { return c.APITranslations != nil },
-			validation.Nested("apiTranslations", c.APITranslations),
-		),
+		validation.Nested("apiTranslations", &c.APITranslations),
 		validation.Nested("upstreams", &c.Upstreams),
 	}
 

--- a/internal/config/routing.go
+++ b/internal/config/routing.go
@@ -32,6 +32,25 @@ type (
 	}
 )
 
+// NamespacelessUpstream returns the upstream a request carrying no namespace
+// lands on when no rule claims it: the system upstream when one is named, and
+// the default upstream otherwise. It mirrors what [router.Mux] does with such a
+// request, so a caller deciding what to install for that destination and the
+// router deciding where to send it cannot disagree.
+//
+// A rule can claim a namespace-less request too - an empty rule namespace
+// matches every namespace, the empty one included - so this names the
+// destination such a request falls through to rather than the only one it can
+// reach. It is empty when neither is configured, which Config.Validate treats as
+// an unroutable namespace-less request rather than an error.
+func (r *Routing) NamespacelessUpstream() string {
+	if r.SystemUpstream != "" {
+		return r.SystemUpstream
+	}
+
+	return r.DefaultUpstream
+}
+
 // Validate checks every rule. Per-rule failures are stamped with a "rules[i]"
 // subject. It does not verify that the referenced upstreams exist; that check
 // needs the full set of upstream names and lives in Config.Validate.

--- a/internal/config/routing_test.go
+++ b/internal/config/routing_test.go
@@ -68,6 +68,50 @@ func TestRouting_Validate(t *testing.T) {
 	}
 }
 
+// TestRoutingNamespacelessUpstream pins where a request carrying no namespace
+// falls through to, which is what decides whether the methods Temporal Cloud
+// cannot serve get translated. The system upstream is optional, so the default
+// has to answer for it when it is unset - a config naming only a default is the
+// ordinary single-upstream one.
+func TestRoutingNamespacelessUpstream(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		routing config.Routing
+		want    string
+	}{
+		{
+			name:    "the system upstream serves them when one is named",
+			routing: config.Routing{DefaultUpstream: "default", SystemUpstream: "system"},
+			want:    "system",
+		},
+		{
+			name:    "the default serves them when no system upstream is named",
+			routing: config.Routing{DefaultUpstream: "default"},
+			want:    "default",
+		},
+		{
+			name:    "naming only a system upstream still serves them there",
+			routing: config.Routing{SystemUpstream: "system"},
+			want:    "system",
+		},
+		{
+			name:    "neither leaves them unroutable",
+			routing: config.Routing{},
+			want:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tt.want, tt.routing.NamespacelessUpstream())
+		})
+	}
+}
+
 func TestRoutingRule_Validate(t *testing.T) {
 	t.Parallel()
 

--- a/internal/dataplane/dataplane.go
+++ b/internal/dataplane/dataplane.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"slices"
+	"strings"
 	"sync"
 
 	"google.golang.org/grpc"
@@ -13,6 +15,7 @@ import (
 
 	"github.com/temporalio/temporal-proxy/internal/auth"
 	"github.com/temporalio/temporal-proxy/internal/auth/outbound"
+	"github.com/temporalio/temporal-proxy/internal/cloud/translation"
 	"github.com/temporalio/temporal-proxy/internal/config"
 	"github.com/temporalio/temporal-proxy/internal/metrics"
 	"github.com/temporalio/temporal-proxy/internal/protoutil"
@@ -62,6 +65,17 @@ type (
 		abort      func(error)
 	}
 
+	// keyedResolver overrides a resolver's pool cache key. A static resolver keys
+	// by dial target, which is unique among upstreams but not among control-plane
+	// connections: every Cloud upstream dials the same address, so without this
+	// they would share whichever was created first, and with it whichever
+	// credentials that one carried.
+	keyedResolver struct {
+		connect.Resolver
+
+		key string
+	}
+
 	// upstreamTier is one upstream's proxy and the socket it binds.
 	upstreamTier struct {
 		name string
@@ -108,6 +122,15 @@ func New(ctx context.Context, cfg *config.Config, opts ...Option) (*Dataplane, e
 	mux, err := router.CompileMux(cfg.Routing)
 	if err != nil {
 		return nil, err
+	}
+
+	// A translation block with no Cloud upstream changes nothing and would leave
+	// an operator waiting for behaviour that cannot arrive, so say so rather than
+	// ignoring it silently. Disabling translation is exempt: turning off something
+	// that was never on is a coherent thing to write.
+	if cfg.APITranslations != nil && cfg.APITranslations.IsEnabled() &&
+		!slices.ContainsFunc(cfg.Upstreams, func(up config.Upstream) bool { return up.IsCloud() }) {
+		o.logger.Warn("apiTranslations is configured but no upstream is Temporal Cloud, so no method will be translated")
 	}
 
 	dp := &Dataplane{
@@ -357,6 +380,23 @@ func newUpstreamTier(
 
 	dialOpts = append(dialOpts, grpc.WithChainUnaryInterceptor(cdc))
 
+	// Cloud does not serve every WorkflowService method on a frontend, so the ones
+	// it answers elsewhere are translated and sent to its control plane instead.
+	// This follows the upstream's own Cloud detection: an upstream that is Cloud
+	// needs this, and one that is not would be broken by it.
+	//
+	// It goes on last so it is the innermost interceptor: the namespace translator
+	// and the payload codec above it then see the method and message types the
+	// caller asked for, and only the hop onto the wire carries the substitute.
+	if up.IsCloud() && cfg.APITranslations.IsEnabled() {
+		reg, conn, err := cloudAPIConn(cfg, o, up)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		dialOpts = append(dialOpts, translation.DialOptions(reg, translation.Via(conn))...)
+	}
+
 	res, err := proxy.ResolverFor(up, dialOpts, o.logger)
 	if err != nil {
 		return nil, nil, err
@@ -390,4 +430,60 @@ func newUpstreamTier(
 	}
 
 	return &upstreamTier{name: up.Name, path: path, svr: svr}, ready, nil
+}
+
+// Resolve returns the overriding cache key with the wrapped resolver's target and
+// options.
+func (r keyedResolver) Resolve(ctx context.Context) (string, string, []grpc.DialOption, error) {
+	_, target, opts, err := r.Resolver.Resolve(ctx)
+	return r.key, target, opts, err
+}
+
+// cloudAPIConn builds the connection translated methods for up are answered
+// over, along with the translations that use it. The connection is dialled by
+// the same resolver and credential machinery as an upstream but is not
+// registered with the router: nothing routes to it, and it is reached only by a
+// translation.
+//
+// It is not opened eagerly. Translation is incidental to an upstream's normal
+// traffic, so a control plane that is unreachable must not stop the proxy
+// serving everything else.
+func cloudAPIConn(cfg *config.Config, o *options, up *config.Upstream) (*translation.Registry, *connect.Conn, error) {
+	reg, err := translation.Default()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to build method translations: %w", err)
+	}
+
+	api := cfg.APITranslations.Cloud().Upstream(up)
+
+	var dialOpts []grpc.DialOption
+	cp, err := outbound.CredentialProviderFor(api.Credentials)
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid credentials for the Cloud API of upstream %q: %w", up.Name, err)
+	}
+	if cp != nil {
+		dialOpts = append(dialOpts, outbound.DialOptions(cp)...)
+	}
+
+	res, err := proxy.ResolverFor(api, dialOpts, o.logger)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to resolve the Cloud API of upstream %q: %w", up.Name, err)
+	}
+
+	conn, err := connect.NewConn(o.pool.ConnOrCreate, keyedResolver{Resolver: res, key: api.Name})
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create the Cloud API client of upstream %q: %w", up.Name, err)
+	}
+
+	log := o.logger.With(tag.String("upstream", up.Name), tag.String("hostPort", api.Listen.HostPort))
+	if !cfg.APITranslations.Cloud().IsEndpoint() {
+		// Nothing but a Cloud deployment serves CloudService, but a test double or
+		// a private environment legitimately carries no Cloud domain, so this is
+		// reported rather than rejected.
+		log.Warn("the configured Cloud API is not a Temporal Cloud endpoint")
+	}
+
+	log.Info("translating methods to the Cloud API", tag.String("methods", strings.Join(reg.Methods(), ", ")))
+
+	return reg, conn, nil
 }

--- a/internal/dataplane/dataplane.go
+++ b/internal/dataplane/dataplane.go
@@ -124,13 +124,14 @@ func New(ctx context.Context, cfg *config.Config, opts ...Option) (*Dataplane, e
 		return nil, err
 	}
 
-	// A translation block with no Cloud upstream changes nothing and would leave
-	// an operator waiting for behaviour that cannot arrive, so say so rather than
-	// ignoring it silently. Disabling translation is exempt: turning off something
-	// that was never on is a coherent thing to write.
-	if cfg.APITranslations != nil && cfg.APITranslations.IsEnabled() &&
-		!slices.ContainsFunc(cfg.Upstreams, func(up config.Upstream) bool { return up.IsCloud() }) {
-		o.logger.Warn("apiTranslations is configured but no upstream is Temporal Cloud, so no method will be translated")
+	// A translation block nothing will consult changes nothing and would leave an
+	// operator waiting for behaviour that cannot arrive, so say so rather than
+	// ignoring it silently.
+	if !cfg.APITranslations.CloudAPI.IsZero() && !translates(cfg) {
+		o.logger.Warn(
+			"apiTranslations is configured but namespace-less requests are not served by a Temporal Cloud upstream, " +
+				"so no method will be translated",
+		)
 	}
 
 	dp := &Dataplane{
@@ -382,13 +383,17 @@ func newUpstreamTier(
 
 	// Cloud does not serve every WorkflowService method on a frontend, so the ones
 	// it answers elsewhere are translated and sent to its control plane instead.
-	// This follows the upstream's own Cloud detection: an upstream that is Cloud
-	// needs this, and one that is not would be broken by it.
+	// Nothing configures that: the methods in question carry no namespace, so they
+	// land on the upstream namespace-less requests are routed to, and that upstream
+	// being Cloud is what makes them translatable. Installing this on any other
+	// upstream would build a control plane connection no request can reach, and on
+	// a Temporal Service that serves those methods itself it would divert a call
+	// that was already going to work.
 	//
 	// It goes on last so it is the innermost interceptor: the namespace translator
 	// and the payload codec above it then see the method and message types the
 	// caller asked for, and only the hop onto the wire carries the substitute.
-	if up.IsCloud() && cfg.APITranslations.IsEnabled() {
+	if up.IsCloud() && cfg.Routing.NamespacelessUpstream() == up.Name {
 		reg, conn, err := cloudAPIConn(cfg, o, up)
 		if err != nil {
 			return nil, nil, err
@@ -439,6 +444,18 @@ func (r keyedResolver) Resolve(ctx context.Context) (string, string, []grpc.Dial
 	return r.key, target, opts, err
 }
 
+// translates reports whether any upstream will have method translation
+// installed, which is the upstream serving namespace-less requests being
+// Temporal Cloud. It is the same question perUpstream asks of one upstream, so a
+// configuration this answers false for installs nothing anywhere.
+func translates(cfg *config.Config) bool {
+	name := cfg.Routing.NamespacelessUpstream()
+
+	return slices.ContainsFunc(cfg.Upstreams, func(up config.Upstream) bool {
+		return up.Name == name && up.IsCloud()
+	})
+}
+
 // cloudAPIConn builds the connection translated methods for up are answered
 // over, along with the translations that use it. The connection is dialled by
 // the same resolver and credential machinery as an upstream but is not
@@ -454,7 +471,7 @@ func cloudAPIConn(cfg *config.Config, o *options, up *config.Upstream) (*transla
 		return nil, nil, fmt.Errorf("failed to build method translations: %w", err)
 	}
 
-	api := cfg.APITranslations.Cloud().Upstream(up)
+	api := cfg.APITranslations.CloudAPI.Upstream(up)
 
 	var dialOpts []grpc.DialOption
 	cp, err := outbound.CredentialProviderFor(api.Credentials)
@@ -476,7 +493,7 @@ func cloudAPIConn(cfg *config.Config, o *options, up *config.Upstream) (*transla
 	}
 
 	log := o.logger.With(tag.String("upstream", up.Name), tag.String("hostPort", api.Listen.HostPort))
-	if !cfg.APITranslations.Cloud().IsEndpoint() {
+	if !cfg.APITranslations.CloudAPI.IsSaasAPI() {
 		// Nothing but a Cloud deployment serves CloudService, but a test double or
 		// a private environment legitimately carries no Cloud domain, so this is
 		// reported rather than rejected.

--- a/internal/dataplane/dataplane_test.go
+++ b/internal/dataplane/dataplane_test.go
@@ -242,3 +242,48 @@ func testingKeyURL(t *testing.T) url.URL {
 
 	return *u
 }
+
+// cloudAPIUnusedWarning is the message New logs for a Cloud API override no
+// upstream can use. TestLogger matches an entry's message in full, so it is
+// spelled once here rather than approximated at each assertion.
+const cloudAPIUnusedWarning = "apiTranslations is configured but no upstream is Temporal Cloud, so no method will be translated"
+
+// TestNewWarnsWhenCloudAPIHasNoCloudUpstream covers a block that changes nothing.
+// The Cloud API is reached only by a translation, and only a Cloud upstream
+// installs one, so configuring the override without such an upstream leaves an
+// operator waiting for behaviour that cannot arrive.
+func TestNewWarnsWhenCloudAPIHasNoCloudUpstream(t *testing.T) {
+	t.Parallel()
+
+	cfg := testConfig()
+	cfg.APITranslations = &config.APITranslations{}
+
+	log := logger.NewTestLogger()
+	deps := newTestDeps(t, cfg)
+	deps.logger = log
+
+	_, err := dataplane.New(deps.ctx, cfg, deps.opts()...)
+	require.NoError(t, err)
+
+	require.True(t, log.Contains(cloudAPIUnusedWarning),
+		"a block that changes nothing must not pass unremarked")
+}
+
+// TestNewIsQuietWhenCloudAPIHasACloudUpstream is the control: the same block with
+// an upstream that can use it must not warn.
+func TestNewIsQuietWhenCloudAPIHasACloudUpstream(t *testing.T) {
+	t.Parallel()
+
+	cfg := testConfig()
+	cfg.APITranslations = &config.APITranslations{}
+	cfg.Upstreams[0].Cloud = true
+
+	log := logger.NewTestLogger()
+	deps := newTestDeps(t, cfg)
+	deps.logger = log
+
+	_, err := dataplane.New(deps.ctx, cfg, deps.opts()...)
+	require.NoError(t, err)
+
+	require.False(t, log.Contains(cloudAPIUnusedWarning))
+}

--- a/internal/dataplane/dataplane_test.go
+++ b/internal/dataplane/dataplane_test.go
@@ -11,13 +11,16 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/reflect/protoregistry"
 
 	"github.com/temporalio/temporal-proxy/internal/auth"
+	"github.com/temporalio/temporal-proxy/internal/cloud/translation"
 	"github.com/temporalio/temporal-proxy/internal/config"
 	"github.com/temporalio/temporal-proxy/internal/dataplane"
 	"github.com/temporalio/temporal-proxy/internal/metrics"
 	"github.com/temporalio/temporal-proxy/internal/protoutil"
+	"github.com/temporalio/temporal-proxy/internal/rpc"
 	"github.com/temporalio/temporal-proxy/internal/services"
 	"github.com/temporalio/temporal-proxy/internal/transport/connect"
 	"github.com/temporalio/temporal-proxy/pkg/crypto"
@@ -246,17 +249,30 @@ func testingKeyURL(t *testing.T) url.URL {
 // cloudAPIUnusedWarning is the message New logs for a Cloud API override no
 // upstream can use. TestLogger matches an entry's message in full, so it is
 // spelled once here rather than approximated at each assertion.
-const cloudAPIUnusedWarning = "apiTranslations is configured but no upstream is Temporal Cloud, so no method will be translated"
+const cloudAPIUnusedWarning = "apiTranslations is configured but namespace-less requests are not served by " +
+	"a Temporal Cloud upstream, so no method will be translated"
+
+// stagingCloudAPI is an override that says something, which is what an inert
+// block has to be to be worth warning about: one that says nothing is
+// indistinguishable from no block at all, and describes the defaults anyway.
+func stagingCloudAPI() config.APITranslations {
+	return config.APITranslations{
+		CloudAPI: config.CloudAPI{
+			Listen: config.ListenConfig{HostPort: "saas-api.staging.tmprl.cloud:443"},
+		},
+	}
+}
 
 // TestNewWarnsWhenCloudAPIHasNoCloudUpstream covers a block that changes nothing.
-// The Cloud API is reached only by a translation, and only a Cloud upstream
-// installs one, so configuring the override without such an upstream leaves an
-// operator waiting for behaviour that cannot arrive.
+// The Cloud API is reached only by a translation, and only the Cloud upstream
+// serving namespace-less requests installs one, so configuring the override
+// without such an upstream leaves an operator waiting for behaviour that cannot
+// arrive.
 func TestNewWarnsWhenCloudAPIHasNoCloudUpstream(t *testing.T) {
 	t.Parallel()
 
 	cfg := testConfig()
-	cfg.APITranslations = &config.APITranslations{}
+	cfg.APITranslations = stagingCloudAPI()
 
 	log := logger.NewTestLogger()
 	deps := newTestDeps(t, cfg)
@@ -269,13 +285,63 @@ func TestNewWarnsWhenCloudAPIHasNoCloudUpstream(t *testing.T) {
 		"a block that changes nothing must not pass unremarked")
 }
 
+// TestNewIsQuietWhenTheOverrideSaysNothing is the other side of the trigger. An
+// apiTranslations block with nothing in it describes the defaults, so there is
+// no override going unused and nothing to report.
+func TestNewIsQuietWhenTheOverrideSaysNothing(t *testing.T) {
+	t.Parallel()
+
+	cfg := testConfig()
+	cfg.APITranslations = config.APITranslations{}
+
+	log := logger.NewTestLogger()
+	deps := newTestDeps(t, cfg)
+	deps.logger = log
+
+	_, err := dataplane.New(deps.ctx, cfg, deps.opts()...)
+	require.NoError(t, err)
+
+	require.False(t, log.Contains(cloudAPIUnusedWarning))
+}
+
+// TestNewWarnsWhenTheCloudUpstreamServesNoNamespacelessRequests covers the
+// hybrid: Temporal Cloud is configured, but namespace-less requests are routed to
+// a Temporal Service that serves them itself. Nothing is translated there, which
+// is correct - and it makes a Cloud API override inert, which is worth saying.
+func TestNewWarnsWhenTheCloudUpstreamServesNoNamespacelessRequests(t *testing.T) {
+	t.Parallel()
+
+	cfg := testConfig()
+	cfg.APITranslations = stagingCloudAPI()
+	cfg.Upstreams = append(cfg.Upstreams, config.Upstream{
+		Name:   "cloud",
+		Cloud:  true,
+		Listen: config.ListenConfig{HostPort: "ns.acct.tmprl.cloud:7233"},
+	})
+	cfg.Routing.Rules = []config.RoutingRule{{
+		Upstream: "cloud",
+		Match:    config.RoutingMatch{Namespace: "*.acct"},
+	}}
+
+	log := logger.NewTestLogger()
+	deps := newTestDeps(t, cfg)
+	deps.logger = log
+
+	_, err := dataplane.New(deps.ctx, cfg, deps.opts()...)
+	require.NoError(t, err)
+
+	require.True(t, log.Contains(cloudAPIUnusedWarning),
+		"the Cloud upstream is not where namespace-less requests land")
+}
+
 // TestNewIsQuietWhenCloudAPIHasACloudUpstream is the control: the same block with
-// an upstream that can use it must not warn.
+// an upstream that can use it must not warn. testConfig names no system upstream,
+// so this also covers namespace-less requests falling through to the default.
 func TestNewIsQuietWhenCloudAPIHasACloudUpstream(t *testing.T) {
 	t.Parallel()
 
 	cfg := testConfig()
-	cfg.APITranslations = &config.APITranslations{}
+	cfg.APITranslations = stagingCloudAPI()
 	cfg.Upstreams[0].Cloud = true
 
 	log := logger.NewTestLogger()
@@ -286,4 +352,38 @@ func TestNewIsQuietWhenCloudAPIHasACloudUpstream(t *testing.T) {
 	require.NoError(t, err)
 
 	require.False(t, log.Contains(cloudAPIUnusedWarning))
+}
+
+// TestEveryTranslatedMethodIsNamespaceless guards the assumption the installation
+// gate rests on. Translation is installed only for the upstream serving
+// namespace-less requests, which covers every translated method exactly while
+// every translated method is namespace-less - true today because a method Cloud
+// refuses on a namespace endpoint is one carrying no namespace to pin to it.
+//
+// A namespace-bearing translation would be routed by its namespace, land on an
+// upstream with no translation installed, and never fire. It has to fail here
+// first, where the gate can be revisited.
+func TestEveryTranslatedMethodIsNamespaceless(t *testing.T) {
+	t.Parallel()
+
+	reg, err := translation.Default()
+	require.NoError(t, err)
+	require.NotEmpty(t, reg.Methods(), "a registry with nothing in it would pass vacuously")
+
+	for _, fullMethod := range reg.Methods() {
+		service, method, ok := rpc.ServiceMethod(fullMethod)
+		require.True(t, ok, "%q is not a gRPC full method", fullMethod)
+
+		d, err := protoregistry.GlobalFiles.FindDescriptorByName(protoreflect.FullName(service))
+		require.NoError(t, err)
+
+		sd, ok := d.(protoreflect.ServiceDescriptor)
+		require.True(t, ok)
+
+		md := sd.Methods().ByName(protoreflect.Name(method))
+		require.NotNil(t, md)
+
+		require.Nil(t, md.Input().Fields().ByName("namespace"),
+			"%s carries a namespace, so the namespace-less upstream is no longer where it lands", fullMethod)
+	}
 }


### PR DESCRIPTION
> **Stacked on #153.** This is the first PR in the stack that changes behaviour.

Nothing installed the translation registry, so the mapping from #153 was compiled in but never reached. This installs it
on a Cloud upstream — which needs no configuration to say so. Building on #147: an upstream is already known to be
Temporal Cloud, by declaration or by its address, and translating the methods Cloud does not serve on a frontend follows
from exactly that.

## Design

**The control plane is derived from the upstream** — `cloud.APIHostPort`, the upstream's own credentials (one Temporal
Cloud API key authorises both frontend and control plane), and the dial default for TLS, which verifies against the
system roots the real control plane presents. TLS is not inherited: the control plane is a different host, so the
upstream's server name or client certificate would not apply.

Where `CloudService` lives is a fixed fact about Cloud, not a policy, so it travels with the translation rather than
being restated as routing an operator could get wrong in either direction.

**Nothing turns it on or off** — it is installed for the upstream serving Namespace-less requests, when that upstream is
Cloud, and nowhere else:

```go
if up.IsCloud() && cfg.Routing.NamespacelessUpstream() == up.Name {
```

A method Cloud refuses on a Namespace endpoint is one carrying no Namespace to pin to that endpoint, so it lands on that
upstream and nowhere else; installing on any other Cloud upstream builds a control plane connection no request can
arrive over. `Routing.NamespacelessUpstream()` mirrors `router.Mux` exactly — the system upstream when one is named, the
default otherwise — so what decides where the request goes and what decides what is installed for it cannot disagree.
The fallback is the load-bearing half: `system` is optional, and the ordinary single-upstream config names only a
`default`.

An operator who prefers Cloud's own failure to a translated answer routes Namespace-less requests at a Temporal Service
that serves them. That is the same statement, made where it belongs, and it is why there is no `enabled` flag.

**An on-prem upstream is never translated** — it is not `IsCloud()`, so the interceptor is never installed on it. The
guard is at installation rather than per-call deliberately: a runtime check on the dial target would break private-link
Cloud upstreams, whose per-VPC hostnames carry no Cloud domain and are the reason `cloud: true` exists.

## Config

Everything above needs no configuration. One optional block covers the two things detection cannot know:

```yaml
apiTranslations:
  cloudApi:               # optional
    hostPort: saas-api.tmprl.cloud:443
    credentials:
      static:
        apiKey: ${TEMPORAL_API_KEY}
```

- `hostPort:` reaches a different Cloud environment.
- `credentials:` supplies the API key an mTLS Cloud upstream has none of to inherit — the Ops API takes a key only, so
  those upstreams have nothing to pass on.

A block that nothing will consult is warned about at startup, which now covers the hybrid it used to miss: Cloud
configured, Namespace-less requests served elsewhere, override inert.

## Rebased onto the TLS default

`main` gained #165 after this stack was cut: a dialled target with no `tls` block now verifies against the system roots,
and plaintext is asked for with `insecure: true`. The second commit adapts this PR to it — the control plane's empty
`tls` block is gone (it now says nothing), `insecure` joins `tls` in what a present `cloudApi` block states
authoritatively (without it a block meaning plaintext could not say so), the rule refusing a credential on an
unencrypted hop follows #165's trigger, and the e2e fakes declare the plaintext they serve. Six tests failed against
the merge with `main` before it and none do after.

## From review

- `CloudService.IsEndpoint` is now `IsSaasAPI` — a `CloudAPI` is always the control plane, so whether it is Cloud's own
  API is the only thing left to ask.
- The `enabled` tribool is gone entirely rather than reshaped, and translation is derived instead. See **Nothing turns it
  on or off** above.
- The receiver nil checks are gone, and so are the pointers that required them. Deleting the guards on their own
  segfaults every configuration that writes no `apiTranslations:` — nil was the path those configurations took — so
  `APITranslations` and `CloudAPI` became values instead. The zero value is the block nobody wrote, and it already
  described the defaults: since #165 an absent `cloudApi` and an empty one derive an identical upstream. `Cloud()` went
  with them, having existed to spare callers a presence check there is no longer any of, and the startup warning now
  triggers on "the override says something" rather than "a block exists".

Verified against the binary, not only in tests: a dev-server upstream with a `cloudApi:` block configured answers
`ListNamespaces` itself and never calls the control plane; the same upstream marked Cloud answers from the control plane
through both `temporal operator namespace list` and `grpcurl`; and a Cloud upstream reachable only by a Namespace rule
translates nothing. `GetSystemInfo` stays with the upstream in all three.

## Two subtleties worth reviewing

**Interceptor ordering is load-bearing.** Translation is installed *last* so it is innermost. `Via` leaves the chain when
a translation fires, so anything below it would not run for a translated call. Innermost, the namespace translator above
still sees the converted reply — a configured suffix rewrites `payments.a1b2c` to `payments` with no special casing.
Move it up and that silently stops working while every other test still passes, so
`TestEndToEndNamespaceRulesApplyToATranslatedReply` guards it. Mutation-checked.

**Pool keying.** `staticResolver` keys the pool by dial target, safe "because upstream hostPorts are unique (enforced by
config)" — see its comment. Control-plane connections break that: every Cloud upstream resolves to the same address, so
two upstreams with different API keys would share whichever connection was created first, and with it the first's
credentials. `keyedResolver` keys on a derived name instead.

**A non-Cloud `cloudApi:` address warns rather than fails.** A test double or private environment legitimately carries no
Cloud domain and that is indistinguishable from a typo — matching how #147 handles a namespace it cannot validate on a
templated upstream.

The connection is not opened eagerly: translation is incidental to normal traffic, so an unreachable control plane must
not stop the proxy serving everything else.

## mTLS upstreams must configure a key

The [Cloud Ops API](https://docs.temporal.io/ops) accepts an **API key only** — unlike a namespace frontend it does not
accept mTLS. So a Cloud upstream authenticating with a client certificate has no credential to inherit, and must name an
API key under `apiTranslations.cloudApi.credentials` or its translated methods are refused. That is the case the block
exists for; documented on the type.

## Scope

+958 / −0, 9 files. `dataplane.go` is the whole integration in 96 lines. Six e2e tests drive the full stack (gateway →
router → forwarder → interceptor) against a fake CloudService.

---

### Stack

| | PR | |
|---|---|---|
| 1 | #152 | translation library — mechanism only |
| 2 | #153 | ListNamespaces → CloudService.GetNamespaces mapping |
| 3 | #154 | integration — first behaviour change |
| 4 | #155 | listnamespace example |

Merge bottom-up. Each PR targets the one above it, so its diff shows only its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

