### PR TITLE
[config]: Dial upstreams over TLS by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ config:
   upstreams:
     - name: local
       hostPort: localhost:7234
+      insecure: true
   routing:
     default: local
 ```

--- a/dev/config.yaml
+++ b/dev/config.yaml
@@ -18,6 +18,7 @@ tls:
 upstreams:
   - name: cluster-1
     hostPort: localhost:7233
+    insecure: true
     namespaces:
       rules:
         # Always add .remote on the way out, and remove it on the way in.
@@ -29,6 +30,7 @@ upstreams:
 
   - name: cluster-2
     hostPort: localhost:7234
+    insecure: true
     namespaces:
       rules:
         # Always add .remote on the way out, and remove it on the way in.
@@ -40,6 +42,7 @@ upstreams:
 
   - name: cluster-3
     hostPort: localhost:7235
+    insecure: true
 
 routing:
   default: cluster-1

--- a/e2e/templated_upstream_test.go
+++ b/e2e/templated_upstream_test.go
@@ -28,7 +28,7 @@ func TestEndToEndTemplatedUpstreamRoutesByRenderedAddress(t *testing.T) {
 		Routing: config.Routing{DefaultUpstream: "dynamic"},
 		Upstreams: config.UpstreamList{{
 			Name:   "dynamic",
-			Listen: config.ListenConfig{HostPort: `{{ index .Metadata "x-upstream" }}`},
+			Listen: config.ListenConfig{HostPort: `{{ index .Metadata "x-upstream" }}`, Insecure: true},
 		}},
 	})
 

--- a/examples/authz/config.yaml
+++ b/examples/authz/config.yaml
@@ -19,6 +19,7 @@ routing:
 upstreams:
   - name: local
     hostPort: 127.0.0.1:7233 # temporal server start-dev
+    insecure: true # start-dev serves plaintext; the proxy dials TLS by default
 
 # The authorization backend. The proxy opens this connection at startup, so an
 # extension server that is not running yet fails the proxy's start rather than
@@ -30,6 +31,7 @@ upstreams:
 extensionServers:
   - name: authz
     hostPort: 127.0.0.1:9444
+    insecure: true
 
 # Inbound authentication and authorization, delegated to the extension server
 # above. Without this block the proxy admits every caller.

--- a/examples/cloud/config.yaml
+++ b/examples/cloud/config.yaml
@@ -27,7 +27,6 @@ upstreams:
   # so the same config serves any number of namespaces.
   - name: cloud
     hostPort: "{{ .RemoteNamespace }}.tmprl.cloud:7233"
-    tls: {}
     namespaces:
       rules:
         # Rewrite the short local name to the Cloud fully-qualified name,
@@ -42,7 +41,6 @@ upstreams:
   # here we reuse TEMPORAL_NAMESPACE's endpoint.
   - name: system
     hostPort: ${TEMPORAL_NAMESPACE}.${TEMPORAL_ACCOUNT}.tmprl.cloud:7233
-    tls: {}
     credentials:
       static:
         apiKey: ${TEMPORAL_API_KEY}

--- a/examples/kms/config.yaml
+++ b/examples/kms/config.yaml
@@ -23,6 +23,7 @@ routing:
 upstreams:
   - name: local
     hostPort: 127.0.0.1:7233 # temporal server start-dev
+    insecure: true # start-dev serves plaintext; the proxy dials TLS by default
 
 # The pluggable key management backend. The proxy builds this connection when it
 # builds its key policies, so a malformed address, credentials without TLS, or an

--- a/internal/api/fx.go
+++ b/internal/api/fx.go
@@ -116,13 +116,14 @@ func extensionConn(pool *connect.Pool, s *config.ExtensionServer) (*connect.Conn
 		opts = append(opts, outbound.DialOptions(cp)...)
 	}
 
-	// A nil TLS block resolves to a plaintext dialer, so this is safe unset.
+	// Only a TLS block can override SNI, and the dialer ignores the name when it
+	// is not verifying a peer, so this is safe unset.
 	serverName := ""
 	if s.Listen.TLS != nil {
 		serverName = s.Listen.TLS.ServerName
 	}
 
-	cred, err := s.Listen.TLS.Dialer().DialOption(serverName)
+	cred, err := s.Listen.Dialer().DialOption(serverName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build credentials for extension server %q: %w", s.Name, err)
 	}

--- a/internal/api/fx_test.go
+++ b/internal/api/fx_test.go
@@ -175,13 +175,21 @@ func TestModuleRejectsInvalidExtensionServers(t *testing.T) {
 			wantErr: "is not a valid host:port",
 		},
 		{
-			name: "credentials without TLS",
+			name: "credentials on an insecure connection",
 			server: config.ExtensionServer{
 				Name:        "audit",
-				Listen:      config.ListenConfig{HostPort: "127.0.0.1:9090"},
+				Listen:      config.ListenConfig{HostPort: "127.0.0.1:9090", Insecure: true},
 				Credentials: &config.CredentialConfig{Static: &config.StaticCredentialConfig{APIKey: "k"}},
 			},
 			wantErr: "requires TLS",
+		},
+		{
+			name: "insecure together with tls",
+			server: config.ExtensionServer{
+				Name:   "audit",
+				Listen: config.ListenConfig{HostPort: "127.0.0.1:9090", Insecure: true, TLS: &config.TLSConfig{}},
+			},
+			wantErr: "cannot be set together with tls",
 		},
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -67,6 +67,31 @@ func TestLoad(t *testing.T) {
 	}
 }
 
+// Load is the only path that exercises the yaml tag, so a typo there would
+// silently leave every plaintext upstream dialing TLS.
+func TestLoad_UpstreamInsecure(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := config.Load(strings.NewReader(
+		"upstreams:\n  - name: local\n    hostPort: localhost:7233\n    insecure: true\n",
+	))
+	require.NoError(t, err)
+	require.True(t, cfg.Upstreams[0].Listen.Insecure)
+}
+
+// Load does not validate, so this covers the whole path from the yaml keys to
+// the rule that rejects them together.
+func TestValidate_UpstreamInsecureWithTLSIsRejected(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := config.Load(strings.NewReader(
+		"routing:\n  default: local\n" +
+			"upstreams:\n  - name: local\n    hostPort: localhost:7233\n    insecure: true\n    tls: {}\n",
+	))
+	require.NoError(t, err)
+	require.ErrorContains(t, cfg.Validate(), "cannot be set together with tls")
+}
+
 func TestLoad_EncryptionURLs(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/extensions.go
+++ b/internal/config/extensions.go
@@ -37,7 +37,8 @@ type (
 
 // Validate checks a single extension server: a name is required, hostPort must
 // be a literal host:port with no template action, and any TLS block must be
-// valid for dialing out. Credentials without TLS are rejected. Failures are
+// valid for dialing out. Credentials over an insecure connection are rejected,
+// as is asking for insecure while supplying TLS material. Failures are
 // unattributed, leaving the caller to stamp the path - ExtensionServerList
 // supplies the index.
 func (s *ExtensionServer) Validate() error {
@@ -54,11 +55,12 @@ func (s *ExtensionServer) Validate() error {
 			validation.Nested("credentials", s.Credentials),
 		),
 		validation.WhenRules(
-			func() bool { return s.Credentials != nil && s.Listen.TLS == nil },
+			func() bool { return s.Credentials != nil && s.Listen.Insecure },
 			func() validation.Errors {
 				return validation.Errors{{Field: "credentials", Message: "requires TLS to the extension server"}}
 			},
 		),
+		s.Listen.insecureRule(),
 	)
 }
 

--- a/internal/config/extensions_test.go
+++ b/internal/config/extensions_test.go
@@ -111,11 +111,13 @@ func TestExtensionServer_ValidateCredentialsRequireTLS(t *testing.T) {
 		}
 	}
 
-	t.Run("credentials without tls is rejected", func(t *testing.T) {
+	// An absent tls block is TLS against the system roots, which is a safe place
+	// to put a credential, so nothing more has to be said.
+	t.Run("credentials without a tls block is accepted", func(t *testing.T) {
 		t.Parallel()
 
 		s := base()
-		require.ErrorContains(t, s.Validate(), "requires TLS")
+		require.NoError(t, s.Validate())
 	})
 
 	t.Run("credentials with tls is accepted", func(t *testing.T) {
@@ -125,6 +127,25 @@ func TestExtensionServer_ValidateCredentialsRequireTLS(t *testing.T) {
 		s.Listen.TLS = &config.TLSConfig{ServerName: "audit.internal"}
 		require.NoError(t, s.Validate())
 	})
+
+	// Only an explicit opt-out puts a credential on the wire in the clear.
+	t.Run("credentials with insecure is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		s := base()
+		s.Listen.Insecure = true
+		require.ErrorContains(t, s.Validate(), "requires TLS")
+	})
+}
+
+func TestExtensionServer_ValidateInsecureConflictsWithTLS(t *testing.T) {
+	t.Parallel()
+
+	s := config.ExtensionServer{
+		Name:   "audit",
+		Listen: config.ListenConfig{HostPort: "audit.internal:9090", Insecure: true, TLS: &config.TLSConfig{}},
+	}
+	require.ErrorContains(t, s.Validate(), "cannot be set together with tls")
 }
 
 func TestExtensionServer_ValidateOutboundTLS(t *testing.T) {

--- a/internal/config/listen.go
+++ b/internal/config/listen.go
@@ -6,23 +6,31 @@ import (
 )
 
 type (
-	// ListenConfig defines properties for an inbound listener.
+	// ListenConfig defines properties for a dial or listen target. TLS is the
+	// default for anything the proxy dials: with no TLS block the peer is
+	// verified against the system root pool, and Insecure is how an operator
+	// deliberately asks for plaintext. A listener has no such default, since it
+	// has no certificate to present, so it stays plaintext until a TLS block
+	// supplies one.
 	ListenConfig struct {
 		HostPort string     `yaml:"hostPort"`
+		Insecure bool       `yaml:"insecure"`
 		TLS      *TLSConfig `yaml:"tls"`
 	}
 
-	// TLSConfig specifies TLS material for an inbound HTTPS listener. When CAFile
-	// is non-empty the listener enforces mutual TLS: connecting clients must
-	// present a certificate signed by that CA.
+	// TLSConfig specifies the TLS material for one target, and reads differently
+	// by direction: a listener presents Cert and Key, and a CA additionally
+	// requires each client to present a certificate signed by it (mutual TLS),
+	// while a dialer verifies its peer against a CA rather than the system roots
+	// and presents Cert and Key only for mutual TLS.
 	//
 	// NB: Be sure to set ServerName when the host name you dial doesn't match the
 	// CN or SAN on the server's certificate.
 	TLSConfig struct {
-		CA         string `yaml:"ca"`         // PEM-encoded CA certificate (mTLS only)
-		Cert       string `yaml:"cert"`       // PEM-encoded server certificate
+		CA         string `yaml:"ca"`         // PEM-encoded CA certificate
+		Cert       string `yaml:"cert"`       // PEM-encoded certificate to present
 		Key        string `yaml:"key"`        // PEM-encoded private key
-		ServerName string `yaml:"serverName"` // Optional SNI override
+		ServerName string `yaml:"serverName"` // Optional SNI override, when dialing
 	}
 )
 
@@ -35,26 +43,50 @@ func (l *ListenConfig) Validate() error {
 			func() bool { return l.TLS != nil },
 			validation.Nested("tls", l.TLS),
 		),
+		l.insecureRule(),
 	)
 }
 
-// Listener resolves the inbound (server) credential for this TLS block. A nil
-// receiver yields an insecure listener.
-func (t *TLSConfig) Listener() *creds.Listener {
-	return creds.NewListener(t.credsOptions()...)
+// Listener resolves the inbound (server) credential for this target. A listener
+// has no certificate to fall back on, so it serves plaintext until a TLS block
+// supplies one.
+func (l *ListenConfig) Listener() *creds.Listener {
+	if l.Insecure {
+		return creds.NewListener(creds.Insecure())
+	}
+
+	return l.TLS.listener()
 }
 
-// Dialer resolves the outbound (client) credential for this TLS block. A nil
-// receiver yields an insecure dialer.
-func (t *TLSConfig) Dialer() *creds.Dialer {
-	return creds.NewDialer(t.credsOptions()...)
+// Dialer resolves the outbound (client) credential for this target. Insecure
+// yields plaintext; otherwise the TLS block decides, and an absent one verifies
+// the peer against the system root pool.
+func (l *ListenConfig) Dialer() *creds.Dialer {
+	if l.Insecure {
+		return creds.NewDialer(creds.Insecure())
+	}
+
+	return l.TLS.dialer()
+}
+
+// insecureRule rejects opting out of transport security while also supplying TLS
+// material. The two say opposite things, and picking either one silently would
+// leave an operator believing the other. It is shared by every role, since the
+// contradiction does not depend on the direction of the connection.
+func (l *ListenConfig) insecureRule() validation.Rule {
+	return validation.WhenRules(
+		func() bool { return l.Insecure && l.TLS != nil },
+		func() validation.Errors {
+			return validation.Errors{{Field: "insecure", Message: "cannot be set together with tls"}}
+		},
+	)
 }
 
 // Validate checks the inbound (listener) TLS material. It delegates to the
 // resolved server credential, which owns the mode decision (server TLS vs mutual
 // TLS) and the certificate file checks.
 func (t *TLSConfig) Validate() error {
-	return t.Listener().Validate()
+	return t.listener().Validate()
 }
 
 // validateOutbound validates the config as client-side TLS used to dial an
@@ -62,16 +94,32 @@ func (t *TLSConfig) Validate() error {
 // decision (system-root, custom-CA, or mutual TLS) and the legality and file
 // checks. Callers must invoke this only when the receiver is non-nil.
 func (t *TLSConfig) validateOutbound() validation.Errors {
-	return validation.Nested("tls", t.Dialer())()
+	return validation.Nested("tls", t.dialer())()
+}
+
+// listener resolves the inbound (server) credential for this TLS block. A nil
+// receiver has no certificate to present, so it yields an insecure listener.
+func (t *TLSConfig) listener() *creds.Listener {
+	if t == nil {
+		return creds.NewListener(creds.Insecure())
+	}
+
+	return creds.NewListener(t.credsOptions()...)
+}
+
+// dialer resolves the outbound (client) credential for this TLS block. A nil
+// receiver supplies no material, which the client resolves to system-root TLS.
+func (t *TLSConfig) dialer() *creds.Dialer {
+	return creds.NewDialer(t.credsOptions()...)
 }
 
 // credsOptions maps the TLS block onto a set of creds options shared by both
 // roles; the caller picks the role via creds.NewListener or creds.NewDialer. A
-// nil block is plaintext. A present block with no CA and no client certificate
-// resolves to system-root TLS for a client.
+// nil block, or a present block with no CA and no client certificate, supplies
+// no material and leaves the mode to the role.
 func (t *TLSConfig) credsOptions() []creds.Option {
 	if t == nil {
-		return []creds.Option{creds.Insecure()}
+		return nil
 	}
 
 	var opts []creds.Option

--- a/internal/config/listen_test.go
+++ b/internal/config/listen_test.go
@@ -7,11 +7,15 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/temporalio/temporal-proxy/internal/config"
+	"github.com/temporalio/temporal-proxy/internal/transport/creds"
+	"github.com/temporalio/temporal-proxy/pkg/testutil"
 	"github.com/temporalio/temporal-proxy/pkg/validation"
 )
 
 func TestListenConfig_Validate(t *testing.T) {
 	t.Parallel()
+
+	certFile, keyFile := testutil.GenerateSelfSignedCert(t)
 
 	tests := []struct {
 		name     string
@@ -21,6 +25,23 @@ func TestListenConfig_Validate(t *testing.T) {
 		{
 			name: "no TLS, valid hostPort",
 			cfg:  &config.ListenConfig{HostPort: ":8080"},
+		},
+		{
+			name: "insecure alone is legal",
+			cfg:  &config.ListenConfig{HostPort: ":8080", Insecure: true},
+		},
+		{
+			// Asking for plaintext while supplying certificates says two
+			// contradictory things, so neither is guessed at.
+			name: "insecure with a tls block is contradictory",
+			cfg: &config.ListenConfig{
+				HostPort: ":8080",
+				Insecure: true,
+				TLS:      &config.TLSConfig{Cert: certFile, Key: keyFile},
+			},
+			wantErrs: []validation.Error{
+				{Field: "insecure", Message: "cannot be set together with tls"},
+			},
 		},
 		{
 			name: "invalid hostPort",
@@ -44,6 +65,98 @@ func TestListenConfig_Validate(t *testing.T) {
 			var errs validation.Errors
 			require.True(t, errors.As(err, &errs), "expected validation.Errors, got %T", err)
 			require.ElementsMatch(t, tt.wantErrs, []validation.Error(errs))
+		})
+	}
+}
+
+func TestListenConfig_Dialer(t *testing.T) {
+	t.Parallel()
+
+	caFile, certFile, keyFile := testutil.GenerateMTLSCerts(t)
+
+	tests := []struct {
+		name string
+		cfg  *config.ListenConfig
+		want creds.Mode
+	}{
+		{
+			// TLS is the default for an outbound target: with nothing configured
+			// the peer is verified against the system roots.
+			name: "no tls block verifies against the system roots",
+			cfg:  &config.ListenConfig{HostPort: "upstream.example:7233"},
+			want: creds.ModeSystemTLS,
+		},
+		{
+			name: "insecure opts out of transport security",
+			cfg:  &config.ListenConfig{HostPort: "localhost:7233", Insecure: true},
+			want: creds.ModeInsecure,
+		},
+		{
+			name: "a ca pins the peer to a private anchor",
+			cfg:  &config.ListenConfig{HostPort: "upstream.example:7233", TLS: &config.TLSConfig{CA: caFile}},
+			want: creds.ModeCustomCA,
+		},
+		{
+			name: "a client key pair selects mutual TLS",
+			cfg: &config.ListenConfig{
+				HostPort: "upstream.example:7233",
+				TLS:      &config.TLSConfig{CA: caFile, Cert: certFile, Key: keyFile},
+			},
+			want: creds.ModeMutualTLS,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tt.want, tt.cfg.Dialer().Mode())
+		})
+	}
+}
+
+func TestListenConfig_Listener(t *testing.T) {
+	t.Parallel()
+
+	caFile, certFile, keyFile := testutil.GenerateMTLSCerts(t)
+
+	tests := []struct {
+		name string
+		cfg  *config.ListenConfig
+		want creds.Mode
+	}{
+		{
+			// Unlike a dialer, a listener cannot fall back on the system roots: it
+			// has nothing to present, so it stays plaintext.
+			name: "no tls block serves plaintext",
+			cfg:  &config.ListenConfig{HostPort: ":7233"},
+			want: creds.ModeInsecure,
+		},
+		{
+			name: "insecure serves plaintext",
+			cfg:  &config.ListenConfig{HostPort: ":7233", Insecure: true},
+			want: creds.ModeInsecure,
+		},
+		{
+			name: "a key pair presents a server certificate",
+			cfg:  &config.ListenConfig{HostPort: ":7233", TLS: &config.TLSConfig{Cert: certFile, Key: keyFile}},
+			want: creds.ModeServerTLS,
+		},
+		{
+			name: "a ca requires a client certificate too",
+			cfg: &config.ListenConfig{
+				HostPort: ":7233",
+				TLS:      &config.TLSConfig{CA: caFile, Cert: certFile, Key: keyFile},
+			},
+			want: creds.ModeMutualTLS,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tt.want, tt.cfg.Listener().Mode())
 		})
 	}
 }

--- a/internal/config/upstream.go
+++ b/internal/config/upstream.go
@@ -18,6 +18,9 @@ type (
 	// Cloud-specific namespace rules. It is only needed for an address
 	// [cloud.IsEndpoint] does not recognize, such as a private-link hostname; a
 	// .tmprl.cloud address is detected without it.
+	//
+	// The proxy dials an upstream over TLS unless Listen says otherwise, so a
+	// plaintext upstream must set its Insecure field.
 	Upstream struct {
 		Name        string            `yaml:"name"`
 		Cloud       bool              `yaml:"cloud"`
@@ -81,11 +84,12 @@ func (u *Upstream) Validate() error {
 			validation.Nested("credentials", u.Credentials),
 		),
 		validation.WhenRules(
-			func() bool { return u.Credentials != nil && u.Listen.TLS == nil },
+			func() bool { return u.Credentials != nil && u.Listen.Insecure },
 			func() validation.Errors {
 				return validation.Errors{{Field: "credentials", Message: "requires TLS to the upstream"}}
 			},
 		),
+		u.Listen.insecureRule(),
 		validation.WhenRules(u.IsCloud, u.cloudRules()...),
 	)
 }

--- a/internal/config/upstream_test.go
+++ b/internal/config/upstream_test.go
@@ -499,10 +499,12 @@ func TestUpstreamCredentialsRequireTLS(t *testing.T) {
 		}
 	}
 
-	t.Run("credentials without tls is rejected", func(t *testing.T) {
+	// An absent tls block is TLS against the system roots, which is a safe place
+	// to put a credential, so nothing more has to be said.
+	t.Run("credentials without a tls block is accepted", func(t *testing.T) {
 		t.Parallel()
 		u := base()
-		require.ErrorContains(t, u.Validate(), "requires TLS")
+		require.NoError(t, u.Validate())
 	})
 
 	t.Run("credentials with tls is accepted", func(t *testing.T) {
@@ -511,6 +513,24 @@ func TestUpstreamCredentialsRequireTLS(t *testing.T) {
 		u.Listen.TLS = &config.TLSConfig{ServerName: "my-ns.acct.tmprl.cloud"}
 		require.NoError(t, u.Validate())
 	})
+
+	// Only an explicit opt-out puts a credential on the wire in the clear.
+	t.Run("credentials with insecure is rejected", func(t *testing.T) {
+		t.Parallel()
+		u := base()
+		u.Listen.Insecure = true
+		require.ErrorContains(t, u.Validate(), "requires TLS")
+	})
+}
+
+func TestUpstreamInsecureConflictsWithTLS(t *testing.T) {
+	t.Parallel()
+
+	u := config.Upstream{
+		Name:   "u",
+		Listen: config.ListenConfig{HostPort: "host:7233", Insecure: true, TLS: &config.TLSConfig{}},
+	}
+	require.ErrorContains(t, u.Validate(), "cannot be set together with tls")
 }
 
 func TestUpstreamOutboundTLS(t *testing.T) {

--- a/internal/dataplane/dataplane.go
+++ b/internal/dataplane/dataplane.go
@@ -154,7 +154,7 @@ func New(ctx context.Context, cfg *config.Config, opts ...Option) (*Dataplane, e
 	)
 
 	gateway, err := server.New(
-		server.WithCredentials(cfg.Listen.TLS.Listener()),
+		server.WithCredentials(cfg.Listen.Listener()),
 		server.WithServerCodec(router.Codec()),
 		// Health entries come from the allowlist, so what the gateway reports a
 		// status for is exactly what it will forward.

--- a/internal/dataplane/dataplane_test.go
+++ b/internal/dataplane/dataplane_test.go
@@ -204,7 +204,7 @@ func testConfig() *config.Config {
 		Routing: config.Routing{DefaultUpstream: "primary"},
 		Upstreams: config.UpstreamList{{
 			Name:   "primary",
-			Listen: config.ListenConfig{HostPort: "127.0.0.1:7233"},
+			Listen: config.ListenConfig{HostPort: "127.0.0.1:7233", Insecure: true},
 		}},
 	}
 }

--- a/internal/dataplane/dataplanetest/dataplanetest.go
+++ b/internal/dataplane/dataplanetest/dataplanetest.go
@@ -58,7 +58,7 @@ func Config(up *Upstream) *config.Config {
 		Routing: config.Routing{DefaultUpstream: DefaultUpstream},
 		Upstreams: config.UpstreamList{{
 			Name:   DefaultUpstream,
-			Listen: config.ListenConfig{HostPort: up.Addr(), TLS: up.TLSConfig()},
+			Listen: up.Listen(),
 		}},
 	}
 }

--- a/internal/dataplane/dataplanetest/upstream.go
+++ b/internal/dataplane/dataplanetest/upstream.go
@@ -120,9 +120,12 @@ func (u *Upstream) Requests() []proto.Message {
 	return slices.Clone(u.requests)
 }
 
-// TLSConfig is the client-side configuration needed to dial this upstream, or
-// nil when it serves plaintext.
-func (u *Upstream) TLSConfig() *config.TLSConfig { return u.tls }
+// Listen is the client-side configuration needed to dial this upstream. A
+// plaintext fake has to say so explicitly, because a target with no TLS block
+// verifies the peer against the system root pool.
+func (u *Upstream) Listen() config.ListenConfig {
+	return config.ListenConfig{HostPort: u.Addr(), Insecure: u.tls == nil, TLS: u.tls}
+}
 
 func (u *Upstream) record(ctx context.Context, req proto.Message) {
 	md, _ := metadata.FromIncomingContext(ctx)

--- a/internal/dataplane/dataplanetest/upstream_test.go
+++ b/internal/dataplane/dataplanetest/upstream_test.go
@@ -20,7 +20,8 @@ func TestTLSUpstreamIsReachableWithItsOwnTLSConfig(t *testing.T) {
 	t.Parallel()
 
 	up := dataplanetest.NewTLSUpstream(t)
-	require.NotNil(t, up.TLSConfig())
+	require.NotNil(t, up.Listen().TLS)
+	require.False(t, up.Listen().Insecure)
 
 	f := dataplanetest.Start(t, dataplanetest.Config(up))
 
@@ -62,8 +63,10 @@ func TestUpstreamRecordsAndEchoesQueryWorkflow(t *testing.T) {
 	require.True(t, proto.Equal(args, got.GetQuery().GetQueryArgs()))
 }
 
-func TestUpstreamPlaintextHasNoTLSConfig(t *testing.T) {
+func TestUpstreamPlaintextAsksForInsecure(t *testing.T) {
 	t.Parallel()
 
-	require.Nil(t, dataplanetest.NewUpstream(t).TLSConfig())
+	listen := dataplanetest.NewUpstream(t).Listen()
+	require.Nil(t, listen.TLS)
+	require.True(t, listen.Insecure, "a plaintext fake must opt out of TLS explicitly")
 }

--- a/internal/dataplane/lifecycle_test.go
+++ b/internal/dataplane/lifecycle_test.go
@@ -196,8 +196,8 @@ func TestStopClosesEveryUpstreamSocket(t *testing.T) {
 	// stale reference still fails Config.Validate.
 	cfg.Routing = config.Routing{}
 	cfg.Upstreams = config.UpstreamList{
-		{Name: "a", Listen: config.ListenConfig{HostPort: dataplanetest.NewUpstream(t).Addr()}},
-		{Name: "b", Listen: config.ListenConfig{HostPort: dataplanetest.NewUpstream(t).Addr()}},
+		{Name: "a", Listen: dataplanetest.NewUpstream(t).Listen()},
+		{Name: "b", Listen: dataplanetest.NewUpstream(t).Listen()},
 	}
 
 	dp, err := dataplane.New(t.Context(), cfg, newTestDeps(t, cfg).opts()...)

--- a/internal/proxy/resolver.go
+++ b/internal/proxy/resolver.go
@@ -114,7 +114,7 @@ func ResolverFor(upstream *config.Upstream, opts []grpc.DialOption, log logger.L
 	// One Dialer per upstream owns the TLS-mode decision and parses its
 	// certificate material once, so a templated upstream reuses it across every
 	// per-request dial (only the rendered server name varies).
-	dialer := upstream.Listen.TLS.Dialer()
+	dialer := upstream.Listen.Dialer()
 
 	if upstream.IsTemplated() {
 		translator := func(s string) string { return s }


### PR DESCRIPTION
Turning on TLS to an upstream meant writing an empty `tls: {}` block, which reads like a no-op and is easy to leave out. The creds package already treats security as the default and takes an explicit Insecure option for plaintext which seems like a good practice.

Move the decision to ListenConfig:

* A _**dialed**_ target with no TLS block now verifies its peer against the system root pool, so plaintext has to be asked for.

* A _**listener**_ has nothing to present and keeps serving plaintext until a TLS block defines a certificate. In effect, insecure is default for the gateway, because there is no known default TLS cert.

Credentials are still refused on a plaintext hop (gRPC freebie), but the trigger moves from "no tls block" to "insecure", which makes a credential over system-root TLS valid.

> [!IMPORTANT]
>
> This breaks existing configs: a plaintext upstream or extension server
> must now say `insecure: true`. Omitting it fails the proxy's start
> instead of downgrading silently.