### PR TITLE
[config]: Default cacheSize instead of disabling the DEK cache

### DIFF
--- a/examples/kms/config.yaml
+++ b/examples/kms/config.yaml
@@ -52,6 +52,13 @@ extensionServers:
 # extension server never receives that name; it selects keys by namespace.
 encryption:
   enabled: true
+
+  # cacheSize bounds the in-memory DEK cache, and defaults to 100 when omitted,
+  # as here. Each entry saves a KEK unwrap - a call to the extension server
+  # below - on every payload opened with that DEK. Setting it to 0 turns the
+  # cache off, which makes every payload opened cost a round trip.
+  # cacheSize: 100
+
   default:
     uri: extension://kms/payloads
     duration: 1h

--- a/internal/config/encryption.go
+++ b/internal/config/encryption.go
@@ -22,13 +22,14 @@ var validKeySchemes = append(crypto.DefaultSchemes(), extensionKeyScheme)
 type (
 	// Encryption configures envelope encryption of payloads. When Enabled, a
 	// Default key policy is required and governs how DEKs are provisioned and
-	// rotated. CacheSize bounds the in-memory DEK cache. Overrides maps a
-	// namespace to a key policy that supersedes Default for that namespace; the
-	// keys are pre-translation (local) namespace names, matching the namespace
-	// the vault seals under at request time.
+	// rotated. CacheSize bounds the in-memory DEK cache; see [Encryption.DEKCacheSize]
+	// for what an absent one means. Overrides maps a namespace to a key policy
+	// that supersedes Default for that namespace; the keys are pre-translation
+	// (local) namespace names, matching the namespace the vault seals under at
+	// request time.
 	Encryption struct {
 		Enabled   bool                 `yaml:"enabled"`
-		CacheSize int                  `yaml:"cacheSize"`
+		CacheSize *int                 `yaml:"cacheSize"`
 		Default   *KeyPolicy           `yaml:"default"`
 		Overrides map[string]KeyPolicy `yaml:"overrides"`
 	}
@@ -46,12 +47,33 @@ type (
 	}
 )
 
