### PR TITLE
[build]: Fix the build and cover it in CI

### DIFF
--- a/examples/go.mod
+++ b/examples/go.mod
@@ -32,7 +32,7 @@ require (
 	go.temporal.io/api v1.63.5 // indirect
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
 	golang.org/x/net v0.58.0 // indirect
-	golang.org/x/sync v0.22.0 // indirect
+	golang.org/x/sync v0.23.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.41.0 // indirect
 	golang.org/x/time v0.15.0 // indirect

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -78,8 +78,8 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.22.0 h1:SZjpbeLmrCk4xhRSZFNZW5gFUeCeFgjekvI/+gfScek=
-golang.org/x/sync v0.22.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
+golang.org/x/sync v0.23.0 h1:KameEIfc1IkluZyXWLn39Wd4tURc6GbCiISGiZm2bQk=
+golang.org/x/sync v0.23.0/go.mod h1:sUUOizhqBxiL6pEWpqNLUiaJn1ShEbZ6BBqskPbjZm0=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/mise.toml
+++ b/mise.toml
@@ -161,4 +161,19 @@ run = "buf generate"
 
 [tasks.build]
 description = "Build binaries"
+run = [
+  { task = "build:examples" },
+  { task = "build:proxy" },
+]
+
+[tasks."build:proxy"]
+description = "Build release binaries"
 run = "goreleaser release --snapshot --clean --skip=publish"
+
+# The examples are a second module with a replace directive onto this tree, so a
+# dependency bump here can leave their go.mod stale. Building them keeps that
+# from going unnoticed. It runs first because it fails in seconds.
+[tasks."build:examples"]
+description = "Build the examples module"
+dir = "examples"
+run = "go build ./..."


### PR DESCRIPTION
The examples are a second module whose go.mod has a replace directive pointing here. Bumping golang.org/x/sync to v0.23.0 in the root (#160) left the examples pinning v0.22.0 as an indirect, and nothing in the examples module was bumped to match. So `go build ./...` under examples/ goes :boom:

Tidy the module, then split the build task into build:proxy and build:examples and have build run both. CI already runs `mise run build`, so it needs no change, and the same command covers the examples locally.

NB: The examples build runs first because it fails in under a second, well before goreleaser.