+// DEKCacheSize is the DEK cache size to apply: the configured size when there is
+// one, and [crypto.DefaultCacheSize] when the field is absent. Zero disables the
+// cache, so every Open unwraps its DEK through the KEK.
+//
+// The distinction is why the field is a pointer. Zero is a meaningful value here
+// and a plain int cannot tell an operator who wrote nothing from one who wrote
+// zero - so an absent field would read as "disable the cache" and silently
+// override the vault's own default, turning every payload the proxy opens into a
+// KMS round trip. Absent means "no opinion", and disabling the cache has to be
+// written down.
+func (e *Encryption) DEKCacheSize() int {
+	if e == nil || e.CacheSize == nil {
+		return crypto.DefaultCacheSize
+	}
+
+	return *e.CacheSize
+}
+
 // Validate requires a non-negative cache size, a Default policy whenever
 // encryption is Enabled, and (when a Default is present at all) that the policy
 // itself is valid.
 func (e *Encryption) Validate() error {
 	rules := []validation.Rule{
-		validation.Field("cacheSize", e.CacheSize, validation.GTE(0)),
+		// Checked through the accessor rather than the field, so an absent size is
+		// the default (which passes) while a negative one still fails, without
+		// dereferencing a pointer that may not be there.
+		validation.Field("cacheSize", e.DEKCacheSize(), validation.GTE(0)),
 		validation.WhenRules(
 			func() bool { return e.Enabled },
 			validation.Field("default", e.Default, validation.Required[*KeyPolicy]()),

--- a/internal/config/encryption_test.go
+++ b/internal/config/encryption_test.go
@@ -2,13 +2,100 @@ package config_test
 
 import (
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/temporalio/temporal-proxy/internal/config"
+	"github.com/temporalio/temporal-proxy/pkg/crypto"
 )
+
+// TestEncryption_DEKCacheSize covers what an absent cacheSize means. The field is
+// a pointer precisely so that absent and zero can differ: zero disables the DEK
+// cache, and an absent field must not.
+func TestEncryption_DEKCacheSize(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		enc  *config.Encryption
+		want int
+	}{
+		{
+			name: "absent inherits the vault's own default",
+			enc:  &config.Encryption{},
+			want: crypto.DefaultCacheSize,
+		},
+		{
+			name: "zero disables the cache, deliberately",
+			enc:  &config.Encryption{CacheSize: new(0)},
+			want: 0,
+		},
+		{
+			name: "a configured size is used as written",
+			enc:  &config.Encryption{CacheSize: new(25)},
+			want: 25,
+		},
+		{
+			name: "a nil block is as absent as an empty one",
+			enc:  nil,
+			want: crypto.DefaultCacheSize,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, tt.enc.DEKCacheSize())
+		})
+	}
+}
+
+// TestLoad_DEKCacheSizeDefault is the same question asked of the YAML, where the
+// distinction actually arises: an omitted key never reaches an unmarshaler, so
+// nothing but the pointer separates "said nothing" from "said zero".
+func TestLoad_DEKCacheSizeDefault(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		yaml string
+		want int
+	}{
+		{
+			name: "an absent encryption block",
+			yaml: "hostPort: :8080\n",
+			want: crypto.DefaultCacheSize,
+		},
+		{
+			name: "an encryption block that omits cacheSize",
+			yaml: "hostPort: :8080\nencryption:\n  enabled: true\n",
+			want: crypto.DefaultCacheSize,
+		},
+		{
+			name: "cacheSize written as zero",
+			yaml: "hostPort: :8080\nencryption:\n  cacheSize: 0\n",
+			want: 0,
+		},
+		{
+			name: "cacheSize written as a size",
+			yaml: "hostPort: :8080\nencryption:\n  cacheSize: 25\n",
+			want: 25,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg, err := config.Load(strings.NewReader(tt.yaml))
+			require.NoError(t, err)
+			require.Equal(t, tt.want, cfg.Encryption.DEKCacheSize())
+		})
+	}
+}
 
 func TestEncryptionValidate(t *testing.T) {
 	t.Parallel()
@@ -30,7 +117,7 @@ func TestEncryptionValidate(t *testing.T) {
 		},
 		{
 			name:    "negative cache size",
-			cfg:     config.Encryption{CacheSize: -1},
+			cfg:     config.Encryption{CacheSize: new(-1)},
 			wantErr: "cacheSize",
 		},
 		{

--- a/internal/dataplane/dataplane_test.go
+++ b/internal/dataplane/dataplane_test.go
@@ -128,7 +128,7 @@ func TestNewRejectsConfiguredKeysWithoutVault(t *testing.T) {
 			cfg := testConfig()
 			cfg.Encryption = config.Encryption{
 				Enabled:   enabled,
-				CacheSize: 10,
+				CacheSize: new(10),
 				Default: &config.KeyPolicy{
 					URI:         testingKeyURL(t),
 					Duration:    time.Hour,

--- a/internal/kms/fx.go
+++ b/internal/kms/fx.go
@@ -62,7 +62,7 @@ var Module = fx.Options(
 				return nil, err
 			}
 
-			v, err := createVault(p.Config, r, reporter)
+			v, err := createVault(p.Config, r, reporter, p.Logger)
 			if err != nil {
 				_ = r.Close()
 				return nil, err
@@ -149,10 +149,26 @@ func runRotation(ctx context.Context, v vaultRefresher, interval time.Duration, 
 // createVault builds a vault from the registry, applying the configured cache
 // size and, when a default key policy is set, its DEK duration and renewal lead
 // time.
-func createVault(c *config.Config, r *crypto.KEKRegistry, reporter *Reporter) (*crypto.Vault, error) {
+//
+// A disabled cache is logged rather than left to be inferred. It is a legitimate
+// choice, but an expensive one - every Open becomes a KEK round trip - and the
+// cache metrics cannot report it: hits and misses both sit at zero whether the
+// cache is off or merely idle, so this line is the only thing that distinguishes
+// them.
+func createVault(
+	c *config.Config,
+	r *crypto.KEKRegistry,
+	reporter *Reporter,
+	log logger.Logger,
+) (*crypto.Vault, error) {
+	size := c.Encryption.DEKCacheSize()
+	if size == 0 {
+		log.Warn("DEK cache is disabled by cacheSize: 0; every payload opened costs a KEK unwrap")
+	}
+
 	opts := make([]crypto.VaultOption, 0, 3+len(c.Encryption.Overrides))
 	opts = append(opts,
-		crypto.WithCacheSize(c.Encryption.CacheSize),
+		crypto.WithCacheSize(size),
 		crypto.WithObserver(reporter),
 	)
 

--- a/internal/kms/fx_test.go
+++ b/internal/kms/fx_test.go
@@ -58,7 +58,7 @@ func TestModule_EnabledWithoutKeys_DoesNotScheduleRotation(t *testing.T) {
 
 	var v *crypto.Vault
 	app := fx.New(append(
-		moduleOptions(t, cfg, logger.NewNoopLogger(), api.Connections{}),
+		moduleOptions(t, cfg, logger.NewNoopLogger(), api.Connections{}, prometheus.NewRegistry()),
 		fx.Populate(&v),
 		fx.NopLogger,
 	)...)
@@ -214,10 +214,17 @@ func TestModule_MixesExtensionAndKeeperKeysInOnePolicy(t *testing.T) {
 	require.NotNil(t, v)
 }
 
-// moduleOptions are the dependencies Module needs, wired for a test: a private
-// metrics registry so collectors cannot collide with another test's, the given
-// logger, and conns for any extension key URIs.
-func moduleOptions(t *testing.T, cfg *config.Config, log logger.Logger, conns api.Connections) []fx.Option {
+// moduleOptions are the dependencies Module needs, wired for a test: metrics on
+// reg, the given logger, and conns for any extension key URIs. Callers pass a
+// registry of their own so collectors cannot collide with another test's, and so
+// a test that cares can read what the vault reported.
+func moduleOptions(
+	t *testing.T,
+	cfg *config.Config,
+	log logger.Logger,
+	conns api.Connections,
+	reg *prometheus.Registry,
+) []fx.Option {
 	t.Helper()
 
 	return []fx.Option{
@@ -225,7 +232,7 @@ func moduleOptions(t *testing.T, cfg *config.Config, log logger.Logger, conns ap
 		fx.Supply(cfg),
 		fx.Provide(func() logger.Logger { return log }),
 		fx.Provide(func() *metrics.Factory {
-			return metrics.New("test", promauto.With(prometheus.NewRegistry()))
+			return metrics.New("test", promauto.With(reg))
 		}),
 		fx.Supply(conns),
 		kms.Module,
@@ -248,7 +255,7 @@ func buildVault(
 
 	var v *crypto.Vault
 	app := fx.New(append(
-		moduleOptions(t, cfg, log, conns),
+		moduleOptions(t, cfg, log, conns, prometheus.NewRegistry()),
 		fx.Populate(&v),
 		fx.NopLogger,
 	)...)
@@ -261,9 +268,18 @@ func buildVault(
 func startVault(t *testing.T, cfg *config.Config) *crypto.Vault {
 	t.Helper()
 
+	return startVaultWithRegistry(t, cfg, prometheus.NewRegistry())
+}
+
+// startVaultWithRegistry is [startVault] with the metrics registry in the
+// caller's hands, for a test that asserts on what the vault reported rather than
+// on what it returned.
+func startVaultWithRegistry(t *testing.T, cfg *config.Config, reg *prometheus.Registry) *crypto.Vault {
+	t.Helper()
+
 	var v *crypto.Vault
 	app := fxtest.New(t, append(
-		moduleOptions(t, cfg, logger.NewNoopLogger(), api.Connections{}),
+		moduleOptions(t, cfg, logger.NewNoopLogger(), api.Connections{}, reg),
 		fx.Populate(&v),
 	)...)
 
@@ -273,11 +289,69 @@ func startVault(t *testing.T, cfg *config.Config) *crypto.Vault {
 	return v
 }
 
+// TestModule_OmittedCacheSizeStillCachesDEKs guards the DEK cache against the
+// config layer switching it off by saying nothing. crypto.NewVault defaults the
+// cache to crypto.DefaultCacheSize, but createVault passes the configured size
+// unconditionally, so an absent cacheSize used to arrive as zero - which
+// WithCacheSize documents as "disable" - and every payload opened cost a KEK
+// unwrap. Most configs omit the field, examples/kms/config.yaml among them.
+func TestModule_OmittedCacheSizeStillCachesDEKs(t *testing.T) {
+	t.Parallel()
+
+	cfg := encryptionConfig(true, keyPolicy(t, 1))
+	cfg.Encryption.CacheSize = nil
+
+	reg := prometheus.NewRegistry()
+	v := startVaultWithRegistry(t, cfg, reg)
+
+	msg, err := v.Seal(t.Context(), "ns", []byte("secret"))
+	require.NoError(t, err)
+
+	// The first Open populates the cache and the second must be served from it.
+	for range 2 {
+		got, err := v.Open(t.Context(), msg)
+		require.NoError(t, err)
+		require.Equal(t, []byte("secret"), got)
+	}
+
+	hits := gather(t, reg, "test_encryption_dek_cache_hits_total")
+	require.NotNil(t, hits, "a disabled cache reports no hits at all")
+	require.Equal(t, 1.0, hits.GetMetric()[0].GetCounter().GetValue(), "the second open must come from the cache")
+}
+
+// TestModule_ZeroCacheSizeDisablesTheCache is the other half: zero remains a way
+// to turn the cache off, now that it has to be written down rather than implied
+// by an absent field.
+func TestModule_ZeroCacheSizeDisablesTheCache(t *testing.T) {
+	t.Parallel()
+
+	cfg := encryptionConfig(true, keyPolicy(t, 1))
+	cfg.Encryption.CacheSize = new(0)
+
+	reg := prometheus.NewRegistry()
+	v := startVaultWithRegistry(t, cfg, reg)
+
+	msg, err := v.Seal(t.Context(), "ns", []byte("secret"))
+	require.NoError(t, err)
+
+	for range 2 {
+		_, err := v.Open(t.Context(), msg)
+		require.NoError(t, err)
+	}
+
+	// The counters are created eagerly, so they exist at zero whether the cache is
+	// off or merely idle - which is exactly why a disabled cache is logged at
+	// startup. Assert the value, not the family.
+	hits := gather(t, reg, "test_encryption_dek_cache_hits_total")
+	require.NotNil(t, hits)
+	require.Zero(t, hits.GetMetric()[0].GetCounter().GetValue(), "there is no cache to hit")
+}
+
 // encryptionConfig builds a Config whose encryption is governed by policy.
 func encryptionConfig(enabled bool, policy config.KeyPolicy) *config.Config {
 	return &config.Config{Encryption: config.Encryption{
 		Enabled:   enabled,
-		CacheSize: 10,
+		CacheSize: new(10),
 		Default:   &policy,
 	}}
 }

--- a/pkg/crypto/vault.go
+++ b/pkg/crypto/vault.go
@@ -87,6 +87,12 @@ type (
 	}
 )
 
+// DefaultCacheSize is the number of decrypted DEKs a Vault retains when no
+// [WithCacheSize] option is given. It is exported so that a caller which
+// defaults the option for itself - configuration, say - inherits this number
+// rather than restating it and drifting from it.
+const DefaultCacheSize = 100
+
 // NewVault constructs a Vault backed by r, applying opts in order. A DEK is
 // pre-generated for every namespace registered via [WithKeyConfig]. NewVault
 // returns an error if any option is invalid (for example, a duplicate namespace
@@ -97,7 +103,7 @@ func NewVault(r *KEKRegistry, opts ...VaultOption) (*Vault, error) {
 	}
 
 	vopts := &vaultOptions{
-		cacheSize: 100,
+		cacheSize: DefaultCacheSize,
 		config:    make(map[string]KeyConfig),
 		nowFn:     time.Now,
 		observer:  nopObserver{},


### PR DESCRIPTION
`crypto.NewVault` defaults the DEK cache to 100, but `createVault` passes
`crypto.WithCacheSize(c.Encryption.CacheSize)` unconditionally (`internal/kms/fx.go:155`) and `config.Load` never
defaulted that field. An absent `cacheSize` therefore arrived as zero — which `WithCacheSize` documents as "disable" —
and validation accepted it, because the rule is `GTE(0)`.

So the config layer silently overrode the vault's own default, and every payload opened cost a KEK unwrap: a KMS call,
or a call to the operator's extension server, on the latency-sensitive path Workers poll. `examples/kms/config.yaml`
omits the field, so the example an operator copies shipped disabled.

## The change

- **`CacheSize` becomes a `*int`.** Zero is meaningful here, and a plain `int` cannot separate "wrote nothing" from
  "wrote zero". Absent now inherits `crypto.DefaultCacheSize`; zero still disables the cache, but has to be written
  down. (`cmp.Or`, used for the metrics defaults, cannot make that distinction — as its own test notes.)
- **`crypto.DefaultCacheSize` is exported**, so the config layer inherits the vault's number rather than restating it.
- **Validation reads the effective value** via `Encryption.DEKCacheSize()`: a negative size still fails, an absent one
  passes, and no pointer is dereferenced.
- **A disabled cache is logged at startup**, because the metrics cannot report it. `dek_cache_hits_total` and
  `dek_cache_misses_total` are created eagerly, so both sit at zero whether the cache is off or merely idle, and an
  operator debugging KMS latency reads "0 hits, 0 misses" as "unused" rather than "absent".
  
### Behavior
| Config              | Effective size                 | Behaviour                                       |
| ------------------- | ------------------------------ | ----------------------------------------------- |
| `cacheSize` absent  | `crypto.DefaultCacheSize` (100) | cache on                                        |
| `cacheSize:` (null) | 100                            | cache on — YAML null is a nil pointer, as absent |
| `cacheSize: 0`      | 0                              | cache off, with a startup warning                |
| `cacheSize: 50`     | 50                             | cache on, 50 entries                             |
| `cacheSize: -1`     | —                              | rejected by validation (`GTE(0)`)                |

## Tests

- `TestModule_OmittedCacheSizeStillCachesDEKs` — absent `cacheSize`, seal once, open twice, assert the second open hit
  the cache. Mutation-checked: forcing the size back to 0 fails it.
- `TestModule_ZeroCacheSizeDisablesTheCache` — asserts the counter's value rather than the family's absence, since eager
  creation means the family is always there.
- `TestEncryption_DEKCacheSize`, `TestLoad_DEKCacheSizeDefault` — absent, zero, set and nil-receiver, at both the struct
  and YAML levels.
